### PR TITLE
feat: dynamic Scans as-of date dropdown from DB

### DIFF
--- a/src/canswim/dashboard/__init__.py
+++ b/src/canswim/dashboard/__init__.py
@@ -73,7 +73,7 @@ class CanswimPlayground:
                     db_path=self.db_path,
                 )
             with gr.Tab("Scans"):
-                ScanTab(
+                scans_tab = ScanTab(
                     self.canswim_model,
                     db_path=self.db_path,
                 )
@@ -83,10 +83,25 @@ class CanswimPlayground:
                     db_path=self.db_path,
                 )
 
+            def _on_load(ticker, lowq):
+                """Page load: plot chart + fill scan as-of dates (newest default)."""
+                chart_out = charts_tab.plot_forecast(ticker, lowq)
+                start_dd = scans_tab.refresh_start_dates()
+                # chart returns dict of component updates in some paths
+                if isinstance(chart_out, dict):
+                    plot_val = chart_out.get(charts_tab.plotComponent)
+                    rr_val = chart_out.get(charts_tab.rrTable)
+                    return plot_val, rr_val, start_dd
+                return chart_out[0], chart_out[1], start_dd
+
             demo.load(
-                fn=charts_tab.plot_forecast,
+                fn=_on_load,
                 inputs=[charts_tab.tickerDropdown, charts_tab.lowq],
-                outputs=[charts_tab.plotComponent, charts_tab.rrTable],
+                outputs=[
+                    charts_tab.plotComponent,
+                    charts_tab.rrTable,
+                    scans_tab.forecastStart,
+                ],
             )
 
         demo.queue().launch()

--- a/src/canswim/dashboard/scans.py
+++ b/src/canswim/dashboard/scans.py
@@ -14,18 +14,22 @@ class ScanTab:
         assert db_path is not None
         self.canswim_model = canswim_model
         self.db_path = db_path
-        start_choices = list_forecast_start_dates(self.db_path)
-        default_start = start_choices[0] if start_choices else None
+        # Choices filled dynamically via refresh_start_dates() (page load / refresh)
         with gr.Row():
             self.forecastStart = gr.Dropdown(
-                choices=start_choices,
-                value=default_start,
+                choices=[],
+                value=None,
                 label="Forecast as-of date (backtest origin)",
                 info=(
-                    "Pick a historic monthly forecast start, or the latest run. "
-                    "Scan scores stocks using that origin only."
+                    "Loaded from the search DB (newest first). "
+                    "Default is the most recent forecast start. "
+                    "Scan scores stocks for that origin only."
                 ),
                 allow_custom_value=False,
+            )
+            self.refreshStartsBtn = gr.Button(
+                value="Refresh dates",
+                scale=0,
             )
         with gr.Row():
             self.lowq = gr.Radio(
@@ -53,13 +57,28 @@ class ScanTab:
         with gr.Row():
             self.scanResult = gr.Dataframe()
 
+        self.refreshStartsBtn.click(
+            fn=self.refresh_start_dates,
+            inputs=[],
+            outputs=[self.forecastStart],
+        )
         self.scanBtn.click(
             fn=self.scan_forecasts,
             inputs=[self.lowq, self.reward, self.rr, self.forecastStart],
             outputs=[self.scanResult],
         )
 
+    def refresh_start_dates(self):
+        """Query DB for distinct start dates; default selection = most recent."""
+        choices = list_forecast_start_dates(self.db_path)
+        default = choices[0] if choices else None
+        logger.info(
+            f"Scan start-date picker: {len(choices)} origins; default={default}"
+        )
+        return gr.Dropdown(choices=choices, value=default)
+
     def scan_forecasts(self, lowq, reward, rr, forecast_start_date=None):
+        # If UI has no selection yet, resolve to newest via scan_forecasts(None)
         df = db_scan_forecasts(
             self.db_path,
             lowq=lowq,

--- a/src/canswim/db.py
+++ b/src/canswim/db.py
@@ -380,30 +380,22 @@ def get_reward_risk(
 def list_forecast_start_dates(db_path: str) -> list[str]:
     """Distinct forecast origin dates (YYYY-MM-DD), newest first.
 
-    Used by the Scans tab backtest picker so users can run RR scans as-of a
-    historical monthly start, not only the global latest run.
+    Efficient single aggregate over ``forecast.start_date`` (not a full scan of
+    all horizon rows as wide dataframes). Used to populate the Scans backtest
+    dropdown; first element is the default (most recent).
     """
     with connect_readonly(db_path) as db_con:
-        df = db_con.sql(
+        # GROUP BY is cheap on the start_date column; strftime avoids Python loops
+        rows = db_con.execute(
             """--sql
-            SELECT DISTINCT start_date
+            SELECT strftime(start_date, '%Y-%m-%d') AS d
             FROM forecast
             WHERE start_date IS NOT NULL
+            GROUP BY start_date
             ORDER BY start_date DESC
             """
-        ).df()
-    if df.empty:
-        return []
-    col = "start_date" if "start_date" in df.columns else df.columns[0]
-    out: list[str] = []
-    for v in df[col].tolist():
-        if hasattr(v, "strftime"):
-            out.append(v.strftime("%Y-%m-%d"))
-        else:
-            s = str(v)[:10]
-            if s and s.lower() != "nat":
-                out.append(s)
-    return out
+        ).fetchall()
+    return [r[0] for r in rows if r and r[0]]
 
 
 def scan_forecasts(

--- a/tests/canswim/test_db.py
+++ b/tests/canswim/test_db.py
@@ -150,8 +150,10 @@ def test_get_reward_risk_all_starts_for_chart(mini_db):
 
 def test_list_forecast_start_dates(mini_db):
     starts = list_forecast_start_dates(mini_db)
-    assert starts[0] == "2025-01-06"  # newest first
+    assert starts[0] == "2025-01-06"  # newest first (default choice)
     assert "2025-01-03" in starts
+    assert starts == sorted(starts, reverse=True)
+    assert all(len(s) == 10 and s[4] == "-" for s in starts)
 
 
 def test_scan_forecasts(mini_db):


### PR DESCRIPTION
## Summary
Backtest as-of dropdown is filled with an efficient SQL query over distinct `forecast.start_date` values (newest first). Default selection is the most recent date.

- `list_forecast_start_dates`: `GROUP BY start_date` + `strftime` (no Python row walk)
- Scans: empty dropdown at construct; filled on **page load** and **Refresh dates**
- Default value = first list entry (latest)

## Test plan
- [x] `./scripts/ci-local.sh`
- [x] Live query returns 13 dates, default 2026-07-09
- [ ] GitHub CI green
- [ ] Manual: Scans tab shows dates after load; Refresh works