### PR TITLE
fix: per-period backtest_error (not same for all rows)

### DIFF
--- a/src/canswim/dashboard/advanced.py
+++ b/src/canswim/dashboard/advanced.py
@@ -37,8 +37,10 @@ class AdvancedTab:
                     max(c.date) as prior_close_date,
                 FROM forecast f, close_price c, backtest_error as e, latest_forecast as lf
                 WHERE f.symbol = lf.symbol AND
-                    f.symbol = c.symbol AND f.symbol = e.symbol AND c.date < lf.date
-                GROUP BY f.symbol, f.start_date, c.symbol, e.symbol, lf.symbol, lf.date
+                    f.symbol = c.symbol AND
+                    f.symbol = e.symbol AND e.start_date = f.start_date AND
+                    CAST(c.Date AS DATE) < f.start_date
+                GROUP BY f.symbol, f.start_date, c.symbol, e.symbol, e.start_date, lf.symbol, lf.date
                 HAVING forecast_close_high > prior_close_price AND
                     f.start_date = lf.date AND
                     reward_risk> 3 AND reward_percent >= 20

--- a/src/canswim/db.py
+++ b/src/canswim/db.py
@@ -207,22 +207,35 @@ def init_search_db(
             ON close_price (symbol, date)
             """
         )
-        logger.info("Creating backtest_error table")
+        logger.info("Creating backtest_error table (per symbol + forecast start_date)")
+        # One mean absolute log-error per forecast origin — not a single
+        # symbol-wide average (which made every RR-table row look identical).
         db_con.sql(
             """--sql
             CREATE OR REPLACE TABLE backtest_error
-            AS SELECT f.symbol, mean(abs(log(greatest(f."close_quantile_0.5", 0.01)/cp.Close))) as mal_error
-            FROM forecast as f, close_price as cp
-            WHERE cp.symbol = f.symbol AND cp.date = f.date
-            GROUP BY f.symbol, cp.symbol
-            HAVING cp.symbol = f.symbol
+            AS SELECT
+                f.symbol,
+                f.start_date,
+                mean(
+                    abs(
+                        log(
+                            greatest(f."close_quantile_0.5", 0.01)
+                            / cp.Close
+                        )
+                    )
+                ) AS mal_error
+            FROM forecast AS f
+            INNER JOIN close_price AS cp
+              ON cp.symbol = f.symbol
+             AND CAST(cp.Date AS DATE) = CAST(f.date AS DATE)
+            GROUP BY f.symbol, f.start_date
             """
         )
         db_con.table("backtest_error").show()
         db_con.sql(
             """--sql
-            CREATE UNIQUE INDEX backtest_error_sym_idx
-            ON backtest_error (symbol)
+            CREATE UNIQUE INDEX backtest_error_sym_start_idx
+            ON backtest_error (symbol, start_date)
             """
         )
     return True
@@ -347,9 +360,11 @@ def get_reward_risk(
                     ) - min(f."{low_quantile_col}"),
                     0.01
                 ) AS reward_risk,
+                -- Per-start-date error (join on start_date), not symbol-global mean
                 max(e.mal_error) AS backtest_error
             FROM forecast f
-            LEFT JOIN backtest_error e ON e.symbol = f.symbol
+            LEFT JOIN backtest_error e
+              ON e.symbol = f.symbol AND e.start_date = f.start_date
             WHERE f.symbol = $ticker
             {latest_clause}
             GROUP BY f.symbol, f.start_date
@@ -387,8 +402,10 @@ def scan_forecasts(
                 max(c.date) as prior_close_date,
             FROM forecast f, close_price c, backtest_error as e, latest_forecast as lf
             WHERE f.symbol = lf.symbol AND
-                f.symbol = c.symbol AND f.symbol = e.symbol AND c.date < lf.date
-            GROUP BY f.symbol, f.start_date, c.symbol, e.symbol, lf.symbol, lf.date
+                f.symbol = c.symbol AND
+                f.symbol = e.symbol AND e.start_date = f.start_date AND
+                CAST(c.Date AS DATE) < f.start_date
+            GROUP BY f.symbol, f.start_date, c.symbol, e.symbol, e.start_date, lf.symbol, lf.date
             HAVING forecast_close_high > prior_close_price AND
                 f.start_date = lf.date AND
                 reward_risk> $rr AND reward_percent >= $reward

--- a/tests/canswim/test_db.py
+++ b/tests/canswim/test_db.py
@@ -72,9 +72,10 @@ def _build_mini_db(path: Path) -> str:
             """
             CREATE TABLE backtest_error AS
             SELECT * FROM (VALUES
-                ('AAA', 0.05),
-                ('BBB', 0.08)
-            ) t(symbol, mal_error)
+                ('AAA', DATE '2025-01-03', 0.03),
+                ('AAA', DATE '2025-01-06', 0.05),
+                ('BBB', DATE '2025-01-06', 0.08)
+            ) t(symbol, start_date, mal_error)
             """
         )
     return db_path
@@ -108,8 +109,9 @@ def test_get_close_prices(mini_db):
 
 def test_get_backtest_error(mini_db):
     df = get_backtest_error(mini_db, symbol="AAA")
-    assert len(df) == 1
-    assert float(df.iloc[0]["mal_error"]) == pytest.approx(0.05)
+    # Per forecast start_date (not a single symbol-wide row)
+    assert len(df) == 2
+    assert set(df["mal_error"].astype(float).round(2)) == {0.03, 0.05}
 
 
 def test_get_reward_risk(mini_db):
@@ -136,6 +138,13 @@ def test_get_reward_risk_all_starts_for_chart(mini_db):
     row = df[df["forecast_start_date"].astype(str).str.startswith("2025-01-03")].iloc[0]
     assert float(row["prior_close_price"]) == pytest.approx(100.0)
     assert float(row["forecast_close_high"]) == pytest.approx(108.0)
+    # backtest_error is per start_date (not a repeated symbol-wide constant)
+    errs = {
+        str(r["forecast_start_date"])[:10]: float(r["backtest_error"])
+        for _, r in df.iterrows()
+    }
+    assert errs["2025-01-03"] == pytest.approx(0.03)
+    assert errs["2025-01-06"] == pytest.approx(0.05)
 
 
 def test_scan_forecasts(mini_db):

--- a/tests/canswim/test_mcp_tools.py
+++ b/tests/canswim/test_mcp_tools.py
@@ -44,7 +44,10 @@ def _build_mini_db(path: Path) -> str:
             "CREATE TABLE latest_forecast AS SELECT * FROM (VALUES ('AAA', DATE '2025-01-06')) t(symbol, date)"
         )
         con.execute(
-            "CREATE TABLE backtest_error AS SELECT * FROM (VALUES ('AAA', 0.05)) t(symbol, mal_error)"
+            """
+            CREATE TABLE backtest_error AS
+            SELECT * FROM (VALUES ('AAA', DATE '2025-01-06', 0.05)) t(symbol, start_date, mal_error)
+            """
         )
     return db_path
 


### PR DESCRIPTION
## Summary
`backtest_error` was one mean per **symbol** over all forecasts, so the chart RR table repeated the same number for every monthly start.

### Fix
- Build `backtest_error` as `(symbol, start_date, mal_error)`
- Join RR / scans on `e.start_date = f.start_date`
- Tests + MCP fixture updated

## Test plan
- [x] `./scripts/ci-local.sh`
- [x] AMZN: 13 distinct mal_error values by start_date
- [ ] GitHub CI green before merge
- [ ] Manual: chart AMZN RR table shows varying `backtest_error`