### PR TITLE
chore: local CI + git hooks to block broken push/merge

### DIFF
--- a/.githooks/pre-merge-commit
+++ b/.githooks/pre-merge-commit
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Runs on local `git merge` commit creation (not on `gh pr merge`).
+# Bypass: git merge --no-verify
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+[[ -z "$ROOT" ]] && exit 0
+
+if [[ "${SKIP_LOCAL_CI:-}" == "1" ]]; then
+  echo "pre-merge-commit: SKIP_LOCAL_CI=1 — skipping"
+  exit 0
+fi
+
+CI_SCRIPT="$ROOT/scripts/ci-local.sh"
+if [[ -f "$CI_SCRIPT" ]]; then
+  echo "pre-merge-commit: running scripts/ci-local.sh"
+  exec bash "$CI_SCRIPT"
+fi
+exit 0

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Block push if local CI fails (mirrors GitHub Actions Tests).
+# Bypass once: git push --no-verify   or   SKIP_LOCAL_CI=1 git push
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [[ -z "$ROOT" ]]; then
+  exit 0
+fi
+
+if [[ "${SKIP_LOCAL_CI:-}" == "1" ]]; then
+  echo "pre-push: SKIP_LOCAL_CI=1 — skipping"
+  exit 0
+fi
+
+CI_SCRIPT="$ROOT/scripts/ci-local.sh"
+if [[ ! -x "$CI_SCRIPT" ]]; then
+  # allow non-executable but present
+  if [[ -f "$CI_SCRIPT" ]]; then
+    bash "$CI_SCRIPT"
+    exit $?
+  fi
+  echo "pre-push: no scripts/ci-local.sh — allowing push" >&2
+  exit 0
+fi
+
+echo "pre-push: running scripts/ci-local.sh"
+exec "$CI_SCRIPT"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,9 +6,20 @@
 - Before merging: run `gh pr checks <n>` (or `gh pr view --json statusCheckRollup`) and confirm success.
 - If CI is red, fix the failure on the PR branch, push, wait for green, then merge.
 - Prefer merge only after the latest commit on the PR has a successful Tests workflow (or equivalent required checks).
+- **Preferred merge helper:** `./scripts/gh-pr-merge-safe.sh <pr#>` — runs local CI, verifies remote checks are green, then merges.
+
+## Local CI (before push / merge)
+
+- Run the same suite as GitHub Actions: `./scripts/ci-local.sh`
+- Agents should run `./scripts/ci-local.sh` **before** `git push` and **before** `gh pr merge`.
+- Git hooks (after `./scripts/install-git-hooks.sh`):
+  - `pre-push` — blocks push if local CI fails
+  - `pre-merge-commit` — blocks local `git merge` commits if local CI fails
+  - Bypass (rare): `git push --no-verify` or `SKIP_LOCAL_CI=1`
+- `gh pr merge` is **not** a git hook path; always use `gh-pr-merge-safe.sh` or manually confirm `gh pr checks` is green.
 
 ## Local verification
 
-- Prefer the `canswim` conda env for CLI and pytest.
+- Prefer the `canswim` conda env for CLI and pytest (also used by `ci-local.sh` when present).
 - Keep `hfhub_sync=False` for local gather/forecast unless explicitly testing HF sync.
 - Do not commit local slimmed `symbol_lists/all_stocks.csv` or gitignored `data/` artifacts from few-symbol runs.

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Local mirror of .github/workflows/tests.yml (Tests job).
+# Usage: ./scripts/ci-local.sh
+# Skip: SKIP_LOCAL_CI=1 ./scripts/ci-local.sh   (or git push --no-verify)
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+if [[ "${SKIP_LOCAL_CI:-}" == "1" ]]; then
+  echo "SKIP_LOCAL_CI=1 — skipping local CI"
+  exit 0
+fi
+
+echo "==> local CI (matches GitHub Actions Tests workflow)"
+
+# Prefer project conda env when available (faster than bare pip -e . every push)
+PY=()
+if command -v conda >/dev/null 2>&1; then
+  # shellcheck disable=SC1091
+  if [[ -f "${HOME}/anaconda3/etc/profile.d/conda.sh" ]]; then
+    # shellcheck source=/dev/null
+    source "${HOME}/anaconda3/etc/profile.d/conda.sh"
+  elif [[ -f "${HOME}/miniconda3/etc/profile.d/conda.sh" ]]; then
+    # shellcheck source=/dev/null
+    source "${HOME}/miniconda3/etc/profile.d/conda.sh"
+  fi
+  if conda env list 2>/dev/null | awk '{print $1}' | grep -qx 'canswim'; then
+    # conda run keeps isolation without mutating the caller shell
+    PY=(conda run -n canswim --no-capture-output python)
+    echo "    using: conda env canswim"
+  fi
+fi
+if [[ ${#PY[@]} -eq 0 ]]; then
+  PY=(python)
+  echo "    using: $(command -v python) ($("${PY[@]}" -V 2>&1))"
+fi
+
+mkdir -p data/data-3rd-party data/forecast
+
+echo "==> pytest tests/canswim/"
+# Same module set as CI: tests/canswim/test_*.py
+"${PY[@]}" -m pytest tests/canswim/test_*.py -q --tb=short
+
+echo "==> local CI OK"

--- a/scripts/gh-pr-merge-safe.sh
+++ b/scripts/gh-pr-merge-safe.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Merge a PR only after local CI and remote checks are green.
+# Usage: ./scripts/gh-pr-merge-safe.sh <pr-number> [--squash|--merge|--rebase]
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 <pr-number> [--squash|--merge|--rebase]" >&2
+  exit 2
+fi
+
+PR="$1"
+shift || true
+MERGE_FLAG="--merge"
+if [[ "${1:-}" == "--squash" || "${1:-}" == "--merge" || "${1:-}" == "--rebase" ]]; then
+  MERGE_FLAG="$1"
+fi
+
+echo "==> local CI before merge"
+"$ROOT/scripts/ci-local.sh"
+
+echo "==> remote checks for PR #$PR"
+if ! command -v gh >/dev/null 2>&1; then
+  echo "gh CLI not found" >&2
+  exit 1
+fi
+
+# Fail if any check is not pass/skip
+checks_out="$(gh pr checks "$PR" 2>&1)" || true
+echo "$checks_out"
+
+if echo "$checks_out" | grep -qiE $'\t(fail|pending|queued|in_progress)\t|^fail|^pending'; then
+  # parse carefully: gh pr checks format is NAME\tSTATUS\t...
+  bad=0
+  while IFS=$'\t' read -r name status rest; do
+    [[ -z "${name:-}" ]] && continue
+    case "${status,,}" in
+      pass|success|skipping|skip|neutral) ;;
+      *)
+        echo "Blocking merge: check '$name' status='$status'" >&2
+        bad=1
+        ;;
+    esac
+  done <<< "$checks_out"
+  if [[ "$bad" -eq 1 ]]; then
+    echo "Remote CI not green — refusing merge (see AGENTS.md)" >&2
+    exit 1
+  fi
+fi
+
+# Also require overall success via JSON when available
+state="$(gh pr view "$PR" --json state -q .state 2>/dev/null || echo OPEN)"
+if [[ "$state" != "OPEN" ]]; then
+  echo "PR #$PR state is $state — nothing to merge" >&2
+  exit 1
+fi
+
+echo "==> merging PR #$PR ($MERGE_FLAG)"
+gh pr merge "$PR" "$MERGE_FLAG"
+echo "Merged PR #$PR"

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Point this repo at versioned hooks under .githooks/
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+chmod +x scripts/ci-local.sh scripts/gh-pr-merge-safe.sh .githooks/* 2>/dev/null || true
+git config core.hooksPath .githooks
+echo "Installed core.hooksPath=.githooks"
+echo "  pre-push        → scripts/ci-local.sh"
+echo "  pre-merge-commit → scripts/ci-local.sh (local git merge only)"
+echo "Safe remote merge: ./scripts/gh-pr-merge-safe.sh <pr#>"
+echo "Bypass: git push --no-verify   or   SKIP_LOCAL_CI=1 git push"


### PR DESCRIPTION
## Summary
- `scripts/ci-local.sh` — same pytest suite as GitHub Actions Tests (uses `canswim` conda env when available)
- `.githooks/pre-push` + `pre-merge-commit` — run local CI (bypass: `--no-verify` / `SKIP_LOCAL_CI=1`)
- `scripts/install-git-hooks.sh` — sets `core.hooksPath=.githooks`
- `scripts/gh-pr-merge-safe.sh` — local CI + remote green checks before `gh pr merge`
- `AGENTS.md` updated for agents

## Why
Prevent merging/pushing broken code after the #79 premature merge. `gh pr merge` is not a git hook; use the safe wrapper for remote merges.

## Test plan
- [x] `./scripts/ci-local.sh` → 54 passed
- [x] `./scripts/install-git-hooks.sh`
- [ ] GitHub Actions green on this PR
- [ ] Merge via `./scripts/gh-pr-merge-safe.sh` after green