### PR TITLE
fix: Reward/Risk table empty under chart with backtests

### DIFF
--- a/src/canswim/dashboard/charts.py
+++ b/src/canswim/dashboard/charts.py
@@ -81,14 +81,23 @@ class ChartTab:
     def get_rr(self, ticker=None, lq=None):
         assert ticker is not None
         assert lq is not None and lq >= 0
-        df = get_reward_risk(self.db_path, symbol=ticker, low_quantile=lq)
+        # Chart plots all backtest starts in range — table must match (not latest-only).
+        # Still filter to uptrending rows (label); prior close is as-of each start.
+        df = get_reward_risk(
+            self.db_path,
+            symbol=ticker,
+            low_quantile=lq,
+            latest_only=False,
+            uptrending_only=True,
+        )
         logger.info(f"rr table df: {df}")
-        df_styler = df.style.format(
+        if df is None or df.empty:
+            return df
+        return df.style.format(
             precision=2,
             thousands=",",
             decimal=".",
         )
-        return df_styler
 
     def plot_quantiles_df(
         self,
@@ -280,10 +289,10 @@ class ChartTab:
                         high_quantile=0.95,
                         label=f"{ticker} Close forecast",
                     )
-                # fetch Reward Risk data for latest forecast
-                latest_forecast_df = saved_forecast_df_list[-1]
-                if latest_forecast_df is not None and not latest_forecast_df.empty:
-                    rr_df = self.get_rr(ticker=ticker, lq=lq)
+            # Reward/Risk for all uptrending forecast starts (incl. monthly backtests),
+            # not only the global latest start (which may be flat/down while older
+            # starts still plot on the chart).
+            rr_df = self.get_rr(ticker=ticker, lq=lq)
             # Set the locator
             major_locator = mdates.YearLocator()  # every year
             minor_locator = mdates.MonthLocator()  # every month

--- a/src/canswim/db.py
+++ b/src/canswim/db.py
@@ -259,38 +259,104 @@ def get_reward_risk(
     *,
     min_rr: float = 1.01,
     min_reward: float = 1.0,
+    latest_only: bool = True,
+    uptrending_only: bool = True,
 ) -> pd.DataFrame:
-    """Reward/risk metrics for a symbol's latest forecast (ChartTab.get_rr SQL)."""
+    """Reward/risk metrics for a symbol's forecast start dates.
+
+    Prior close is the last ``close_price`` **before each** ``forecast_start_date``
+    (not only before the global latest start). Charts should pass
+    ``latest_only=False`` so monthly backtests appear; scans keep the default.
+
+    When ``uptrending_only`` is True (default), only rows with positive reward
+    and reward/risk above the thresholds are returned (matches UI label).
+    """
     assert symbol is not None
     assert low_quantile is not None and low_quantile >= 0
     low_quantile_col = f"close_quantile_{low_quantile}"
     mean_col = "close_quantile_0.5"
+    latest_clause = ""
+    if latest_only:
+        latest_clause = """
+            AND f.start_date = (
+                SELECT lf.date FROM latest_forecast lf
+                WHERE lf.symbol = f.symbol
+            )
+        """
+    having_clause = ""
+    if uptrending_only:
+        having_clause = f"""
+            HAVING forecast_close_high > prior_close_price
+                AND reward_risk > {float(min_rr)}
+                AND reward_percent >= {float(min_reward)}
+        """
     with connect_readonly(db_path) as db_con:
         sql_result = db_con.sql(
             f"""--sql
             SELECT
                 f.symbol,
-                f.start_date as forecast_start_date,
-                arg_max(c.close, c.date) as prior_close_price,
-                min("{low_quantile_col}") as forecast_close_low,
-                max("{mean_col}") as forecast_close_high,
-                100*(forecast_close_high / prior_close_price - 1) as reward_percent,
-                (forecast_close_high - prior_close_price)/GREATEST(prior_close_price-forecast_close_low, 0.01) as reward_risk,
-                max(e.mal_error) as backtest_error,
-                max(c.date) as prior_close_date,
-            FROM forecast f, close_price c, backtest_error as e, latest_forecast as lf
-            WHERE f.symbol = $ticker AND f.symbol = lf.symbol AND
-                f.symbol = c.symbol AND f.symbol = e.symbol AND c.date < lf.date
-            GROUP BY f.symbol, f.start_date, c.symbol, e.symbol, lf.symbol, lf.date
-            HAVING forecast_close_high > prior_close_price AND
-                f.start_date = lf.date AND
-                reward_risk> $rr AND reward_percent >= $reward
+                f.start_date AS forecast_start_date,
+                (
+                    SELECT c.Close
+                    FROM close_price c
+                    WHERE c.Symbol = f.symbol
+                      AND CAST(c.Date AS DATE) < f.start_date
+                    ORDER BY c.Date DESC
+                    LIMIT 1
+                ) AS prior_close_price,
+                (
+                    SELECT CAST(c.Date AS DATE)
+                    FROM close_price c
+                    WHERE c.Symbol = f.symbol
+                      AND CAST(c.Date AS DATE) < f.start_date
+                    ORDER BY c.Date DESC
+                    LIMIT 1
+                ) AS prior_close_date,
+                min(f."{low_quantile_col}") AS forecast_close_low,
+                max(f."{mean_col}") AS forecast_close_high,
+                100 * (
+                    max(f."{mean_col}") / nullif(
+                        (
+                            SELECT c.Close
+                            FROM close_price c
+                            WHERE c.Symbol = f.symbol
+                              AND CAST(c.Date AS DATE) < f.start_date
+                            ORDER BY c.Date DESC
+                            LIMIT 1
+                        ),
+                        0
+                    ) - 1
+                ) AS reward_percent,
+                (
+                    max(f."{mean_col}") - (
+                        SELECT c.Close
+                        FROM close_price c
+                        WHERE c.Symbol = f.symbol
+                          AND CAST(c.Date AS DATE) < f.start_date
+                        ORDER BY c.Date DESC
+                        LIMIT 1
+                    )
+                ) / GREATEST(
+                    (
+                        SELECT c.Close
+                        FROM close_price c
+                        WHERE c.Symbol = f.symbol
+                          AND CAST(c.Date AS DATE) < f.start_date
+                        ORDER BY c.Date DESC
+                        LIMIT 1
+                    ) - min(f."{low_quantile_col}"),
+                    0.01
+                ) AS reward_risk,
+                max(e.mal_error) AS backtest_error
+            FROM forecast f
+            LEFT JOIN backtest_error e ON e.symbol = f.symbol
+            WHERE f.symbol = $ticker
+            {latest_clause}
+            GROUP BY f.symbol, f.start_date
+            {having_clause}
+            ORDER BY f.start_date
             """,
-            params={
-                "ticker": symbol,
-                "rr": min_rr,
-                "reward": min_reward,
-            },
+            params={"ticker": symbol},
         )
         df = sql_result.df()
     return _format_date_columns(df, ["prior_close_date", "forecast_start_date"])

--- a/tests/canswim/test_db.py
+++ b/tests/canswim/test_db.py
@@ -43,11 +43,12 @@ def _build_mini_db(path: Path) -> str:
             ) t(Date, Symbol, Close)
             """
         )
-        # latest forecast start 2025-01-06; prior closes before that
+        # Two AAA starts: older 2025-01-03 (uptrend vs prior 100) and latest 2025-01-06
         con.execute(
             """
             CREATE TABLE forecast AS
             SELECT * FROM (VALUES
+                (TIMESTAMP '2025-01-03', 'AAA', DATE '2025-01-03', 95.0, 96.0, 97.0, 108.0, 110.0, 112.0, 115.0),
                 (TIMESTAMP '2025-01-06', 'AAA', DATE '2025-01-06', 98.0, 99.0, 100.0, 110.0, 115.0, 120.0, 125.0),
                 (TIMESTAMP '2025-01-07', 'AAA', DATE '2025-01-06', 99.0, 100.0, 101.0, 112.0, 118.0, 122.0, 128.0),
                 (TIMESTAMP '2025-01-06', 'BBB', DATE '2025-01-06', 48.0, 49.0, 50.0, 52.0, 53.0, 54.0, 55.0)
@@ -112,10 +113,29 @@ def test_get_backtest_error(mini_db):
 
 
 def test_get_reward_risk(mini_db):
-    # low quantile 0.2 corresponds to confidence 80
+    # low quantile 0.2 corresponds to confidence 80; default = latest start only
     df = get_reward_risk(mini_db, "AAA", low_quantile=0.2)
     assert not df.empty
+    assert len(df) == 1
+    assert str(df.iloc[0]["forecast_start_date"]).startswith("2025-01-06")
     assert float(df.iloc[0]["forecast_close_high"]) == pytest.approx(112.0)
+    # prior close is last close before *that* start (102 on 2025-01-03)
+    assert float(df.iloc[0]["prior_close_price"]) == pytest.approx(102.0)
+
+
+def test_get_reward_risk_all_starts_for_chart(mini_db):
+    """Chart table uses latest_only=False so monthly backtests appear."""
+    df = get_reward_risk(
+        mini_db, "AAA", low_quantile=0.2, latest_only=False, uptrending_only=True
+    )
+    assert len(df) >= 2
+    starts = set(str(x)[:10] for x in df["forecast_start_date"].tolist())
+    assert "2025-01-03" in starts
+    assert "2025-01-06" in starts
+    # as-of 2025-01-03 prior is 100 (2025-01-02)
+    row = df[df["forecast_start_date"].astype(str).str.startswith("2025-01-03")].iloc[0]
+    assert float(row["prior_close_price"]) == pytest.approx(100.0)
+    assert float(row["forecast_close_high"]) == pytest.approx(108.0)
 
 
 def test_scan_forecasts(mini_db):


### PR DESCRIPTION
## Summary
Chart Reward/Risk table stayed empty for AMZN while many backtest forecasts plotted. Query was **latest start only** + uptrending filters; latest AMZN forecast is slightly down so zero rows.

### Fix
- `get_reward_risk`: prior close relative to **each** `start_date`; optional `latest_only` / `uptrending_only`
- Chart uses `latest_only=False` (all uptrending starts, including monthly backtests)
- Unit tests for multi-start RR

## Test plan
- [x] `./scripts/ci-local.sh` (55 passed)
- [x] Live DB: AMZN → 9 uptrending RR rows
- [ ] GitHub CI green
- [ ] Manual: http://127.0.0.1:7860/ Charts → AMZN → Plot → table non-empty