### PR TITLE
fix: CI gather_data ImportError + never-merge-red rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# canswim agent rules
+
+## Pull requests and merge
+
+- **Never merge a PR unless CI is green.** Do not use `gh pr merge` (or merge via API/UI automation) while checks are failing, pending, or missing when required.
+- Before merging: run `gh pr checks <n>` (or `gh pr view --json statusCheckRollup`) and confirm success.
+- If CI is red, fix the failure on the PR branch, push, wait for green, then merge.
+- Prefer merge only after the latest commit on the PR has a successful Tests workflow (or equivalent required checks).
+
+## Local verification
+
+- Prefer the `canswim` conda env for CLI and pytest.
+- Keep `hfhub_sync=False` for local gather/forecast unless explicitly testing HF sync.
+- Do not commit local slimmed `symbol_lists/all_stocks.csv` or gitignored `data/` artifacts from few-symbol runs.

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,8 +34,7 @@ install_requires =
     duckdb
     mcp>=1.2,<2
     python-dotenv
-    requests-ratelimiter
-    pyrate-limiter
+    requests-ratelimiter>=0.6,<1
     # hvplot
     # requests
     # importlib-metadata; python_version<"3.8"

--- a/src/canswim/gather_data.py
+++ b/src/canswim/gather_data.py
@@ -4,8 +4,6 @@ Gather stock market data from 3rd party sources
 
 import yfinance as yf
 from requests import Session
-from requests_ratelimiter import LimiterMixin
-from pyrate_limiter import Duration, RequestRate, Limiter
 import pandas as pd
 from dotenv import load_dotenv
 from loguru import logger
@@ -26,22 +24,6 @@ from canswim.market_data_io import (
 )
 from fmpsdk.url_methods import __return_json_v3, __validate_period
 from pandas.api.types import is_datetime64_any_dtype as is_datetime
-
-# MemoryQueueBucket is optional: some requests-ratelimiter builds re-export it,
-# others do not (CI ImportError). Prefer pyrate_limiter, else default bucket.
-try:
-    from requests_ratelimiter import MemoryQueueBucket as _MemoryQueueBucket
-except ImportError:  # pragma: no cover - version skew
-    try:
-        from pyrate_limiter import MemoryQueueBucket as _MemoryQueueBucket
-    except ImportError:  # pragma: no cover
-        _MemoryQueueBucket = None
-
-
-class RateLimitedSession(LimiterMixin, Session):
-    """Rate-limited session without multi-GB SQLite cache (default)."""
-
-    pass
 
 def get_latest_date(datetime_col):
     """Return the latest datetime value in a datetime formatted dataframe column"""
@@ -118,16 +100,15 @@ class MarketDataGatherer:
         self.use_yfinance_cache = _env_bool("YFINANCE_USE_CACHE", default=False)
 
     def _yfinance_session(self):
-        """Rate-limited session. Avoids SQLite cache hang by default."""
-        session_kwargs = {
-            "limiter": Limiter(RequestRate(5, Duration.SECOND * 1)),
-        }
-        if _MemoryQueueBucket is not None:
-            session_kwargs["bucket_class"] = _MemoryQueueBucket
+        """Rate-limited session. Avoids SQLite cache hang by default.
 
+        Uses ``requests_ratelimiter.LimiterSession`` when available (stable
+        across pyrate-limiter v2/v3 API breaks). Falls back to a plain Session.
+        """
         if self.use_yfinance_cache:
             try:
                 from requests_cache import CacheMixin, SQLiteCache
+                from requests_ratelimiter import LimiterMixin
 
                 class CachedLimiterSession(CacheMixin, LimiterMixin, Session):
                     pass
@@ -135,16 +116,20 @@ class MarketDataGatherer:
                 logger.warning(
                     "YFINANCE_USE_CACHE=1: using SQLite cache (can be very large/slow)"
                 )
-                cache_kwargs = {
-                    "limiter": Limiter(RequestRate(2, Duration.SECOND * 5)),
-                    "backend": SQLiteCache("yfinance.cache"),
-                }
-                if _MemoryQueueBucket is not None:
-                    cache_kwargs["bucket_class"] = _MemoryQueueBucket
-                return CachedLimiterSession(**cache_kwargs)
+                # per_second is supported by LimiterMixin / LimiterSession
+                return CachedLimiterSession(
+                    per_second=0.4,
+                    backend=SQLiteCache("yfinance.cache"),
+                )
             except Exception as e:
                 logger.warning(f"Could not enable yfinance cache ({e}); uncached session")
-        return RateLimitedSession(**session_kwargs)
+        try:
+            from requests_ratelimiter import LimiterSession
+
+            return LimiterSession(per_second=5)
+        except Exception as e:
+            logger.warning(f"requests_ratelimiter unavailable ({e}); plain Session")
+            return Session()
 
     def _data_file(self, name: str) -> str:
         d = data_3rd_party_dir()

--- a/src/canswim/gather_data.py
+++ b/src/canswim/gather_data.py
@@ -4,7 +4,7 @@ Gather stock market data from 3rd party sources
 
 import yfinance as yf
 from requests import Session
-from requests_ratelimiter import LimiterMixin, MemoryQueueBucket
+from requests_ratelimiter import LimiterMixin
 from pyrate_limiter import Duration, RequestRate, Limiter
 import pandas as pd
 from dotenv import load_dotenv
@@ -26,6 +26,16 @@ from canswim.market_data_io import (
 )
 from fmpsdk.url_methods import __return_json_v3, __validate_period
 from pandas.api.types import is_datetime64_any_dtype as is_datetime
+
+# MemoryQueueBucket is optional: some requests-ratelimiter builds re-export it,
+# others do not (CI ImportError). Prefer pyrate_limiter, else default bucket.
+try:
+    from requests_ratelimiter import MemoryQueueBucket as _MemoryQueueBucket
+except ImportError:  # pragma: no cover - version skew
+    try:
+        from pyrate_limiter import MemoryQueueBucket as _MemoryQueueBucket
+    except ImportError:  # pragma: no cover
+        _MemoryQueueBucket = None
 
 
 class RateLimitedSession(LimiterMixin, Session):
@@ -109,6 +119,12 @@ class MarketDataGatherer:
 
     def _yfinance_session(self):
         """Rate-limited session. Avoids SQLite cache hang by default."""
+        session_kwargs = {
+            "limiter": Limiter(RequestRate(5, Duration.SECOND * 1)),
+        }
+        if _MemoryQueueBucket is not None:
+            session_kwargs["bucket_class"] = _MemoryQueueBucket
+
         if self.use_yfinance_cache:
             try:
                 from requests_cache import CacheMixin, SQLiteCache
@@ -119,17 +135,16 @@ class MarketDataGatherer:
                 logger.warning(
                     "YFINANCE_USE_CACHE=1: using SQLite cache (can be very large/slow)"
                 )
-                return CachedLimiterSession(
-                    limiter=Limiter(RequestRate(2, Duration.SECOND * 5)),
-                    bucket_class=MemoryQueueBucket,
-                    backend=SQLiteCache("yfinance.cache"),
-                )
+                cache_kwargs = {
+                    "limiter": Limiter(RequestRate(2, Duration.SECOND * 5)),
+                    "backend": SQLiteCache("yfinance.cache"),
+                }
+                if _MemoryQueueBucket is not None:
+                    cache_kwargs["bucket_class"] = _MemoryQueueBucket
+                return CachedLimiterSession(**cache_kwargs)
             except Exception as e:
                 logger.warning(f"Could not enable yfinance cache ({e}); uncached session")
-        return RateLimitedSession(
-            limiter=Limiter(RequestRate(5, Duration.SECOND * 1)),
-            bucket_class=MemoryQueueBucket,
-        )
+        return RateLimitedSession(**session_kwargs)
 
     def _data_file(self, name: str) -> str:
         d = data_3rd_party_dir()


### PR DESCRIPTION
## Summary
- Fix CI collection failure: `MemoryQueueBucket` is not always exported from `requests_ratelimiter` on CI; optional import + default bucket.
- Add `AGENTS.md`: **never merge unless CI is green**.

## Test plan
- [x] Local: import `canswim.gather_data` and create `_yfinance_session()`
- [x] Local: `pytest tests/canswim/`
- [ ] GitHub Actions Tests workflow green on this PR before merge