### PR TITLE
fix: Scans empty results + live vs backtest date labels

### DIFF
--- a/src/canswim/dashboard/scans.py
+++ b/src/canswim/dashboard/scans.py
@@ -2,7 +2,7 @@ from loguru import logger
 from canswim.model import CanswimModel
 import gradio as gr
 from canswim.db import (
-    list_forecast_start_dates,
+    list_forecast_start_date_choices,
     scan_forecasts as db_scan_forecasts,
 )
 
@@ -14,16 +14,24 @@ class ScanTab:
         assert db_path is not None
         self.canswim_model = canswim_model
         self.db_path = db_path
+        # Horizon for open-vs-completed labels (TiDE output_chunk_length when loaded)
+        try:
+            self._pred_horizon = int(self.canswim_model.pred_horizon)
+        except Exception:
+            self._pred_horizon = 42
+
         # Choices filled dynamically via refresh_start_dates() (page load / refresh)
         with gr.Row():
             self.forecastStart = gr.Dropdown(
                 choices=[],
                 value=None,
-                label="Forecast as-of date (backtest origin)",
+                label="Forecast start date (as-of origin)",
                 info=(
-                    "Loaded from the search DB (newest first). "
-                    "Default is the most recent forecast start. "
-                    "Scan scores stocks for that origin only."
+                    "Queried from the search DB (newest first). Default = most recent. "
+                    "Includes the latest run, which may still be an **open-horizon live "
+                    "forecast** (not a finished backtest) if today is inside the "
+                    "prediction window. Older dates with a fully elapsed horizon are "
+                    "**completed backtests**. Scan scores only that origin."
                 ),
                 allow_custom_value=False,
             )
@@ -40,15 +48,15 @@ class ScanTab:
             )
             self.reward = gr.Radio(
                 choices=[5, 10, 15, 20, 25],
-                value=10,
-                label="Minimum probabilistic price gain.",
-                info="Choose reward percentage",
+                value=5,
+                label="Minimum probabilistic price gain (%)",
+                info="Median forecast high vs prior close. Lower if the table is empty.",
             )
             self.rr = gr.Radio(
                 choices=[1, 1.5, 3, 5, 10],
-                value=1.5,
-                label="Probabilistic Reward to Risk ratio between price increase and price drop within the forecast period.",
-                info="Choose R/R ratio",
+                value=1,
+                label="Minimum reward / risk ratio",
+                info="Upside to downside (low-confidence quantile). Lower if empty.",
             )
 
         with gr.Row():
@@ -70,15 +78,17 @@ class ScanTab:
 
     def refresh_start_dates(self):
         """Query DB for distinct start dates; default selection = most recent."""
-        choices = list_forecast_start_dates(self.db_path)
-        default = choices[0] if choices else None
+        choices = list_forecast_start_date_choices(
+            self.db_path, pred_horizon_bdays=self._pred_horizon
+        )
+        # Gradio: list of (label, value); value is ISO date
+        default = choices[0][1] if choices else None
         logger.info(
             f"Scan start-date picker: {len(choices)} origins; default={default}"
         )
         return gr.Dropdown(choices=choices, value=default)
 
     def scan_forecasts(self, lowq, reward, rr, forecast_start_date=None):
-        # If UI has no selection yet, resolve to newest via scan_forecasts(None)
         df = db_scan_forecasts(
             self.db_path,
             lowq=lowq,
@@ -86,12 +96,18 @@ class ScanTab:
             rr=rr,
             forecast_start_date=forecast_start_date,
         )
+        n = 0 if df is None else len(df)
         logger.info(
             f"Scan as-of={forecast_start_date} lowq={lowq} reward={reward} rr={rr} "
-            f"hits={0 if df is None else len(df)}"
+            f"hits={n}"
         )
-        logger.debug(f"df types: {df.dtypes if df is not None else None}")
         if df is None or df.empty:
+            gr.Warning(
+                f"No symbols met reward ≥ {reward}% and R/R ≥ {rr} for as-of "
+                f"{forecast_start_date or 'latest'}. "
+                f"Try lower thresholds (e.g. 5% / 1.0) or another start date. "
+                f"Latest open-horizon forecasts are often milder than past backtests."
+            )
             return df
         return df.style.format(
             precision=2,

--- a/src/canswim/db.py
+++ b/src/canswim/db.py
@@ -377,6 +377,10 @@ def get_reward_risk(
     return _format_date_columns(df, ["prior_close_date", "forecast_start_date"])
 
 
+# Default TiDE output_chunk_length when model is not available for labeling
+_DEFAULT_PRED_HORIZON_BDAYS = 42
+
+
 def list_forecast_start_dates(db_path: str) -> list[str]:
     """Distinct forecast origin dates (YYYY-MM-DD), newest first.
 
@@ -398,6 +402,56 @@ def list_forecast_start_dates(db_path: str) -> list[str]:
     return [r[0] for r in rows if r and r[0]]
 
 
+def list_forecast_start_date_choices(
+    db_path: str,
+    *,
+    pred_horizon_bdays: int = _DEFAULT_PRED_HORIZON_BDAYS,
+    asof: Optional[Union[str, pd.Timestamp]] = None,
+) -> list[tuple[str, str]]:
+    """Gradio dropdown choices: ``(label, value)`` newest first.
+
+    Labels distinguish:
+    - **latest · open horizon** — most recent origin, and today's date is still
+      inside the forecast horizon (not a finished backtest yet)
+    - **open horizon** — older origin whose horizon has not fully elapsed
+    - **completed backtest** — all horizon sessions are in the past relative to
+      the latest available close (or calendar as-of)
+
+    ``value`` is always ISO ``YYYY-MM-DD`` for scanning.
+    """
+    from pandas.tseries.offsets import BDay
+
+    dates = list_forecast_start_dates(db_path)
+    if not dates:
+        return []
+
+    # Reference "today" = last close in DB when available (market as-of), else calendar
+    ref = pd.Timestamp(asof).normalize() if asof is not None else None
+    if ref is None:
+        with connect_readonly(db_path) as db_con:
+            row = db_con.execute(
+                "SELECT max(CAST(Date AS DATE)) FROM close_price"
+            ).fetchone()
+        if row and row[0] is not None:
+            ref = pd.Timestamp(row[0]).normalize()
+        else:
+            ref = pd.Timestamp.now().normalize()
+
+    newest = dates[0]
+    choices: list[tuple[str, str]] = []
+    for d in dates:
+        start = pd.Timestamp(d)
+        horizon_end = (start + BDay(n=int(pred_horizon_bdays))).normalize()
+        if d == newest and ref <= horizon_end:
+            kind = "latest · open horizon (not a finished backtest)"
+        elif ref <= horizon_end:
+            kind = "open horizon (backtest incomplete)"
+        else:
+            kind = "completed backtest"
+        choices.append((f"{d}  —  {kind}", d))
+    return choices
+
+
 def scan_forecasts(
     db_path: str,
     lowq: int,
@@ -410,16 +464,22 @@ def scan_forecasts(
     ``forecast_start_date`` selects the forecast origin (backtest as-of).
     When omitted, uses the newest date in ``latest_forecast`` (live scan).
     """
+    # Gradio radios often pass strings; coerce for SQL numeric compares
+    lowq = int(lowq)
+    reward = float(reward)
+    rr = float(rr)
     lq = (100 - lowq) / 100
     low_quantile_col = f"close_quantile_{lq}"
     mean_col = "close_quantile_0.5"
     if forecast_start_date is None or (
-        isinstance(forecast_start_date, str) and not forecast_start_date.strip()
+        isinstance(forecast_start_date, str) and not str(forecast_start_date).strip()
     ):
         starts = list_forecast_start_dates(db_path)
         asof = starts[0] if starts else None
     else:
-        asof = pd.Timestamp(forecast_start_date).strftime("%Y-%m-%d")
+        # Dropdown may send "YYYY-MM-DD  —  label" if misconfigured; take ISO prefix
+        raw = str(forecast_start_date).strip()
+        asof = pd.Timestamp(raw[:10]).strftime("%Y-%m-%d")
     if asof is None:
         logger.warning("scan_forecasts: no forecast start dates in database")
         return pd.DataFrame()
@@ -445,7 +505,7 @@ def scan_forecasts(
             WHERE f.start_date = CAST($start AS DATE)
             GROUP BY f.symbol, f.start_date
             HAVING forecast_close_high > prior_close_price AND
-                reward_risk > $rr AND reward_percent >= $reward
+                reward_risk >= $rr AND reward_percent >= $reward
             ORDER BY reward_percent DESC, reward_risk DESC
             """,
             params={

--- a/tests/canswim/test_db.py
+++ b/tests/canswim/test_db.py
@@ -16,6 +16,7 @@ from canswim.db import (
     get_forecast_rows,
     get_reward_risk,
     is_select_only,
+    list_forecast_start_date_choices,
     list_forecast_start_dates,
     list_tickers,
     run_select,
@@ -154,6 +155,21 @@ def test_list_forecast_start_dates(mini_db):
     assert "2025-01-03" in starts
     assert starts == sorted(starts, reverse=True)
     assert all(len(s) == 10 and s[4] == "-" for s in starts)
+
+
+def test_list_forecast_start_date_choices_labels(mini_db):
+    choices = list_forecast_start_date_choices(
+        mini_db, pred_horizon_bdays=42, asof="2025-06-01"
+    )
+    assert choices[0][1] == "2025-01-06"  # value = ISO date
+    assert "2025-01-06" in choices[0][0]
+    # Both starts fully before mid-2025 → completed backtest labels
+    assert all("completed backtest" in lab for lab, _ in choices)
+    # Open-horizon labeling when asof is near newest start
+    open_choices = list_forecast_start_date_choices(
+        mini_db, pred_horizon_bdays=42, asof="2025-01-10"
+    )
+    assert "open horizon" in open_choices[0][0].lower() or "latest" in open_choices[0][0].lower()
 
 
 def test_scan_forecasts(mini_db):


### PR DESCRIPTION
## Summary
Users saw no Scans hits for any as-of date, and the label implied every date is a backtest.

### Why empty
Default filters (10% / R/R 1.5) plus **latest open-horizon** forecasts (mild) often match nothing. Backend works; e.g. as-of 2026-03-02 with 5%/1.0 returns AMZN, GOOGL, AAPL, MSFT.

### Changes
- Dropdown labels via efficient SQL + horizon classification:
  - `latest · open horizon (not a finished backtest)`
  - `open horizon (backtest incomplete)`
  - `completed backtest`
- Defaults: reward **5%**, R/R **1.0**
- Coerce string radio values; `reward_risk >= rr`
- Gradio warning when zero hits with how to fix

## Test plan
- [x] `./scripts/ci-local.sh` (58 passed)
- [x] Labels: 2026-07-09 marked latest open horizon
- [ ] CI green → merge
- [ ] Manual: Scans → completed backtest date → Scan shows rows