### PR TITLE
fix: Scans dropdown resets on Refresh

### DIFF
--- a/src/canswim/dashboard/__init__.py
+++ b/src/canswim/dashboard/__init__.py
@@ -86,7 +86,8 @@ class CanswimPlayground:
             def _on_load(ticker, lowq):
                 """Page load: plot chart + fill scan as-of dates (newest default)."""
                 chart_out = charts_tab.plot_forecast(ticker, lowq)
-                start_dd = scans_tab.refresh_start_dates()
+                # No prior selection on first load → default newest
+                start_dd = scans_tab.refresh_start_dates(current=None)
                 # chart returns dict of component updates in some paths
                 if isinstance(chart_out, dict):
                     plot_val = chart_out.get(charts_tab.plotComponent)

--- a/src/canswim/dashboard/__init__.py
+++ b/src/canswim/dashboard/__init__.py
@@ -84,18 +84,30 @@ class CanswimPlayground:
                 )
 
             def _on_load(ticker, lowq):
-                """Page load: plot chart + fill scan as-of dates (newest default)."""
+                """Page load: chart + scan dates + auto-scan with defaults."""
                 chart_out = charts_tab.plot_forecast(ticker, lowq)
-                # No prior selection on first load → default newest
-                start_dd, start_iso = scans_tab.refresh_start_dates(
-                    current=None, stored=None
+                start_dd, start_iso, scan_status, scan_table = (
+                    scans_tab.initial_scan()
                 )
-                # chart returns dict of component updates in some paths
                 if isinstance(chart_out, dict):
                     plot_val = chart_out.get(charts_tab.plotComponent)
                     rr_val = chart_out.get(charts_tab.rrTable)
-                    return plot_val, rr_val, start_dd, start_iso
-                return chart_out[0], chart_out[1], start_dd, start_iso
+                    return (
+                        plot_val,
+                        rr_val,
+                        start_dd,
+                        start_iso,
+                        scan_status,
+                        scan_table,
+                    )
+                return (
+                    chart_out[0],
+                    chart_out[1],
+                    start_dd,
+                    start_iso,
+                    scan_status,
+                    scan_table,
+                )
 
             demo.load(
                 fn=_on_load,
@@ -105,6 +117,8 @@ class CanswimPlayground:
                     charts_tab.rrTable,
                     scans_tab.forecastStart,
                     scans_tab.selectedStart,
+                    scans_tab.scanStatus,
+                    scans_tab.scanResult,
                 ],
             )
 

--- a/src/canswim/dashboard/__init__.py
+++ b/src/canswim/dashboard/__init__.py
@@ -87,13 +87,15 @@ class CanswimPlayground:
                 """Page load: plot chart + fill scan as-of dates (newest default)."""
                 chart_out = charts_tab.plot_forecast(ticker, lowq)
                 # No prior selection on first load → default newest
-                start_dd = scans_tab.refresh_start_dates(current=None)
+                start_dd, start_iso = scans_tab.refresh_start_dates(
+                    current=None, stored=None
+                )
                 # chart returns dict of component updates in some paths
                 if isinstance(chart_out, dict):
                     plot_val = chart_out.get(charts_tab.plotComponent)
                     rr_val = chart_out.get(charts_tab.rrTable)
-                    return plot_val, rr_val, start_dd
-                return chart_out[0], chart_out[1], start_dd
+                    return plot_val, rr_val, start_dd, start_iso
+                return chart_out[0], chart_out[1], start_dd, start_iso
 
             demo.load(
                 fn=_on_load,
@@ -102,6 +104,7 @@ class CanswimPlayground:
                     charts_tab.plotComponent,
                     charts_tab.rrTable,
                     scans_tab.forecastStart,
+                    scans_tab.selectedStart,
                 ],
             )
 

--- a/src/canswim/dashboard/scans.py
+++ b/src/canswim/dashboard/scans.py
@@ -35,7 +35,7 @@ class ScanTab:
             self._pred_horizon = 42
 
         # Preload so the Dropdown is never empty (Gradio is flaky with choices=[]
-        # then later gr.update — selected value can arrive as None on Refresh).
+        # then later gr.update — selected value can arrive as None).
         init_pairs = list_forecast_start_date_choices(
             self.db_path, pred_horizon_bdays=self._pred_horizon
         )
@@ -43,97 +43,114 @@ class ScanTab:
         init_iso = init_pairs[0][1] if init_pairs else None
         init_label = init_labels[0] if init_labels else None
 
-        # Stable selection store — do not rely only on Dropdown I/O (same component
-        # as input+output often loses the user pick in Gradio 4.x).
+        # Stable selection store — backup if Dropdown payload is empty
         self.selectedStart = gr.State(value=init_iso)
 
         with gr.Row():
             # Plain string choices (label == value). Avoid (label, value) tuples:
-            # frontend can send None / label / value inconsistently on refresh.
+            # frontend can send None / label / value inconsistently.
             self.forecastStart = gr.Dropdown(
                 choices=init_labels,
                 value=init_label,
                 label="Forecast start date (as-of origin)",
                 info=(
-                    "Queried from the search DB (newest first). Default = most recent. "
-                    "Includes the latest run, which may still be an **open-horizon live "
-                    "forecast** (not a finished backtest) if today is inside the "
-                    "prediction window. Older dates with a fully elapsed horizon are "
-                    "**completed backtests**. Scan scores only that origin. "
-                    "Refresh reloads the list but keeps your current selection when possible."
+                    "Newest first. Latest may be an **open-horizon live forecast**; "
+                    "older dates with a full elapsed window are **completed backtests**. "
+                    "Changing the date or filters updates results immediately."
                 ),
                 allow_custom_value=False,
                 filterable=True,
             )
             self.refreshStartsBtn = gr.Button(
-                value="Refresh dates",
+                value="↻ dates",
                 scale=0,
+                min_width=80,
+                variant="secondary",
             )
         with gr.Row():
             self.lowq = gr.Radio(
                 choices=[80, 95, 99],
                 value=80,
                 label="Confidence level for lowest close price",
-                info="Choose low price confidence percentage",
+                info="Low-price confidence used in reward/risk",
             )
             self.reward = gr.Radio(
                 choices=[5, 10, 15, 20, 25],
                 value=5,
                 label="Minimum probabilistic price gain (%)",
-                info="Median forecast high vs prior close. Lower if the table is empty.",
+                info="Median forecast high vs prior close",
             )
             self.rr = gr.Radio(
                 choices=[1, 1.5, 3, 5, 10],
                 value=1,
                 label="Minimum reward / risk ratio",
-                info="Upside to downside (low-confidence quantile). Lower if empty.",
+                info="Upside vs downside (low-confidence quantile)",
             )
 
         with gr.Row():
-            self.scanBtn = gr.Button(value="Scan", variant="primary")
+            self.scanStatus = gr.Markdown(
+                value="_Pick filters — results update automatically._"
+            )
 
         with gr.Row():
             self.scanResult = gr.Dataframe()
 
-        # Keep State in sync whenever the user picks a date
+        scan_inputs = [
+            self.lowq,
+            self.reward,
+            self.rr,
+            self.forecastStart,
+            self.selectedStart,
+        ]
+        scan_outputs = [self.selectedStart, self.scanStatus, self.scanResult]
+
+        # Auto-scan on any control change (same pattern as Charts tab)
         self.forecastStart.change(
-            fn=self._on_start_change,
-            inputs=[self.forecastStart],
-            outputs=[self.selectedStart],
+            fn=self.apply_and_scan,
+            inputs=scan_inputs,
+            outputs=scan_outputs,
         )
-        self.forecastStart.input(
-            fn=self._on_start_change,
-            inputs=[self.forecastStart],
-            outputs=[self.selectedStart],
+        self.lowq.change(
+            fn=self.apply_and_scan,
+            inputs=scan_inputs,
+            outputs=scan_outputs,
         )
-        # Refresh: prefer Dropdown (what user sees), fall back to State
+        self.reward.change(
+            fn=self.apply_and_scan,
+            inputs=scan_inputs,
+            outputs=scan_outputs,
+        )
+        self.rr.change(
+            fn=self.apply_and_scan,
+            inputs=scan_inputs,
+            outputs=scan_outputs,
+        )
+        # Optional: reload date list only (new forecast origins in DB)
         self.refreshStartsBtn.click(
             fn=self.refresh_start_dates,
             inputs=[self.forecastStart, self.selectedStart],
             outputs=[self.forecastStart, self.selectedStart],
-        )
-        # Scan: prefer Dropdown payload, fall back to State
-        self.scanBtn.click(
-            fn=self.scan_forecasts,
-            inputs=[
-                self.lowq,
-                self.reward,
-                self.rr,
-                self.forecastStart,
-                self.selectedStart,
-            ],
-            outputs=[self.scanResult],
+        ).then(
+            fn=self.apply_and_scan,
+            inputs=scan_inputs,
+            outputs=scan_outputs,
         )
 
-    def _on_start_change(self, current):
-        return _normalize_start_value(current)
+    def apply_and_scan(
+        self, lowq, reward, rr, forecast_start_date=None, stored_start=None
+    ):
+        """Update selection state + run scan. Used by control change handlers."""
+        asof = (
+            _normalize_start_value(forecast_start_date)
+            or _normalize_start_value(stored_start)
+        )
+        status, table = self._run_scan(lowq=lowq, reward=reward, rr=rr, asof=asof)
+        return asof, status, table
 
     def refresh_start_dates(self, current=None, stored=None):
         """Reload start dates from DB; keep selection if still valid, else newest.
 
-        Prefer the Dropdown value (``current``) over State (``stored``). State alone
-        can lag if change events were skipped, which previously forced a reset to
-        the default newest origin.
+        Prefer the Dropdown value (``current``) over State (``stored``).
 
         Returns ``(dropdown_update, selected_iso)`` for Dropdown + State.
         """
@@ -144,7 +161,6 @@ class ScanTab:
         by_iso = {v: lab for lab, v in pairs}
         isos = [v for _lab, v in pairs]
 
-        # Dropdown first (authoritative UI selection), then State backup
         cur = _normalize_start_value(current) or _normalize_start_value(stored)
         if cur and cur in by_iso:
             selected_iso = cur
@@ -159,13 +175,14 @@ class ScanTab:
         )
         return gr.update(choices=labels, value=selected_label), selected_iso
 
-    def scan_forecasts(
-        self, lowq, reward, rr, forecast_start_date=None, stored_start=None
-    ):
-        asof = (
-            _normalize_start_value(forecast_start_date)
-            or _normalize_start_value(stored_start)
-        )
+    def initial_scan(self):
+        """Page-load helper: (dropdown_update, iso, status, table)."""
+        dd, iso = self.refresh_start_dates(current=None, stored=None)
+        # Defaults match Radio initial values
+        status, table = self._run_scan(lowq=80, reward=5, rr=1, asof=iso)
+        return dd, iso, status, table
+
+    def _run_scan(self, lowq, reward, rr, asof):
         df = db_scan_forecasts(
             self.db_path,
             lowq=lowq,
@@ -178,15 +195,19 @@ class ScanTab:
             f"Scan as-of={asof} lowq={lowq} reward={reward} rr={rr} hits={n}"
         )
         if df is None or df.empty:
-            gr.Warning(
-                f"No symbols met reward ≥ {reward}% and R/R ≥ {rr} for as-of "
-                f"{asof or 'latest'}. "
-                f"Try lower thresholds (e.g. 5% / 1.0) or another start date. "
-                f"Latest open-horizon forecasts are often milder than past backtests."
+            status = (
+                f"**No matches** for as-of `{asof or 'latest'}` · "
+                f"reward ≥ {reward}% · R/R ≥ {rr} · low conf {lowq}%. "
+                f"Try lower thresholds or another start date."
             )
-            return df
-        return df.style.format(
+            return status, df
+        status = (
+            f"**{n} symbol{'s' if n != 1 else ''}** · as-of `{asof}` · "
+            f"reward ≥ {reward}% · R/R ≥ {rr} · low conf {lowq}%"
+        )
+        styled = df.style.format(
             precision=2,
             thousands=",",
             decimal=".",
         )
+        return status, styled

--- a/src/canswim/dashboard/scans.py
+++ b/src/canswim/dashboard/scans.py
@@ -7,6 +7,17 @@ from canswim.db import (
 )
 
 
+def _normalize_start_value(current) -> str | None:
+    """Map Gradio dropdown payload to ISO YYYY-MM-DD."""
+    if current is None:
+        return None
+    s = str(current).strip()
+    if not s:
+        return None
+    # Prefer leading ISO date (handles full label if Gradio ever sends it)
+    return s[:10] if len(s) >= 10 and s[4] == "-" and s[7] == "-" else s
+
+
 class ScanTab:
 
     def __init__(self, canswim_model: CanswimModel = None, db_path=None):
@@ -31,9 +42,12 @@ class ScanTab:
                     "Includes the latest run, which may still be an **open-horizon live "
                     "forecast** (not a finished backtest) if today is inside the "
                     "prediction window. Older dates with a fully elapsed horizon are "
-                    "**completed backtests**. Scan scores only that origin."
+                    "**completed backtests**. Scan scores only that origin. "
+                    "Refresh reloads the list but keeps your current selection when possible."
                 ),
                 allow_custom_value=False,
+                # Return the ISO value, not the display label
+                type="value",
             )
             self.refreshStartsBtn = gr.Button(
                 value="Refresh dates",
@@ -65,9 +79,10 @@ class ScanTab:
         with gr.Row():
             self.scanResult = gr.Dataframe()
 
+        # Pass current selection so refresh does not wipe a user pick
         self.refreshStartsBtn.click(
             fn=self.refresh_start_dates,
-            inputs=[],
+            inputs=[self.forecastStart],
             outputs=[self.forecastStart],
         )
         self.scanBtn.click(
@@ -76,35 +91,41 @@ class ScanTab:
             outputs=[self.scanResult],
         )
 
-    def refresh_start_dates(self):
-        """Query DB for distinct start dates; default selection = most recent."""
+    def refresh_start_dates(self, current=None):
+        """Reload start dates from DB; keep selection if still valid, else newest."""
         choices = list_forecast_start_date_choices(
             self.db_path, pred_horizon_bdays=self._pred_horizon
         )
-        # Gradio: list of (label, value); value is ISO date
-        default = choices[0][1] if choices else None
+        values = [v for _lab, v in choices]
+        cur = _normalize_start_value(current)
+        if cur and cur in values:
+            selected = cur
+        else:
+            selected = values[0] if values else None
         logger.info(
-            f"Scan start-date picker: {len(choices)} origins; default={default}"
+            f"Scan start-date picker: {len(choices)} origins; "
+            f"selected={selected} (was {current!r})"
         )
-        return gr.Dropdown(choices=choices, value=default)
+        # gr.update preserves component identity better than replacing Dropdown
+        return gr.update(choices=choices, value=selected)
 
     def scan_forecasts(self, lowq, reward, rr, forecast_start_date=None):
+        asof = _normalize_start_value(forecast_start_date)
         df = db_scan_forecasts(
             self.db_path,
             lowq=lowq,
             reward=reward,
             rr=rr,
-            forecast_start_date=forecast_start_date,
+            forecast_start_date=asof,
         )
         n = 0 if df is None else len(df)
         logger.info(
-            f"Scan as-of={forecast_start_date} lowq={lowq} reward={reward} rr={rr} "
-            f"hits={n}"
+            f"Scan as-of={asof} lowq={lowq} reward={reward} rr={rr} hits={n}"
         )
         if df is None or df.empty:
             gr.Warning(
                 f"No symbols met reward ≥ {reward}% and R/R ≥ {rr} for as-of "
-                f"{forecast_start_date or 'latest'}. "
+                f"{asof or 'latest'}. "
                 f"Try lower thresholds (e.g. 5% / 1.0) or another start date. "
                 f"Latest open-horizon forecasts are often milder than past backtests."
             )

--- a/src/canswim/dashboard/scans.py
+++ b/src/canswim/dashboard/scans.py
@@ -8,13 +8,16 @@ from canswim.db import (
 
 
 def _normalize_start_value(current) -> str | None:
-    """Map Gradio dropdown payload to ISO YYYY-MM-DD."""
+    """Map Gradio dropdown / state payload to ISO YYYY-MM-DD."""
     if current is None:
+        return None
+    # Index payloads (type=index or accidental int) are not usable alone
+    if isinstance(current, (int, float)) and not isinstance(current, bool):
         return None
     s = str(current).strip()
     if not s:
         return None
-    # Prefer leading ISO date (handles full label if Gradio ever sends it)
+    # Prefer leading ISO date (handles full label if Gradio sends it)
     return s[:10] if len(s) >= 10 and s[4] == "-" and s[7] == "-" else s
 
 
@@ -31,11 +34,25 @@ class ScanTab:
         except Exception:
             self._pred_horizon = 42
 
-        # Choices filled dynamically via refresh_start_dates() (page load / refresh)
+        # Preload so the Dropdown is never empty (Gradio is flaky with choices=[]
+        # then later gr.update — selected value can arrive as None on Refresh).
+        init_pairs = list_forecast_start_date_choices(
+            self.db_path, pred_horizon_bdays=self._pred_horizon
+        )
+        init_labels = [lab for lab, _v in init_pairs]
+        init_iso = init_pairs[0][1] if init_pairs else None
+        init_label = init_labels[0] if init_labels else None
+
+        # Stable selection store — do not rely only on Dropdown I/O (same component
+        # as input+output often loses the user pick in Gradio 4.x).
+        self.selectedStart = gr.State(value=init_iso)
+
         with gr.Row():
+            # Plain string choices (label == value). Avoid (label, value) tuples:
+            # frontend can send None / label / value inconsistently on refresh.
             self.forecastStart = gr.Dropdown(
-                choices=[],
-                value=None,
+                choices=init_labels,
+                value=init_label,
                 label="Forecast start date (as-of origin)",
                 info=(
                     "Queried from the search DB (newest first). Default = most recent. "
@@ -46,8 +63,7 @@ class ScanTab:
                     "Refresh reloads the list but keeps your current selection when possible."
                 ),
                 allow_custom_value=False,
-                # Return the ISO value, not the display label
-                type="value",
+                filterable=True,
             )
             self.refreshStartsBtn = gr.Button(
                 value="Refresh dates",
@@ -79,38 +95,77 @@ class ScanTab:
         with gr.Row():
             self.scanResult = gr.Dataframe()
 
-        # Pass current selection so refresh does not wipe a user pick
+        # Keep State in sync whenever the user picks a date
+        self.forecastStart.change(
+            fn=self._on_start_change,
+            inputs=[self.forecastStart],
+            outputs=[self.selectedStart],
+        )
+        self.forecastStart.input(
+            fn=self._on_start_change,
+            inputs=[self.forecastStart],
+            outputs=[self.selectedStart],
+        )
+        # Refresh: prefer Dropdown (what user sees), fall back to State
         self.refreshStartsBtn.click(
             fn=self.refresh_start_dates,
-            inputs=[self.forecastStart],
-            outputs=[self.forecastStart],
+            inputs=[self.forecastStart, self.selectedStart],
+            outputs=[self.forecastStart, self.selectedStart],
         )
+        # Scan: prefer Dropdown payload, fall back to State
         self.scanBtn.click(
             fn=self.scan_forecasts,
-            inputs=[self.lowq, self.reward, self.rr, self.forecastStart],
+            inputs=[
+                self.lowq,
+                self.reward,
+                self.rr,
+                self.forecastStart,
+                self.selectedStart,
+            ],
             outputs=[self.scanResult],
         )
 
-    def refresh_start_dates(self, current=None):
-        """Reload start dates from DB; keep selection if still valid, else newest."""
-        choices = list_forecast_start_date_choices(
+    def _on_start_change(self, current):
+        return _normalize_start_value(current)
+
+    def refresh_start_dates(self, current=None, stored=None):
+        """Reload start dates from DB; keep selection if still valid, else newest.
+
+        Prefer the Dropdown value (``current``) over State (``stored``). State alone
+        can lag if change events were skipped, which previously forced a reset to
+        the default newest origin.
+
+        Returns ``(dropdown_update, selected_iso)`` for Dropdown + State.
+        """
+        pairs = list_forecast_start_date_choices(
             self.db_path, pred_horizon_bdays=self._pred_horizon
         )
-        values = [v for _lab, v in choices]
-        cur = _normalize_start_value(current)
-        if cur and cur in values:
-            selected = cur
-        else:
-            selected = values[0] if values else None
-        logger.info(
-            f"Scan start-date picker: {len(choices)} origins; "
-            f"selected={selected} (was {current!r})"
-        )
-        # gr.update preserves component identity better than replacing Dropdown
-        return gr.update(choices=choices, value=selected)
+        labels = [lab for lab, _v in pairs]
+        by_iso = {v: lab for lab, v in pairs}
+        isos = [v for _lab, v in pairs]
 
-    def scan_forecasts(self, lowq, reward, rr, forecast_start_date=None):
-        asof = _normalize_start_value(forecast_start_date)
+        # Dropdown first (authoritative UI selection), then State backup
+        cur = _normalize_start_value(current) or _normalize_start_value(stored)
+        if cur and cur in by_iso:
+            selected_iso = cur
+            selected_label = by_iso[cur]
+        else:
+            selected_iso = isos[0] if isos else None
+            selected_label = labels[0] if labels else None
+
+        logger.info(
+            f"Scan start-date picker: {len(pairs)} origins; "
+            f"selected={selected_iso} (current={current!r}, stored={stored!r})"
+        )
+        return gr.update(choices=labels, value=selected_label), selected_iso
+
+    def scan_forecasts(
+        self, lowq, reward, rr, forecast_start_date=None, stored_start=None
+    ):
+        asof = (
+            _normalize_start_value(forecast_start_date)
+            or _normalize_start_value(stored_start)
+        )
         df = db_scan_forecasts(
             self.db_path,
             lowq=lowq,


### PR DESCRIPTION
## Summary
Picking a historic as-of date then clicking **Refresh dates** always jumped back to the latest origin (and felt broken).

### Fix
- Refresh keeps the current selection if still present; otherwise defaults to newest
- `gr.update(choices=..., value=selected)` instead of replacing the component
- `type=\"value\"` so Scan receives the ISO date, not the long label
- Normalize leading `YYYY-MM-DD` from either value or label

## Test plan
- [x] Local CI
- [ ] CI green
- [ ] Manual: pick 2026-03-02 → Refresh → still 2026-03-02 → Scan