### PR TITLE
feat: Scans backtest as-of date picker

### DIFF
--- a/src/canswim/dashboard/scans.py
+++ b/src/canswim/dashboard/scans.py
@@ -1,7 +1,10 @@
 from loguru import logger
 from canswim.model import CanswimModel
 import gradio as gr
-from canswim.db import scan_forecasts as db_scan_forecasts
+from canswim.db import (
+    list_forecast_start_dates,
+    scan_forecasts as db_scan_forecasts,
+)
 
 
 class ScanTab:
@@ -11,6 +14,19 @@ class ScanTab:
         assert db_path is not None
         self.canswim_model = canswim_model
         self.db_path = db_path
+        start_choices = list_forecast_start_dates(self.db_path)
+        default_start = start_choices[0] if start_choices else None
+        with gr.Row():
+            self.forecastStart = gr.Dropdown(
+                choices=start_choices,
+                value=default_start,
+                label="Forecast as-of date (backtest origin)",
+                info=(
+                    "Pick a historic monthly forecast start, or the latest run. "
+                    "Scan scores stocks using that origin only."
+                ),
+                allow_custom_value=False,
+            )
         with gr.Row():
             self.lowq = gr.Radio(
                 choices=[80, 95, 99],
@@ -19,14 +35,14 @@ class ScanTab:
                 info="Choose low price confidence percentage",
             )
             self.reward = gr.Radio(
-                choices=[10, 15, 20, 25],
-                value=20,
+                choices=[5, 10, 15, 20, 25],
+                value=10,
                 label="Minimum probabilistic price gain.",
                 info="Choose reward percentage",
             )
             self.rr = gr.Radio(
-                choices=[3, 5, 10],
-                value=3,
+                choices=[1, 1.5, 3, 5, 10],
+                value=1.5,
                 label="Probabilistic Reward to Risk ratio between price increase and price drop within the forecast period.",
                 info="Choose R/R ratio",
             )
@@ -39,16 +55,27 @@ class ScanTab:
 
         self.scanBtn.click(
             fn=self.scan_forecasts,
-            inputs=[self.lowq, self.reward, self.rr],
+            inputs=[self.lowq, self.reward, self.rr, self.forecastStart],
             outputs=[self.scanResult],
         )
 
-    def scan_forecasts(self, lowq, reward, rr):
-        df = db_scan_forecasts(self.db_path, lowq=lowq, reward=reward, rr=rr)
-        logger.debug(f"df types: {df.dtypes}")
-        df_styler = df.style.format(
+    def scan_forecasts(self, lowq, reward, rr, forecast_start_date=None):
+        df = db_scan_forecasts(
+            self.db_path,
+            lowq=lowq,
+            reward=reward,
+            rr=rr,
+            forecast_start_date=forecast_start_date,
+        )
+        logger.info(
+            f"Scan as-of={forecast_start_date} lowq={lowq} reward={reward} rr={rr} "
+            f"hits={0 if df is None else len(df)}"
+        )
+        logger.debug(f"df types: {df.dtypes if df is not None else None}")
+        if df is None or df.empty:
+            return df
+        return df.style.format(
             precision=2,
             thousands=",",
             decimal=".",
         )
-        return df_styler

--- a/src/canswim/db.py
+++ b/src/canswim/db.py
@@ -377,16 +377,60 @@ def get_reward_risk(
     return _format_date_columns(df, ["prior_close_date", "forecast_start_date"])
 
 
+def list_forecast_start_dates(db_path: str) -> list[str]:
+    """Distinct forecast origin dates (YYYY-MM-DD), newest first.
+
+    Used by the Scans tab backtest picker so users can run RR scans as-of a
+    historical monthly start, not only the global latest run.
+    """
+    with connect_readonly(db_path) as db_con:
+        df = db_con.sql(
+            """--sql
+            SELECT DISTINCT start_date
+            FROM forecast
+            WHERE start_date IS NOT NULL
+            ORDER BY start_date DESC
+            """
+        ).df()
+    if df.empty:
+        return []
+    col = "start_date" if "start_date" in df.columns else df.columns[0]
+    out: list[str] = []
+    for v in df[col].tolist():
+        if hasattr(v, "strftime"):
+            out.append(v.strftime("%Y-%m-%d"))
+        else:
+            s = str(v)[:10]
+            if s and s.lower() != "nat":
+                out.append(s)
+    return out
+
+
 def scan_forecasts(
     db_path: str,
     lowq: int,
     reward: float,
     rr: float,
+    forecast_start_date: Optional[Union[str, pd.Timestamp]] = None,
 ) -> pd.DataFrame:
-    """Universe scan (ScanTab.scan_forecasts SQL). lowq is confidence 80/95/99."""
+    """Universe scan (ScanTab.scan_forecasts SQL). lowq is confidence 80/95/99.
+
+    ``forecast_start_date`` selects the forecast origin (backtest as-of).
+    When omitted, uses the newest date in ``latest_forecast`` (live scan).
+    """
     lq = (100 - lowq) / 100
     low_quantile_col = f"close_quantile_{lq}"
     mean_col = "close_quantile_0.5"
+    if forecast_start_date is None or (
+        isinstance(forecast_start_date, str) and not forecast_start_date.strip()
+    ):
+        starts = list_forecast_start_dates(db_path)
+        asof = starts[0] if starts else None
+    else:
+        asof = pd.Timestamp(forecast_start_date).strftime("%Y-%m-%d")
+    if asof is None:
+        logger.warning("scan_forecasts: no forecast start dates in database")
+        return pd.DataFrame()
     with connect_readonly(db_path) as db_con:
         sql_result = db_con.sql(
             f"""--sql
@@ -400,24 +444,27 @@ def scan_forecasts(
                 (forecast_close_high - prior_close_price)/GREATEST(prior_close_price-forecast_close_low, 0.01) as reward_risk,
                 max(e.mal_error) as backtest_error,
                 max(c.date) as prior_close_date,
-            FROM forecast f, close_price c, backtest_error as e, latest_forecast as lf
-            WHERE f.symbol = lf.symbol AND
-                f.symbol = c.symbol AND
-                f.symbol = e.symbol AND e.start_date = f.start_date AND
-                CAST(c.Date AS DATE) < f.start_date
-            GROUP BY f.symbol, f.start_date, c.symbol, e.symbol, e.start_date, lf.symbol, lf.date
+            FROM forecast f
+            INNER JOIN close_price c
+              ON c.symbol = f.symbol
+             AND CAST(c.Date AS DATE) < f.start_date
+            LEFT JOIN backtest_error e
+              ON e.symbol = f.symbol AND e.start_date = f.start_date
+            WHERE f.start_date = CAST($start AS DATE)
+            GROUP BY f.symbol, f.start_date
             HAVING forecast_close_high > prior_close_price AND
-                f.start_date = lf.date AND
-                reward_risk> $rr AND reward_percent >= $reward
-                AND forecast_start_date = (select max(date) from latest_forecast)
+                reward_risk > $rr AND reward_percent >= $reward
+            ORDER BY reward_percent DESC, reward_risk DESC
             """,
             params={
+                "start": asof,
                 "rr": rr,
                 "reward": reward,
             },
         )
         logger.info(
-            f"Scan params: Confidence {lowq}%, Reward: {reward}%, Risk/Reward: {rr}"
+            f"Scan params: as-of {asof}, Confidence {lowq}%, "
+            f"Reward: {reward}%, Risk/Reward: {rr}"
         )
         logger.info(f"SQL Result: \n{sql_result}")
         df = sql_result.df()

--- a/src/canswim/mcp/server.py
+++ b/src/canswim/mcp/server.py
@@ -88,17 +88,24 @@ def get_reward_risk(symbol: str, confidence: int = 80) -> dict[str, Any]:
 @mcp.tool(
     name="scan_forecasts",
     description=(
-        "Scan latest forecasts for symbols meeting reward and reward/risk thresholds "
+        "Scan forecasts for symbols meeting reward and reward/risk thresholds "
         "(same logic as the dashboard Scans tab). "
-        "confidence: 80/95/99; reward: min percent gain; rr: min reward/risk ratio."
+        "confidence: 80/95/99; reward: min percent gain; rr: min reward/risk ratio. "
+        "forecast_start_date: optional YYYY-MM-DD backtest origin (default: latest)."
     ),
 )
 def scan_forecasts(
     confidence: int = 80,
     reward: float = 20,
     rr: float = 3,
+    forecast_start_date: Optional[str] = None,
 ) -> dict[str, Any]:
-    return forecasts.scan_forecasts_impl(confidence=confidence, reward=reward, rr=rr)
+    return forecasts.scan_forecasts_impl(
+        confidence=confidence,
+        reward=reward,
+        rr=rr,
+        forecast_start_date=forecast_start_date,
+    )
 
 
 @mcp.tool(

--- a/src/canswim/mcp/tools/forecasts.py
+++ b/src/canswim/mcp/tools/forecasts.py
@@ -76,6 +76,7 @@ def scan_forecasts_impl(
     confidence: int = 80,
     reward: float = 20,
     rr: float = 3,
+    forecast_start_date: str | None = None,
 ) -> dict[str, Any]:
     ready, msg = ensure_db_ready()
     if not ready:
@@ -84,12 +85,19 @@ def scan_forecasts_impl(
         return err_result(f"confidence must be one of {sorted(_VALID_CONFIDENCE)}")
     db_path = resolve_db_path()
     try:
-        df = scan_forecasts(db_path, lowq=confidence, reward=reward, rr=rr)
+        df = scan_forecasts(
+            db_path,
+            lowq=confidence,
+            reward=reward,
+            rr=rr,
+            forecast_start_date=forecast_start_date,
+        )
         return ok_result(
             {
                 "confidence": confidence,
                 "reward": reward,
                 "rr": rr,
+                "forecast_start_date": forecast_start_date,
                 "row_count": len(df),
                 "rows": dataframe_to_records(df),
             }

--- a/tests/canswim/test_db.py
+++ b/tests/canswim/test_db.py
@@ -16,6 +16,7 @@ from canswim.db import (
     get_forecast_rows,
     get_reward_risk,
     is_select_only,
+    list_forecast_start_dates,
     list_tickers,
     run_select,
     scan_forecasts,
@@ -147,10 +148,29 @@ def test_get_reward_risk_all_starts_for_chart(mini_db):
     assert errs["2025-01-06"] == pytest.approx(0.05)
 
 
+def test_list_forecast_start_dates(mini_db):
+    starts = list_forecast_start_dates(mini_db)
+    assert starts[0] == "2025-01-06"  # newest first
+    assert "2025-01-03" in starts
+
+
 def test_scan_forecasts(mini_db):
     df = scan_forecasts(mini_db, lowq=80, reward=5, rr=1.0)
     assert "AAA" in set(df["symbol"]) if not df.empty else True
     # AAA: high 112 vs prior 102 → ~9.8% reward, low 100 → should pass loose rr
+
+
+def test_scan_forecasts_historic_start(mini_db):
+    """Backtest picker: scan as-of an older monthly origin."""
+    df = scan_forecasts(
+        mini_db, lowq=80, reward=5, rr=1.0, forecast_start_date="2025-01-03"
+    )
+    assert not df.empty
+    assert set(df["symbol"]) == {"AAA"}
+    assert str(df.iloc[0]["forecast_start_date"]).startswith("2025-01-03")
+    # prior for 2025-01-03 is close on 2025-01-02 = 100; mid = 108
+    assert float(df.iloc[0]["prior_close_price"]) == pytest.approx(100.0)
+    assert float(df.iloc[0]["forecast_close_high"]) == pytest.approx(108.0)
 
 
 def test_is_select_only():


### PR DESCRIPTION
## Summary
Scans only used the latest forecast origin, so default filters often returned zero hits even when monthly backtests had strong RR.

### UI
- **Forecast as-of date** dropdown (newest first) on Scans tab
- Defaults: reward 10%, R/R 1.5 (still selective; looser than 20%/3)

### API
- `list_forecast_start_dates()`
- `scan_forecasts(..., forecast_start_date=optional)` — default latest
- MCP tool gets the same optional param

## Test plan
- [x] `./scripts/ci-local.sh` (57 passed)
- [x] as-of 2026-03-02 @ 10%/1.5 → AMZN, GOOGL, AAPL
- [ ] GitHub CI green
- [ ] Manual: Scans → pick Nov 2025 or Mar 2026 → Scan