### PR TITLE
feat: GUI + MCP gather/forecast with week-aligned starts

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,11 @@ options:
 NOTE: NOT FINANCIAL OR INVESTMENT ADVICE. USE AT YOUR OWN RISK.
 ```
 
-## MCP server (read-only)
+## MCP server (read-only by default)
 
-Expose precomputed TiDE forecasts and local market data to MCP clients (Claude Desktop, Cursor, etc.) over the **same DuckDB search database** used by the dashboard. The MCP process does **not** load the torch model and does not run train/gather/forecast.
+Expose precomputed TiDE forecasts and local market data to MCP clients (Claude Desktop, Cursor, etc.) over the **same DuckDB search database** used by the dashboard.
+
+By default the process stays **read-only** (no torch, no gather/forecast). Optional **write tools** are always listed but only execute when `MCP_ALLOW_RUNS=1` (or `CANSWIM_ALLOW_RUNS=1`).
 
 ### Prerequisites
 
@@ -102,6 +104,12 @@ python -m canswim.mcp
 ```
 
 Configure paths via `.env` (`data_dir`, `db_file`) — same as the dashboard.
+
+Enable gather/forecast triggers (local mutation + possible model load):
+
+```bash
+MCP_ALLOW_RUNS=1 python -m canswim mcp
+```
 
 ### Example client config (stdio)
 
@@ -126,7 +134,7 @@ Configure paths via `.env` (`data_dir`, `db_file`) — same as the dashboard.
 | Tool | Description |
 |------|-------------|
 | `health_check` | DB path / readiness |
-| `get_server_info` | Version, read-only flag, tool list |
+| `get_server_info` | Version, read-only / runs_allowed flags, tool list |
 | `list_tickers` | Symbols in search DB |
 | `get_forecast` | Quantile forecast rows for a symbol |
 | `get_reward_risk` | Reward/risk for latest forecast (confidence 80/95/99) |
@@ -134,5 +142,12 @@ Configure paths via `.env` (`data_dir`, `db_file`) — same as the dashboard.
 | `get_close_price` | Historical closes |
 | `get_backtest_error` | Forecast vs actual error |
 | `run_select` | Single SELECT only (Advanced Queries) |
+| `resolve_forecast_start` | Preview week-aligned forecast start (read-only) |
+| `gather_tickers` | Gather data for ticker list (**requires `MCP_ALLOW_RUNS=1`**) |
+| `forecast_tickers` | Forecast ticker list, week-aligned start (**requires `MCP_ALLOW_RUNS=1`**) |
+
+### Dashboard Run tab
+
+The Gradio **Run** tab uses the same orchestration as the MCP write tools (without the env gate): paste tickers, optional forecast start date (snapped to market week start), **Gather data** / **Run forecast**.
 
 **NOT FINANCIAL OR INVESTMENT ADVICE. USE AT YOUR OWN RISK.**

--- a/README.md
+++ b/README.md
@@ -55,26 +55,27 @@ Optional HF:
 
 Train/forecast **skip tickers without complete ground-truth OHLCV** (no synthetic price fill).
 
-## Gather & forecast: one contract (CLI · GUI · MCP)
+## Get market data & run forecasts (CLI · GUI · MCP)
 
-Scoped runs share **`canswim.run_triggers`** (tickers + week-aligned start). Full detail: **[docs/run_triggers.md](docs/run_triggers.md)**.
+Two separate steps, same backend (`canswim.run_triggers`). Details: **[docs/run_triggers.md](docs/run_triggers.md)**.
 
-| Surface | Gather | Forecast | Preview start |
-|---------|--------|----------|---------------|
-| **CLI** | `gatherdata --tickers "…"` | `forecast --tickers "…" [--forecast_start_date] [--dry_run]` | `resolve_start [--forecast_start_date]` |
-| **GUI** | Dashboard → **Run** → Gather | **Run** → Forecast | **Preview start date** |
-| **MCP** | `gather_tickers` (`MCP_ALLOW_RUNS=1`) | `forecast_tickers` (`MCP_ALLOW_RUNS=1`) | `resolve_forecast_start` (always) |
+| | Get market data | Run a forecast | Check start date |
+|--|-----------------|----------------|------------------|
+| **CLI** | `gatherdata --tickers "…"` | `forecast --tickers "…" [date] [--dry_run]` | `resolve_start` |
+| **GUI** | **Update market data** | **Run forecast** | **Check start date** |
+| **MCP** | `gather_tickers`* | `forecast_tickers`* | `resolve_forecast_start` |
 
-**Start-date policy (all three):** past dates → first NYSE session of that market week (holiday Monday → next open that week); empty/today → live origin after latest week-end close; no pure-future origins.
+\*MCP write tools need `MCP_ALLOW_RUNS=1`.
+
+Scoped get-market-data uses **~2 years** of history and **skips downloads** when local files are already complete. Forecasts **stop** if data is incomplete (no invented prices).
 
 ```bash
-# examples
+python -m canswim gatherdata --tickers "AAPL, MSFT"
 python -m canswim resolve_start --forecast_start_date 2026-03-05
 python -m canswim forecast --tickers AAPL --forecast_start_date 2026-03-05 --dry_run
-python -m canswim forecast --tickers "AAPL,MSFT" --forecast_start_date 2026-03-05
 ```
 
-Without `--tickers`, `gatherdata` / `forecast` keep legacy full-universe behavior.
+Without `--tickers`, `gatherdata` / `forecast` keep full-universe / train-style behavior.
 
 ## Command line interface
 

--- a/README.md
+++ b/README.md
@@ -34,11 +34,14 @@ That HF snapshot step is slow and was a common reason the CLI “hung”. Instea
 3. Resolve ticker universes from checked-in **`symbol_lists/*.csv`** (light reference files).
 
 ```bash
-# typical local gather (no HF dataset sync)
+# full-universe local gather (no HF dataset sync)
 hfhub_sync=False python -m canswim gatherdata
 
-# optional: only a few symbols
+# scoped list via env (legacy full gather path)
 stock_tickers_list=few_stocks.csv hfhub_sync=False python -m canswim gatherdata
+
+# scoped list via --tickers (same pipeline as Dashboard Run + MCP gather_tickers)
+hfhub_sync=False python -m canswim gatherdata --tickers "AAPL, MSFT"
 ```
 
 Optional HF:
@@ -48,40 +51,55 @@ Optional HF:
 | `hfhub_sync` | `False` | Full dataset/model sync off |
 | `SYNC_SYMBOL_LISTS` | `False` | If `True`, fetch only light CSVs from the HF dataset once |
 | `YFINANCE_USE_CACHE` | `False` | Avoid multi‑GB SQLite cache hang |
+| `MCP_ALLOW_RUNS` | unset | Enable MCP gather/forecast tools (CLI/GUI do not need this) |
 
 Train/forecast **skip tickers without complete ground-truth OHLCV** (no synthetic price fill).
 
+## Gather & forecast: one contract (CLI · GUI · MCP)
+
+Scoped runs share **`canswim.run_triggers`** (tickers + week-aligned start). Full detail: **[docs/run_triggers.md](docs/run_triggers.md)**.
+
+| Surface | Gather | Forecast | Preview start |
+|---------|--------|----------|---------------|
+| **CLI** | `gatherdata --tickers "…"` | `forecast --tickers "…" [--forecast_start_date] [--dry_run]` | `resolve_start [--forecast_start_date]` |
+| **GUI** | Dashboard → **Run** → Gather | **Run** → Forecast | **Preview start date** |
+| **MCP** | `gather_tickers` (`MCP_ALLOW_RUNS=1`) | `forecast_tickers` (`MCP_ALLOW_RUNS=1`) | `resolve_forecast_start` (always) |
+
+**Start-date policy (all three):** past dates → first NYSE session of that market week (holiday Monday → next open that week); empty/today → live origin after latest week-end close; no pure-future origins.
+
+```bash
+# examples
+python -m canswim resolve_start --forecast_start_date 2026-03-05
+python -m canswim forecast --tickers AAPL --forecast_start_date 2026-03-05 --dry_run
+python -m canswim forecast --tickers "AAPL,MSFT" --forecast_start_date 2026-03-05
+```
+
+Without `--tickers`, `gatherdata` / `forecast` keep legacy full-universe behavior.
+
 ## Command line interface
 
+```bash
+python -m canswim -h
 ```
-$  python -m canswim -h
-usage: canswim [-h] [--forecast_start_date FORECAST_START_DATE] [--new_model NEW_MODEL] [--same_data SAME_DATA] {dashboard,gatherdata,downloaddata,uploaddata,modelsearch,train,forecast}
 
-CANSWIM is a toolkit for CANSLIM style investors. Aims to complement the Simple Moving Average and other technical indicators.
+Main tasks: `dashboard`, `gatherdata`, `forecast`, `train`, `modelsearch`, `downloaddata`, `uploaddata`, `mcp`, `resolve_start`.
 
-positional arguments:
-  {dashboard,gatherdata,downloaddata,uploaddata,modelsearch,train,forecast}
-                        Which canswim task to run: `dashboard` for stock charting and scans of recorded forecasts. 'gatherdata` to gather 3rd party stock market data and save to HF Hub. 'downloaddata` download model training and forecast
-                        data from HF Hub to local data storage. 'uploaddata` upload to HF Hub any interim changes to local train and forecast data. `modelsearch` to find and save optimal hyperparameters for model training. `train` for
-                        continuous model training. `forecast` to run forecast on stocks and upload dataset to HF Hub.
+Useful flags:
 
-options:
-  -h, --help            show this help message and exit
-  --forecast_start_date FORECAST_START_DATE
-                        Optional argument for the `forecast` task. Indicate forecast start date in YYYY-MM-DD format. If not specified, forecast will start from the end of the target series.
-  --new_model NEW_MODEL
-                        Optional argument for the `train` task. Whether to train a newly created model or continue training an existing pre-trained model.
-  --same_data SAME_DATA
-                        Optional argument for the `dashboard` task. Whether to reuse previously created search database (faster start time) or update with new forecast data (slower start time).
-
-NOTE: NOT FINANCIAL OR INVESTMENT ADVICE. USE AT YOUR OWN RISK.
-```
+| Flag | Used by | Meaning |
+|------|---------|---------|
+| `--tickers` | `gatherdata`, `forecast` | Scoped run via shared orchestration |
+| `--forecast_start_date` | `forecast`, `resolve_start` | Origin date (week-aligned when using `--tickers` / resolve) |
+| `--dry_run` | `forecast --tickers` | Resolve start + validate only |
+| `--no_covariates` | `gatherdata --tickers` | Prices (+ broad market) only |
+| `--same_data` | `dashboard` | Reuse DuckDB search DB |
+| `--new_model` | `train` | Fresh model vs continue |
 
 ## MCP server (read-only by default)
 
 Expose precomputed TiDE forecasts and local market data to MCP clients (Claude Desktop, Cursor, etc.) over the **same DuckDB search database** used by the dashboard.
 
-By default the process stays **read-only** (no torch, no gather/forecast). Optional **write tools** are always listed but only execute when `MCP_ALLOW_RUNS=1` (or `CANSWIM_ALLOW_RUNS=1`).
+By default the process stays **read-only**. Write tools are listed for discoverability but only execute when `MCP_ALLOW_RUNS=1` (or `CANSWIM_ALLOW_RUNS=1`). CLI `--tickers` and the Dashboard **Run** tab do **not** use that flag.
 
 ### Prerequisites
 
@@ -97,19 +115,13 @@ python -m canswim dashboard --same_data True
 
 ```bash
 python -m canswim mcp
-# or
-canswim-mcp
-# or
-python -m canswim.mcp
+# or canswim-mcp / python -m canswim.mcp
+
+# enable gather/forecast tools
+MCP_ALLOW_RUNS=1 python -m canswim mcp
 ```
 
 Configure paths via `.env` (`data_dir`, `db_file`) — same as the dashboard.
-
-Enable gather/forecast triggers (local mutation + possible model load):
-
-```bash
-MCP_ALLOW_RUNS=1 python -m canswim mcp
-```
 
 ### Example client config (stdio)
 
@@ -142,12 +154,12 @@ MCP_ALLOW_RUNS=1 python -m canswim mcp
 | `get_close_price` | Historical closes |
 | `get_backtest_error` | Forecast vs actual error |
 | `run_select` | Single SELECT only (Advanced Queries) |
-| `resolve_forecast_start` | Preview week-aligned forecast start (read-only) |
-| `gather_tickers` | Gather data for ticker list (**requires `MCP_ALLOW_RUNS=1`**) |
-| `forecast_tickers` | Forecast ticker list, week-aligned start (**requires `MCP_ALLOW_RUNS=1`**) |
+| `resolve_forecast_start` | Preview week-aligned start (≡ CLI `resolve_start`) |
+| `gather_tickers` | Scoped gather (≡ `gatherdata --tickers`; needs `MCP_ALLOW_RUNS=1`) |
+| `forecast_tickers` | Scoped forecast (≡ `forecast --tickers`; needs `MCP_ALLOW_RUNS=1`) |
 
 ### Dashboard Run tab
 
-The Gradio **Run** tab uses the same orchestration as the MCP write tools (without the env gate): paste tickers, optional forecast start date (snapped to market week start), **Gather data** / **Run forecast**.
+Paste tickers → **Gather data** / **Run forecast** / **Preview start date**. Same `run_triggers` path as CLI `--tickers` and MCP write tools (see [docs/run_triggers.md](docs/run_triggers.md)).
 
 **NOT FINANCIAL OR INVESTMENT ADVICE. USE AT YOUR OWN RISK.**

--- a/docs/run_triggers.md
+++ b/docs/run_triggers.md
@@ -1,74 +1,61 @@
-# Gather & forecast triggers (CLI · GUI · MCP)
+# Get market data & run forecasts (CLI · GUI · MCP)
 
-One shared contract for **scoped** data gather and TiDE forecast runs.
-Implementation: `canswim.run_triggers` (+ `canswim.calendar_weeks` for dates).
+User-facing actions for a **short list of symbols**. Implementation: `canswim.run_triggers`,
+`canswim.gather_policy`, `canswim.calendar_weeks`.
 
 **NOT FINANCIAL OR INVESTMENT ADVICE. USE AT YOUR OWN RISK.**
 
-## Surfaces (aligned)
+## Two separate steps
 
-| Surface | How to invoke | Gate |
-|---------|----------------|------|
-| **CLI** | `python -m canswim gatherdata --tickers "AAPL,MSFT"` | Always (local CLI) |
-| **CLI** | `python -m canswim forecast --tickers "AAPL" [--forecast_start_date …] [--dry_run]` | Always |
-| **CLI** | `python -m canswim resolve_start [--forecast_start_date …]` | Always |
-| **GUI** | Dashboard → **Run** tab | Always (in-process UI) |
-| **MCP** | tools `gather_tickers`, `forecast_tickers` | **`MCP_ALLOW_RUNS=1`** (or `CANSWIM_ALLOW_RUNS=1`) |
-| **MCP** | tool `resolve_forecast_start` | Read-only; always available |
+| Step | What it does | CLI | GUI | MCP |
+|------|----------------|-----|-----|-----|
+| **Get market data** | Update local prices for listed symbols | `gatherdata --tickers "AAPL,MSFT"` | **Update market data** | `gather_tickers` |
+| **Run a forecast** | Forecast those symbols | `forecast --tickers "AAPL" …` | **Run forecast** | `forecast_tickers` |
+| **Check start date** | Show which start date will be used | `resolve_start` | **Check start date** | `resolve_forecast_start` |
 
-Without `--tickers`, CLI `gatherdata` / `forecast` keep **legacy full-universe** behavior
-(`stock_tickers_list` / all stocks; forecast default = next open after latest bar).
-That path is intentionally separate so weekend batch jobs stay stable.
+MCP write tools need `MCP_ALLOW_RUNS=1`. CLI and dashboard do not.
 
-## Shared parameters
+Without `--tickers`, CLI `gatherdata` / `forecast` keep **full-universe / train-style** behavior.
 
-### Tickers
-- Comma, semicolon, whitespace, and/or **newlines**
-- Uppercased; duplicates reported; invalid tokens rejected
-- Soft max **50** symbols per run (`DEFAULT_MAX_TICKERS`)
+## Get market data (lean & rate-limit aware)
 
-### Forecast start date (`YYYY-MM-DD` or empty)
+For scoped runs (`--tickers` / dashboard / MCP):
 
-| Input | Resolved start |
-|-------|----------------|
-| Empty / omitted | **Live default**: first NYSE session **after** the last completed week-end close (usually Monday after Friday), using local latest close when known |
-| Today (calendar) | Same as live default |
-| Past calendar day | First NYSE session of that **ISO market week** (usually Monday) |
-| Holiday Monday (e.g. Memorial Day) | First **open** session of that week (often Tuesday) — **not** prior week |
-| After allowed live origin | **Rejected** (no pure-future origins) |
+- Target about the **last 2 years** of prices (enough to forecast)—not multi-decade history.
+- **Skip remote download** when local history is already complete and recent.
+- If history is short or gappy, download only the **missing window**.
+- If history is complete but stale, download only a **short tail** refresh.
+- **Train** mode (`gatherdata` without `--tickers`) still uses full `train_date_start` history.
 
-Preview without running the model:
-- CLI: `python -m canswim resolve_start --forecast_start_date 2026-03-05`
-- GUI: **Preview start date**
-- MCP: `resolve_forecast_start`
+Forecasts never invent prices. If history is incomplete, **Run a forecast** fails and asks you to update market data first.
+
+## Start date rules (enforced in code)
+
+| You enter | System uses |
+|-----------|-------------|
+| Blank / today | Next market-week start after the latest completed trading week |
+| A past date | Start of that market week (first open session; if Monday is a holiday, next open day that week) |
+| A future date past the allowed default | Rejected |
+
+Operator detail only—primary UI uses plain language.
 
 ## Examples
 
 ```bash
-# Gather two symbols (local-first; same as Run tab / MCP gather_tickers)
+# Update market data for two symbols (missing-only, ~2y)
 hfhub_sync=False python -m canswim gatherdata --tickers "AAPL, MSFT"
 
-# Preview week-aligned start only
+# See start date
 python -m canswim resolve_start
 python -m canswim forecast --tickers AAPL --forecast_start_date 2026-03-05 --dry_run
 
-# Scoped forecast (week-aligned)
+# Forecast (fails if data incomplete)
 python -m canswim forecast --tickers "AAPL,MSFT" --forecast_start_date 2026-03-05
-
-# MCP write tools (default server is read-only)
-MCP_ALLOW_RUNS=1 python -m canswim mcp
 ```
-
-## Result shape
-
-Structured JSON (CLI prints it; GUI shows it; MCP wraps in `{ok, data|error}`):
-
-- **Gather:** `ok`, `tickers`, `rejected`, `messages`, optional `error`
-- **Forecast:** `ok`, `tickers`, `resolved_start`, `forecasted`, `skipped`, `messages`, optional `dry_run` / `error`
 
 ## Design rules
 
-1. **One orchestration** — do not reimplement parse/snap in GUI or MCP.
-2. **MCP stays safe by default** — write tools listed for discoverability, gated at invoke time.
-3. **Small lists** — keep runs short; full-universe stays on legacy CLI without `--tickers`.
-4. **Local-first** — `hfhub_sync` remains off unless explicitly enabled.
+1. One orchestration for CLI / GUI / MCP.
+2. Missing-only remote calls for forecast-scoped gather; train stays full-history.
+3. Fail closed on incomplete forecast data.
+4. Consumer copy in the product; policy detail in this doc.

--- a/docs/run_triggers.md
+++ b/docs/run_triggers.md
@@ -1,0 +1,74 @@
+# Gather & forecast triggers (CLI · GUI · MCP)
+
+One shared contract for **scoped** data gather and TiDE forecast runs.
+Implementation: `canswim.run_triggers` (+ `canswim.calendar_weeks` for dates).
+
+**NOT FINANCIAL OR INVESTMENT ADVICE. USE AT YOUR OWN RISK.**
+
+## Surfaces (aligned)
+
+| Surface | How to invoke | Gate |
+|---------|----------------|------|
+| **CLI** | `python -m canswim gatherdata --tickers "AAPL,MSFT"` | Always (local CLI) |
+| **CLI** | `python -m canswim forecast --tickers "AAPL" [--forecast_start_date …] [--dry_run]` | Always |
+| **CLI** | `python -m canswim resolve_start [--forecast_start_date …]` | Always |
+| **GUI** | Dashboard → **Run** tab | Always (in-process UI) |
+| **MCP** | tools `gather_tickers`, `forecast_tickers` | **`MCP_ALLOW_RUNS=1`** (or `CANSWIM_ALLOW_RUNS=1`) |
+| **MCP** | tool `resolve_forecast_start` | Read-only; always available |
+
+Without `--tickers`, CLI `gatherdata` / `forecast` keep **legacy full-universe** behavior
+(`stock_tickers_list` / all stocks; forecast default = next open after latest bar).
+That path is intentionally separate so weekend batch jobs stay stable.
+
+## Shared parameters
+
+### Tickers
+- Comma, semicolon, whitespace, and/or **newlines**
+- Uppercased; duplicates reported; invalid tokens rejected
+- Soft max **50** symbols per run (`DEFAULT_MAX_TICKERS`)
+
+### Forecast start date (`YYYY-MM-DD` or empty)
+
+| Input | Resolved start |
+|-------|----------------|
+| Empty / omitted | **Live default**: first NYSE session **after** the last completed week-end close (usually Monday after Friday), using local latest close when known |
+| Today (calendar) | Same as live default |
+| Past calendar day | First NYSE session of that **ISO market week** (usually Monday) |
+| Holiday Monday (e.g. Memorial Day) | First **open** session of that week (often Tuesday) — **not** prior week |
+| After allowed live origin | **Rejected** (no pure-future origins) |
+
+Preview without running the model:
+- CLI: `python -m canswim resolve_start --forecast_start_date 2026-03-05`
+- GUI: **Preview start date**
+- MCP: `resolve_forecast_start`
+
+## Examples
+
+```bash
+# Gather two symbols (local-first; same as Run tab / MCP gather_tickers)
+hfhub_sync=False python -m canswim gatherdata --tickers "AAPL, MSFT"
+
+# Preview week-aligned start only
+python -m canswim resolve_start
+python -m canswim forecast --tickers AAPL --forecast_start_date 2026-03-05 --dry_run
+
+# Scoped forecast (week-aligned)
+python -m canswim forecast --tickers "AAPL,MSFT" --forecast_start_date 2026-03-05
+
+# MCP write tools (default server is read-only)
+MCP_ALLOW_RUNS=1 python -m canswim mcp
+```
+
+## Result shape
+
+Structured JSON (CLI prints it; GUI shows it; MCP wraps in `{ok, data|error}`):
+
+- **Gather:** `ok`, `tickers`, `rejected`, `messages`, optional `error`
+- **Forecast:** `ok`, `tickers`, `resolved_start`, `forecasted`, `skipped`, `messages`, optional `dry_run` / `error`
+
+## Design rules
+
+1. **One orchestration** — do not reimplement parse/snap in GUI or MCP.
+2. **MCP stays safe by default** — write tools listed for discoverability, gated at invoke time.
+3. **Small lists** — keep runs short; full-universe stays on legacy CLI without `--tickers`.
+4. **Local-first** — `hfhub_sync` remains off unless explicitly enabled.

--- a/src/canswim/__main__.py
+++ b/src/canswim/__main__.py
@@ -31,7 +31,6 @@ import argparse
 from canswim.run_triggers import (
     FORECAST_START_HELP,
     TICKERS_HELP,
-    DATE_POLICY_SUMMARY,
     RUNS_OPT_IN_HELP,
 )
 
@@ -43,7 +42,9 @@ parser = argparse.ArgumentParser(
         """,
     epilog=(
         "NOTE: NOT FINANCIAL OR INVESTMENT ADVICE. USE AT YOUR OWN RISK.\n"
-        f"{DATE_POLICY_SUMMARY}\n"
+        "Get market data: gatherdata --tickers …\n"
+        "Run a forecast: forecast --tickers … [--forecast_start_date] [--dry_run]\n"
+        "See docs/run_triggers.md for start-date rules and operator detail.\n"
         f"{RUNS_OPT_IN_HELP}"
     ),
     formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -53,15 +54,15 @@ parser.add_argument(
     "task",
     type=str,
     help="""Which %(prog)s task to run:
-        `dashboard` — charts, scans, and Run tab (gather/forecast for ticker lists).
-        `gatherdata` — full-universe gather, or scoped with --tickers (same as GUI/MCP).
+        `dashboard` — charts, scans, get market data, run forecasts.
+        `gatherdata` — get market data (all symbols, or --tickers for a short list).
         `downloaddata` — download model training and forecast data from HF Hub.
         `uploaddata` — upload local train/forecast data to HF Hub.
         `modelsearch` — find and save optimal hyperparameters.
-        `train` — continuous model training.
-        `forecast` — full-universe forecast, or scoped with --tickers (week-aligned start).
+        `train` — continuous model training (full history).
+        `forecast` — run forecasts (all symbols, or --tickers for a short list).
         `mcp` — MCP server (read-only by default; write tools need MCP_ALLOW_RUNS=1).
-        `resolve_start` — print week-aligned forecast start (no model/IO beyond local close).
+        `resolve_start` — show which forecast start date would be used.
         """,
     choices=[
         "dashboard",
@@ -82,9 +83,8 @@ parser.add_argument(
     required=False,
     default=None,
     help=(
-        f"Scope `gatherdata` / `forecast` to an explicit list. {TICKERS_HELP} "
-        "Uses the same orchestration as the Dashboard Run tab and MCP "
-        "gather_tickers / forecast_tickers tools."
+        f"Limit get-market-data / forecast to these symbols. {TICKERS_HELP} "
+        "Matches the dashboard and MCP tools."
     ),
 )
 
@@ -93,10 +93,7 @@ parser.add_argument(
     type=str,
     required=False,
     help=(
-        f"For `forecast` (with or without --tickers) and `resolve_start`. "
-        f"{FORECAST_START_HELP} "
-        "Without --tickers, legacy full-universe forecast still accepts this date "
-        "but does not force week-align (use --tickers or resolve_start for the shared policy)."
+        f"For `forecast` and `resolve_start`. {FORECAST_START_HELP}"
     ),
 )
 
@@ -105,8 +102,7 @@ parser.add_argument(
     action="store_true",
     default=False,
     help=(
-        "With `forecast --tickers`: validate tickers and resolve week-aligned start only "
-        "(no model load). Same as MCP forecast_tickers dry_run=true."
+        "With `forecast --tickers`: only check symbols and start date (no model run)."
     ),
 )
 
@@ -114,7 +110,7 @@ parser.add_argument(
     "--no_covariates",
     action="store_true",
     default=False,
-    help="With `gatherdata --tickers`: skip per-ticker covariates (earnings, metrics, …).",
+    help="With `gatherdata --tickers`: prices only (skip earnings, dividends, etc.).",
 )
 
 parser.add_argument(

--- a/src/canswim/__main__.py
+++ b/src/canswim/__main__.py
@@ -28,27 +28,40 @@ from loguru import logger
 import os
 import argparse
 
+from canswim.run_triggers import (
+    FORECAST_START_HELP,
+    TICKERS_HELP,
+    DATE_POLICY_SUMMARY,
+    RUNS_OPT_IN_HELP,
+)
+
 # Instantiate the parser
 parser = argparse.ArgumentParser(
     prog="canswim",
     description="""CANSWIM is a toolkit for CANSLIM style investors.
         Aims to complement the Simple Moving Average and other technical indicators.
         """,
-    epilog="NOTE: NOT FINANCIAL OR INVESTMENT ADVICE. USE AT YOUR OWN RISK.",
+    epilog=(
+        "NOTE: NOT FINANCIAL OR INVESTMENT ADVICE. USE AT YOUR OWN RISK.\n"
+        f"{DATE_POLICY_SUMMARY}\n"
+        f"{RUNS_OPT_IN_HELP}"
+    ),
+    formatter_class=argparse.RawDescriptionHelpFormatter,
 )
 
 parser.add_argument(
     "task",
     type=str,
     help="""Which %(prog)s task to run:
-        `dashboard` for stock charting and scans of recorded forecasts.
-        'gatherdata` to gather 3rd party stock market data and save to HF Hub.
-        'downloaddata` download model training and forecast data from HF Hub to local data storage.
-        'uploaddata` upload to HF Hub any interim changes to local train and forecast data.
-        `modelsearch` to find and save optimal hyperparameters for model training.
-        `train` for continuous model training.
-        `forecast` to run forecast on stocks and upload dataset to HF Hub.
-        `mcp` start the read-only MCP server (stdio) over the local DuckDB search database.
+        `dashboard` — charts, scans, and Run tab (gather/forecast for ticker lists).
+        `gatherdata` — full-universe gather, or scoped with --tickers (same as GUI/MCP).
+        `downloaddata` — download model training and forecast data from HF Hub.
+        `uploaddata` — upload local train/forecast data to HF Hub.
+        `modelsearch` — find and save optimal hyperparameters.
+        `train` — continuous model training.
+        `forecast` — full-universe forecast, or scoped with --tickers (week-aligned start).
+        `mcp` — MCP server (read-only by default; write tools need MCP_ALLOW_RUNS=1).
+        `resolve_start` — print week-aligned forecast start (no model/IO beyond local close).
         """,
     choices=[
         "dashboard",
@@ -59,14 +72,49 @@ parser.add_argument(
         "train",
         "forecast",
         "mcp",
+        "resolve_start",
     ],
+)
+
+parser.add_argument(
+    "--tickers",
+    type=str,
+    required=False,
+    default=None,
+    help=(
+        f"Scope `gatherdata` / `forecast` to an explicit list. {TICKERS_HELP} "
+        "Uses the same orchestration as the Dashboard Run tab and MCP "
+        "gather_tickers / forecast_tickers tools."
+    ),
 )
 
 parser.add_argument(
     "--forecast_start_date",
     type=str,
     required=False,
-    help="""Optional argument for the `forecast` task. Indicate forecast start date in YYYY-MM-DD format. If not specified, forecast will start from the end of the target series.""",
+    help=(
+        f"For `forecast` (with or without --tickers) and `resolve_start`. "
+        f"{FORECAST_START_HELP} "
+        "Without --tickers, legacy full-universe forecast still accepts this date "
+        "but does not force week-align (use --tickers or resolve_start for the shared policy)."
+    ),
+)
+
+parser.add_argument(
+    "--dry_run",
+    action="store_true",
+    default=False,
+    help=(
+        "With `forecast --tickers`: validate tickers and resolve week-aligned start only "
+        "(no model load). Same as MCP forecast_tickers dry_run=true."
+    ),
+)
+
+parser.add_argument(
+    "--no_covariates",
+    action="store_true",
+    default=False,
+    help="With `gatherdata --tickers`: skip per-ticker covariates (earnings, metrics, …).",
 )
 
 parser.add_argument(
@@ -130,6 +178,15 @@ match args.task:
 
         model_search.main()
     case "gatherdata":
+        if args.tickers:
+            from canswim.cli_run import run_gather_tickers
+
+            sys.exit(
+                run_gather_tickers(
+                    args.tickers,
+                    include_covariates=not args.no_covariates,
+                )
+            )
         from canswim import gather_data
 
         gather_data.main()
@@ -146,9 +203,26 @@ match args.task:
 
         train.main(new_model=args.new_model)
     case "forecast":
+        if args.tickers:
+            from canswim.cli_run import run_forecast_tickers
+
+            sys.exit(
+                run_forecast_tickers(
+                    args.tickers,
+                    forecast_start_date=args.forecast_start_date,
+                    dry_run=args.dry_run,
+                )
+            )
+        if args.dry_run:
+            logger.error("--dry_run requires --tickers (scoped forecast path)")
+            sys.exit(2)
         from canswim import forecast
 
         forecast.main(forecast_start_date=args.forecast_start_date)
+    case "resolve_start":
+        from canswim.cli_run import run_resolve_start
+
+        sys.exit(run_resolve_start(args.forecast_start_date))
     case "mcp":
         from canswim.mcp.server import main as mcp_main
 

--- a/src/canswim/calendar_weeks.py
+++ b/src/canswim/calendar_weeks.py
@@ -80,17 +80,16 @@ def last_session_of_iso_week(d: DateLike) -> pd.Timestamp:
 
 
 def snap_to_week_start_on_or_before(pick: DateLike) -> pd.Timestamp:
-    """Nearest market-week start on or before ``pick``."""
-    day = _ts(pick)
-    ws = first_session_of_iso_week(day)
-    if day < ws:
-        # Weekend before Monday session → previous week's start
-        prev = day - pd.Timedelta(days=7)
-        return first_session_of_iso_week(prev)
-    # If pick is mid-week, week start of that week is on or before pick
-    if ws <= day:
-        return ws
-    return first_session_of_iso_week(day - pd.Timedelta(days=7))
+    """Market-week start for the ISO week containing ``pick``.
+
+    Week start = first NYSE session of that ISO week (usually Monday). When
+    Monday is a holiday, the week start is the next open session (often
+    Tuesday) — holiday Mondays must **not** fall back to the prior week.
+
+    Mid-week picks (Tue–Fri) snap to that same first session, which is on or
+    before the pick whenever Monday was open.
+    """
+    return first_session_of_iso_week(pick)
 
 
 def last_completed_week_end(

--- a/src/canswim/calendar_weeks.py
+++ b/src/canswim/calendar_weeks.py
@@ -1,0 +1,245 @@
+"""NYSE market-week helpers for forecast start date policy.
+
+Rules (normative for user-triggered runs):
+- Week start = first NYSE session of the ISO week.
+- Backtest picks snap to the week start **on or before** the selected date.
+- Empty / today / default → live origin: first session of the week **after**
+  the most recent completed end-of-week close (typically Monday after Friday),
+  using ``latest_close`` when available else calendar ``asof``.
+- Origins after the live default are rejected (no pure-future starts).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime
+from typing import Optional, Union
+
+import pandas as pd
+import pandas_market_calendars as mcal
+from pandas.tseries.offsets import BDay
+
+DateLike = Union[str, date, datetime, pd.Timestamp]
+
+
+def _ts(d: DateLike) -> pd.Timestamp:
+    return pd.Timestamp(d).tz_localize(None).normalize()
+
+
+def _nyse():
+    return mcal.get_calendar("NYSE")
+
+
+def nyse_sessions(
+    start: DateLike,
+    end: DateLike,
+) -> pd.DatetimeIndex:
+    """NYSE valid sessions in [start, end], tz-naive midnight."""
+    s, e = _ts(start), _ts(end)
+    if e < s:
+        return pd.DatetimeIndex([])
+    days = _nyse().valid_days(start_date=s, end_date=e, tz=None)
+    if days is None or len(days) == 0:
+        return pd.DatetimeIndex([])
+    return pd.DatetimeIndex(pd.to_datetime(days)).tz_localize(None).normalize()
+
+
+def first_session_of_iso_week(d: DateLike) -> pd.Timestamp:
+    """First NYSE session in the ISO week containing ``d``."""
+    day = _ts(d)
+    # Monday = 0 … Sunday = 6
+    week_monday = day - pd.Timedelta(days=int(day.weekday()))
+    week_friday = week_monday + pd.Timedelta(days=4)
+    sessions = nyse_sessions(week_monday, week_friday + pd.Timedelta(days=2))
+    if len(sessions) == 0:
+        # Holiday-only stub week — search forward a few days
+        sessions = nyse_sessions(week_monday, week_monday + pd.Timedelta(days=10))
+    if len(sessions) == 0:
+        raise ValueError(f"No NYSE session found near ISO week of {day.date()}")
+    # First session that still belongs to this ISO week
+    iso = day.isocalendar()[:2]  # (year, week)
+    for s in sessions:
+        if s.isocalendar()[:2] == iso:
+            return pd.Timestamp(s).normalize()
+    return pd.Timestamp(sessions[0]).normalize()
+
+
+def last_session_of_iso_week(d: DateLike) -> pd.Timestamp:
+    """Last NYSE session in the ISO week containing ``d``."""
+    day = _ts(d)
+    week_monday = day - pd.Timedelta(days=int(day.weekday()))
+    week_end = week_monday + pd.Timedelta(days=6)
+    sessions = nyse_sessions(week_monday, week_end)
+    if len(sessions) == 0:
+        raise ValueError(f"No NYSE session found in ISO week of {day.date()}")
+    iso = day.isocalendar()[:2]
+    in_week = [pd.Timestamp(s).normalize() for s in sessions if s.isocalendar()[:2] == iso]
+    if not in_week:
+        return pd.Timestamp(sessions[-1]).normalize()
+    return in_week[-1]
+
+
+def snap_to_week_start_on_or_before(pick: DateLike) -> pd.Timestamp:
+    """Nearest market-week start on or before ``pick``."""
+    day = _ts(pick)
+    ws = first_session_of_iso_week(day)
+    if day < ws:
+        # Weekend before Monday session → previous week's start
+        prev = day - pd.Timedelta(days=7)
+        return first_session_of_iso_week(prev)
+    # If pick is mid-week, week start of that week is on or before pick
+    if ws <= day:
+        return ws
+    return first_session_of_iso_week(day - pd.Timedelta(days=7))
+
+
+def last_completed_week_end(
+    *,
+    asof: Optional[DateLike] = None,
+    latest_close: Optional[DateLike] = None,
+) -> pd.Timestamp:
+    """Most recent end-of-week market close on or before the reference date.
+
+    Reference = ``latest_close`` when set, else ``asof``, else today.
+    A week is completed when its last session is on or before the reference.
+    """
+    ref = _ts(latest_close if latest_close is not None else (asof if asof is not None else pd.Timestamp.now()))
+    # Walk back: last session of the ISO week of ref, if that EOW <= ref; else previous week
+    eow = last_session_of_iso_week(ref)
+    if eow <= ref:
+        return eow
+    return last_session_of_iso_week(ref - pd.Timedelta(days=7))
+
+
+def default_live_forecast_start(
+    *,
+    asof: Optional[DateLike] = None,
+    latest_close: Optional[DateLike] = None,
+) -> pd.Timestamp:
+    """Live origin: first NYSE session strictly after the last completed week-end close.
+
+    Typically Monday after the latest Friday close. Using "next session after EOW"
+    (not ISO-week of Saturday) avoids snapping back into the completed week.
+    """
+    eow = last_completed_week_end(asof=asof, latest_close=latest_close)
+    sessions = nyse_sessions(eow + pd.Timedelta(days=1), eow + pd.Timedelta(days=14))
+    if len(sessions) == 0:
+        raise ValueError(f"No NYSE session found after week-end close {eow.date()}")
+    return pd.Timestamp(sessions[0]).normalize()
+
+
+@dataclass(frozen=True)
+class ResolvedForecastStart:
+    """Result of resolving a user-facing forecast start request."""
+
+    ok: bool
+    start: Optional[str]  # ISO YYYY-MM-DD when ok
+    reason: str
+    live_default: str
+    input: Optional[str] = None
+    error: Optional[str] = None
+
+    def as_dict(self) -> dict:
+        return {
+            "ok": self.ok,
+            "start": self.start,
+            "reason": self.reason,
+            "live_default": self.live_default,
+            "input": self.input,
+            "error": self.error,
+        }
+
+
+def resolve_forecast_start(
+    user_date: Optional[DateLike] = None,
+    *,
+    asof: Optional[DateLike] = None,
+    latest_close: Optional[DateLike] = None,
+) -> ResolvedForecastStart:
+    """Resolve user date / default to a week-aligned forecast origin.
+
+    Parameters
+    ----------
+    user_date:
+        Calendar pick or ISO string. ``None`` / empty → live default.
+    asof:
+        "Today" for policy (defaults to wall clock). Used for future checks.
+    latest_close:
+        Latest available ground-truth close (DB/parquet) when known.
+    """
+    today = _ts(asof if asof is not None else pd.Timestamp.now())
+    # Data-aware live origin (empty/today default)
+    live = default_live_forecast_start(asof=today, latest_close=latest_close)
+    # Calendar cap so a stale latest_close cannot block legitimate backtests
+    # still on/before the calendar live origin
+    calendar_live = default_live_forecast_start(asof=today, latest_close=None)
+    cap = live if live >= calendar_live else calendar_live
+    live_iso = live.strftime("%Y-%m-%d")
+    cap_iso = cap.strftime("%Y-%m-%d")
+
+    raw = user_date
+    if raw is None or (isinstance(raw, str) and not str(raw).strip()):
+        return ResolvedForecastStart(
+            ok=True,
+            start=live_iso,
+            reason="default_live",
+            live_default=live_iso,
+            input=None,
+        )
+
+    try:
+        pick = _ts(raw)
+    except Exception as e:
+        return ResolvedForecastStart(
+            ok=False,
+            start=None,
+            reason="invalid_date",
+            live_default=live_iso,
+            input=str(raw),
+            error=f"Invalid date: {e}",
+        )
+
+    pick_iso = pick.strftime("%Y-%m-%d")
+
+    # Today or any calendar day on/after "today" → live default (not pure future)
+    if pick >= today:
+        if pick > cap and pick > today:
+            return ResolvedForecastStart(
+                ok=False,
+                start=None,
+                reason="future_rejected",
+                live_default=live_iso,
+                input=pick_iso,
+                error=(
+                    f"Forecast start {pick_iso} is in the future; "
+                    f"latest allowed origin is {cap_iso}."
+                ),
+            )
+        return ResolvedForecastStart(
+            ok=True,
+            start=live_iso,
+            reason="today_or_default",
+            live_default=live_iso,
+            input=pick_iso,
+        )
+
+    snapped = snap_to_week_start_on_or_before(pick)
+    snapped_iso = snapped.strftime("%Y-%m-%d")
+    if snapped > cap:
+        return ResolvedForecastStart(
+            ok=False,
+            start=None,
+            reason="future_rejected",
+            live_default=live_iso,
+            input=pick_iso,
+            error=(
+                f"Snapped start {snapped_iso} is after latest allowed origin {cap_iso}."
+            ),
+        )
+    return ResolvedForecastStart(
+        ok=True,
+        start=snapped_iso,
+        reason="snapped_week_start",
+        live_default=live_iso,
+        input=pick_iso,
+    )

--- a/src/canswim/cli_run.py
+++ b/src/canswim/cli_run.py
@@ -1,0 +1,63 @@
+"""CLI helpers that route scoped gather/forecast through run_triggers.
+
+Keeps ``__main__`` thin and ensures CLI shares the same orchestration as GUI/MCP.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any, Optional
+
+from loguru import logger
+
+from canswim.run_triggers import (
+    forecast_for_tickers,
+    gather_for_tickers,
+    resolve_start_for_run,
+)
+
+
+def _print_result(payload: dict[str, Any]) -> int:
+    """Print JSON result; return process exit code (0 ok, 1 error)."""
+    print(json.dumps(payload, indent=2, default=str))
+    return 0 if payload.get("ok") else 1
+
+
+def run_gather_tickers(
+    tickers: str,
+    *,
+    include_covariates: bool = True,
+) -> int:
+    logger.info(f"CLI scoped gather (run_triggers): {tickers!r}")
+    result = gather_for_tickers(
+        tickers,
+        include_covariates=include_covariates,
+        force_allow=True,
+    )
+    return _print_result(result)
+
+
+def run_forecast_tickers(
+    tickers: str,
+    forecast_start_date: Optional[str] = None,
+    *,
+    dry_run: bool = False,
+) -> int:
+    logger.info(
+        f"CLI scoped forecast (run_triggers): tickers={tickers!r} "
+        f"start={forecast_start_date!r} dry_run={dry_run}"
+    )
+    result = forecast_for_tickers(
+        tickers,
+        forecast_start_date=forecast_start_date or None,
+        dry_run=dry_run,
+        force_allow=True,
+    )
+    return _print_result(result)
+
+
+def run_resolve_start(forecast_start_date: Optional[str] = None) -> int:
+    """Preview week-aligned start (no gather/forecast)."""
+    info = resolve_start_for_run(forecast_start_date or None)
+    return _print_result(info)

--- a/src/canswim/covariates.py
+++ b/src/canswim/covariates.py
@@ -146,26 +146,90 @@ class Covariates:
 
         return t_earn_series
 
+    # Feature columns used by institutional ownership past-covariates (FMP schema).
+    # Used to zero-fill when a ticker has no ownership rows so model input dim stays fixed.
+    INST_OWNERSHIP_COLS = (
+        "cik",
+        "investorsHolding",
+        "lastInvestorsHolding",
+        "investorsHoldingChange",
+        "numberOf13Fshares",
+        "lastNumberOf13Fshares",
+        "numberOf13FsharesChange",
+        "totalInvested",
+        "lastTotalInvested",
+        "totalInvestedChange",
+        "ownershipPercent",
+        "lastOwnershipPercent",
+        "ownershipPercentChange",
+        "newPositions",
+        "lastNewPositions",
+        "newPositionsChange",
+        "increasedPositions",
+        "lastIncreasedPositions",
+        "increasedPositionsChange",
+        "closedPositions",
+        "lastClosedPositions",
+        "closedPositionsChange",
+        "reducedPositions",
+        "lastReducedPositions",
+        "reducedPositionsChange",
+        "totalCalls",
+        "lastTotalCalls",
+        "totalCallsChange",
+        "totalPuts",
+        "lastTotalPuts",
+        "totalPutsChange",
+        "putCallRatio",
+        "lastPutCallRatio",
+        "putCallRatioChange",
+    )
+
+    def _zero_ownership_series(self, prices: TimeSeries) -> TimeSeries:
+        """Zero-filled institutional ownership aligned to a price series calendar."""
+        from canswim.eligibility import timeseries_from_observed_df
+
+        idx = pd.DatetimeIndex(pd.to_datetime(prices.time_index)).normalize()
+        cols = list(self.INST_OWNERSHIP_COLS)
+        # Prefer live schema from loaded parquet when available
+        df_src = getattr(self, "inst_symbol_ownership_df", None)
+        if df_src is not None and len(df_src.columns) > 0:
+            cols = [c for c in df_src.columns if c in self.INST_OWNERSHIP_COLS] or cols
+            # Keep any extra columns present in training data file
+            for c in df_src.columns:
+                if c not in cols:
+                    cols.append(c)
+        df = pd.DataFrame(0.0, index=idx, columns=cols)
+        return timeseries_from_observed_df(df)
+
     def prepare_institutional_symbol_ownership_series(self, stock_price_series=None):
         logger.info(f"preparing past covariates: institutional ownership of symbol")
         inst_ownership_df = self.inst_symbol_ownership_df.copy()
         # cleanup data with known dirty columns
-        inst_ownership_df["cik"] = (
-            pd.to_numeric(inst_ownership_df["cik"], errors="coerce")
-            .fillna(0)
-            .astype(pd.Int64Dtype())
-        )
-        inst_ownership_df["totalCallsChange"] = (
-            pd.to_numeric(inst_ownership_df["totalCallsChange"], errors="coerce")
-            .fillna(0)
-            .astype(pd.Float64Dtype())
-        )
-        inst_ownership_df["totalPutsChange"] = (
-            pd.to_numeric(inst_ownership_df["totalPutsChange"], errors="coerce")
-            .fillna(0)
-            .astype(pd.Float64Dtype())
-        )
-        # convert earnings dataframe to series
+        if not inst_ownership_df.empty:
+            if "cik" in inst_ownership_df.columns:
+                inst_ownership_df["cik"] = (
+                    pd.to_numeric(inst_ownership_df["cik"], errors="coerce")
+                    .fillna(0)
+                    .astype(pd.Int64Dtype())
+                )
+            if "totalCallsChange" in inst_ownership_df.columns:
+                inst_ownership_df["totalCallsChange"] = (
+                    pd.to_numeric(
+                        inst_ownership_df["totalCallsChange"], errors="coerce"
+                    )
+                    .fillna(0)
+                    .astype(pd.Float64Dtype())
+                )
+            if "totalPutsChange" in inst_ownership_df.columns:
+                inst_ownership_df["totalPutsChange"] = (
+                    pd.to_numeric(
+                        inst_ownership_df["totalPutsChange"], errors="coerce"
+                    )
+                    .fillna(0)
+                    .astype(pd.Float64Dtype())
+                )
+        # convert ownership dataframe to series (zero-fill missing tickers)
         t_inst_ownership_series = {}
         for t, prices in stock_price_series.items():
             try:
@@ -173,30 +237,10 @@ class Covariates:
                 t_iown = inst_ownership_df.loc[[t]]
                 t_iown = t_iown.droplevel("Symbol")
                 t_iown.index = pd.to_datetime(t_iown.index)
-                # logger.info(f"t_iown index: {t_iown.index}")
-                # logger.info(f"t_iown index to biz days")
-                # assert not t_iown.index.duplicated().any(), "date index has duplicates"
-                # logger.info(f"t_iown no index duplicates")
-                # assert not t_iown.index.isnull().any(), "date index has missing values"
-                # logger.info(f"t_iown no index NaNs")
                 t_iown = self.df_index_to_biz_days(t_iown)
-                # logger.info(f"t_iown index to biz days")
-                # t_iown = (
-                #     t_iown.reset_index()
-                #     .drop_duplicates(subset="Date", keep="last")
-                #     .set_index("Date")
-                # )
                 t_iown = t_iown[~t_iown.index.duplicated(keep="last")]
                 assert t_iown.index.is_unique, "date index has duplicates"
-                # logger.info(f"t_iown no index duplicates")
                 assert not t_iown.index.isnull().any(), "date index has missing values"
-                # logger.info(f"t_iown no index NaNs")
-                # logger.info(f't_earn freq: {t_earn.index}')
-                # save cik as a static covariate
-                ##cik = t_iown["cik"].iloc[0].astype(pd.Int64Dtype)
-                ##t_iown = t_iown.drop(columns=["cik"])
-                ##static_covs_single = pd.DataFrame(data={"cik": [cik]})
-                # logger.info(f"Company with ticker {t} has cik: {cik}")
                 ts_tmp = TimeSeries.from_dataframe(
                     t_iown, freq="B", fill_missing_dates=True
                 )
@@ -212,30 +256,80 @@ class Covariates:
                 ), f"found gaps in series: \n{ts_padded.gaps()}"
                 t_inst_ownership_series[t] = ts_padded
             except KeyError as e:
+                # Do not drop the symbol: model was trained with ownership columns.
                 logger.info(
-                    f"""Skipping {t} from covariates series. 
-                        No institutional ownership data available for {t}, error: {type(e)}, {e}"""
+                    f"No institutional ownership rows for {t} ({e}); zero-filling "
+                    f"{len(self.INST_OWNERSHIP_COLS)} ownership columns"
                 )
+                t_inst_ownership_series[t] = self._zero_ownership_series(prices)
             except AssertionError as e:
-                logger.warning(f"Skipping {t} due to error: {type(e)}: {e}")
+                logger.warning(
+                    f"Ownership series invalid for {t} ({type(e)}: {e}); zero-filling"
+                )
+                t_inst_ownership_series[t] = self._zero_ownership_series(prices)
 
         return t_inst_ownership_series
 
-    def stack_covariates(self, old_covs=None, new_covs=None, min_samples=1):
+    def stack_covariates(
+        self, old_covs=None, new_covs=None, min_samples=1, column_template=None
+    ):
+        """Stack new_covs onto old_covs per ticker.
+
+        When a ticker is missing from new_covs, zero-fill using a template series
+        from another ticker (or ``column_template``) so feature dimensionality
+        stays consistent with training.
+        """
         logger.info(f"stacking covariates.")
-        # stack sales and earnigns to past covariates
+        old_covs = old_covs or {}
+        new_covs = new_covs or {}
+        # Nothing new to stack — keep existing (do not wipe symbols)
+        if not new_covs:
+            if column_template is not None and old_covs:
+                logger.warning(
+                    "No new covariates for this stack step; zero-filling "
+                    f"{len(column_template.components)} template columns"
+                )
+                stacked = {}
+                for t, covs in old_covs.items():
+                    try:
+                        new_ts = self._zero_cov_like(column_template, covs)
+                        old_sliced, new_sliced = self._align_series_on_common_index(
+                            covs, new_ts
+                        )
+                        stacked[t] = old_sliced.stack(new_sliced)
+                    except (ValueError, AssertionError) as e:
+                        logger.warning(
+                            f"Skipping {t} while zero-fill stacking: {type(e)}: {e}"
+                        )
+                return stacked if stacked else old_covs
+            logger.warning(
+                "No new covariates for this stack step; keeping prior covariates"
+            )
+            return old_covs
+        # stack sales and earnings to past covariates
         stacked_covs = {}
+        template = next(iter(new_covs.values()))
         for t, covs in list(old_covs.items()):
             try:
+                if t not in new_covs:
+                    # Missing optional cov for this ticker: zero-fill columns so
+                    # feature dim stays consistent and we do not drop the symbol.
+                    logger.info(
+                        f"No new covariates for {t}; zero-filling "
+                        f"{len(template.components)} columns"
+                    )
+                    new_ts = self._zero_cov_like(template, covs)
+                else:
+                    new_ts = new_covs[t]
                 assert (
-                    type(new_covs[t]) == TimeSeries
-                ), f"type of {t} is not TimeSeries, but {type(new_covs[t])}"
+                    type(new_ts) == TimeSeries
+                ), f"type of {t} is not TimeSeries, but {type(new_ts)}"
                 # Align on shared timestamps with a common observed-bar freq.
                 # Price series use CustomBusinessDay (no invented holiday bars);
                 # sparse covs still use "B". slice_intersect alone fails when
                 # freqs disagree (pandas freq validation → ValueError).
                 old_sliced, new_sliced = self._align_series_on_common_index(
-                    covs, new_covs[t]
+                    covs, new_ts
                 )
                 stacked = old_sliced.stack(new_sliced)
                 if len(stacked) >= min_samples:
@@ -249,8 +343,18 @@ class Covariates:
             except (ValueError, AssertionError) as e:
                 logger.warning(f"Skipping {t} while stacking covariates: {type(e)}: {e}")
         if len(stacked_covs.keys()) > 0:
-            logger.info(f"stacked covariates column count: {len(stacked.columns)}")
+            sample = next(iter(stacked_covs.values()))
+            logger.info(f"stacked covariates column count: {len(sample.components)}")
         return stacked_covs
+
+    def _zero_cov_like(self, template: TimeSeries, like: TimeSeries) -> TimeSeries:
+        """Zero-filled series with template columns, aligned to like's time index."""
+        from canswim.eligibility import timeseries_from_observed_df
+
+        idx = pd.DatetimeIndex(pd.to_datetime(like.time_index)).normalize()
+        cols = list(template.components)
+        df = pd.DataFrame(0.0, index=idx, columns=cols)
+        return timeseries_from_observed_df(df)
 
     @staticmethod
     def _align_series_on_common_index(a: TimeSeries, b: TimeSeries):
@@ -961,25 +1065,26 @@ class Covariates:
         pred_horizon: int = None,
     ):
         logger.info("Preparing future covariates")
-        # add analyst estimates
+        # Seed with dividends (always has a per-ticker series, zero if no divs)
+        # so missing analyst estimates never empty the entire future-cov dict.
+        future_covariates = (
+            self.prepare_dividends(stock_price_series=stock_price_series) or {}
+        )
         quarter_est_series, annual_est_series = self.prepare_analyst_estimates(
             stock_price_series=stock_price_series
         )
-        ## Stack analyst estimates to future covariates
-        future_covariates = self.stack_covariates(
-            old_covs=quarter_est_series,
-            new_covs=annual_est_series,
-            min_samples=min_samples,
-        )
-        # add stock dividends covariates
-        # for some stocks there will be dividends declared prior to the forecast date
-        # with known payment dates scheduled into the future
-        dividend_series = self.prepare_dividends(stock_price_series=stock_price_series)
-        future_covariates = self.stack_covariates(
-            old_covs=future_covariates,
-            new_covs=dividend_series,
-            min_samples=min_samples,
-        )
+        if quarter_est_series:
+            future_covariates = self.stack_covariates(
+                old_covs=future_covariates,
+                new_covs=quarter_est_series,
+                min_samples=min_samples,
+            )
+        if annual_est_series:
+            future_covariates = self.stack_covariates(
+                old_covs=future_covariates,
+                new_covs=annual_est_series,
+                min_samples=min_samples,
+            )
         # extend covars into forecast horizon future dates
         future_covariates = self.__extend_series(
             n=pred_horizon, series=future_covariates, target=stock_price_series

--- a/src/canswim/dashboard/__init__.py
+++ b/src/canswim/dashboard/__init__.py
@@ -82,6 +82,7 @@ class CanswimPlayground:
                 RunTab(
                     self.canswim_model,
                     db_path=self.db_path,
+                    charts_ticker_dropdown=charts_tab.tickerDropdown,
                 )
             with gr.Tab("Advanced Queries"):
                 AdvancedTab(

--- a/src/canswim/dashboard/__init__.py
+++ b/src/canswim/dashboard/__init__.py
@@ -7,6 +7,7 @@ from loguru import logger
 from canswim.dashboard.charts import ChartTab
 from canswim.dashboard.scans import ScanTab
 from canswim.dashboard.advanced import AdvancedTab
+from canswim.dashboard.run_tab import RunTab
 from canswim.db import DataPaths, init_search_db
 
 # Note: It appears that gradio Plot ignores the backend plot lib setting
@@ -74,6 +75,11 @@ class CanswimPlayground:
                 )
             with gr.Tab("Scans"):
                 scans_tab = ScanTab(
+                    self.canswim_model,
+                    db_path=self.db_path,
+                )
+            with gr.Tab("Run"):
+                RunTab(
                     self.canswim_model,
                     db_path=self.db_path,
                 )

--- a/src/canswim/dashboard/charts.py
+++ b/src/canswim/dashboard/charts.py
@@ -258,29 +258,63 @@ class ChartTab:
         return ax
 
     def plot_forecast(self, ticker: str = None, lowq: int = 0.2):
-        load_start_date = pd.Timestamp.now() - BDay(
-            n=self.canswim_model.min_samples + self.canswim_model.train_history
+        # Chart / forecast display only needs forecast-horizon history, not full train min_samples
+        # (train min_samples ≈ lookback*2 + horizons; scoped gather keeps ~2y of prices).
+        th = int(self.canswim_model.train_history)
+        ph = int(self.canswim_model.pred_horizon)
+        chart_min_samples = th + ph + ph  # same floor as forecast_only mode
+        load_start_date = pd.Timestamp.now() - BDay(n=chart_min_samples + th)
+        self.canswim_model.load_data(
+            stock_tickers=[ticker],
+            start_date=load_start_date,
+            min_samples=chart_min_samples,
         )
-        self.canswim_model.load_data(stock_tickers=[ticker], start_date=load_start_date)
         # prepare timeseries for forecast
         self.canswim_model.prepare_stock_price_data(start_date=load_start_date)
         fig, axes = plt.subplots(figsize=(20, 12))
         target = self.get_target(ticker)
         # reward risk df
         rr_df = None
+        plot_start_date = pd.Timestamp.now() - BDay(th)
+        lq = (100 - lowq) / 100
         if target is None:
-            msg = f"Not enough data available to forecast {ticker}"
-            gr.Info(msg)
-            plt.text(0.5, 0.5, msg, fontsize="large")
+            # Fallback: plot closes from search DB so newly gathered symbols still show a price chart
+            from canswim.db import get_close_prices
+
+            try:
+                close_df = get_close_prices(
+                    self.db_path,
+                    ticker,
+                    start=plot_start_date.strftime("%Y-%m-%d"),
+                )
+            except Exception as e:
+                logger.warning(f"close_price fallback failed for {ticker}: {e}")
+                close_df = None
+            if close_df is not None and len(close_df) > 0:
+                date_col = "date" if "date" in close_df.columns else "Date"
+                close_col = "close" if "close" in close_df.columns else "Close"
+                s = close_df.set_index(date_col)[close_col].sort_index()
+                s.index = pd.to_datetime(s.index)
+                axes.plot(s.index, s.values, label=f"{ticker} Close actual")
+                msg = (
+                    f"{ticker}: showing local prices. "
+                    f"No forecast lines yet — run a forecast for this symbol on the Run tab."
+                )
+                gr.Info(msg)
+                axes.set_title(msg)
+            else:
+                msg = (
+                    f"Not enough local price history for {ticker} to chart. "
+                    f"Use Run → Update market data first."
+                )
+                gr.Info(msg)
+                plt.text(0.5, 0.5, msg, fontsize="large", ha="center", va="center")
         else:
-            plot_start_date = pd.Timestamp.now() - BDay(
-                self.canswim_model.train_history
-            )
             visible_target = target.drop_before(plot_start_date)
-            saved_forecast_df_list = self.get_saved_forecasts(ticker=ticker, start_date=plot_start_date)
-            lq = (100 - lowq) / 100
+            saved_forecast_df_list = self.get_saved_forecasts(
+                ticker=ticker, start_date=plot_start_date
+            )
             visible_target.plot(label=f"{ticker} Close actual")
-            # logger.debug(f"Plotting saved forecast: {saved_forecast_df_list}")
             if saved_forecast_df_list is not None and len(saved_forecast_df_list) > 0:
                 for forecast in saved_forecast_df_list:
                     self.plot_quantiles_df(
@@ -289,6 +323,11 @@ class ChartTab:
                         high_quantile=0.95,
                         label=f"{ticker} Close forecast",
                     )
+            else:
+                gr.Info(
+                    f"{ticker}: prices shown. No saved forecasts yet — "
+                    f"run a forecast on the Run tab to add prediction lines."
+                )
             # Reward/Risk for all uptrending forecast starts (incl. monthly backtests),
             # not only the global latest start (which may be flat/down while older
             # starts still plot on the chart).
@@ -305,10 +344,12 @@ class ChartTab:
             # Specify formatter
             X.set_major_formatter(major_fmt)
             X.set_minor_formatter(minor_fmt)
-            # plt.show()
             # plt.grid(gridOn=True, which='major', color='b', linestyle='-')
             plt.grid(which="minor", color="lightgrey", linestyle="--")
             plt.legend()
+        if target is None:
+            axes.legend()
+            axes.grid(True, which="major", linestyle="-", alpha=0.3)
         return {self.plotComponent: fig, self.rrTable: rr_df}
 
     def get_saved_forecasts(self, ticker: str = None, start_date=None):

--- a/src/canswim/dashboard/run_tab.py
+++ b/src/canswim/dashboard/run_tab.py
@@ -1,4 +1,9 @@
-"""Dashboard Run tab: gather data + week-aligned forecast for user tickers."""
+"""Dashboard Run tab: gather data + week-aligned forecast for user tickers.
+
+Uses the same ``canswim.run_triggers`` orchestration as:
+- CLI: ``python -m canswim gatherdata|forecast --tickers …``
+- MCP: ``gather_tickers`` / ``forecast_tickers`` (opt-in)
+"""
 
 from __future__ import annotations
 
@@ -8,6 +13,9 @@ import gradio as gr
 from loguru import logger
 
 from canswim.run_triggers import (
+    DATE_POLICY_SUMMARY,
+    FORECAST_START_HELP,
+    TICKERS_HELP,
     forecast_for_tickers,
     gather_for_tickers,
     parse_ticker_list,
@@ -26,12 +34,15 @@ class RunTab:
         self.db_path = db_path
 
         gr.Markdown(
-            """
+            f"""
 ### Run gather & forecast
-Enter one or more tickers (comma or newline separated).  
-**Gather** pulls local market data for those symbols.  
-**Forecast** runs TiDE for that list with a **week-aligned** start date
-(snapped to the first NYSE session of the market week; default / today → live week origin).
+Same pipeline as **CLI** (`--tickers`) and **MCP** (`gather_tickers` / `forecast_tickers`).
+
+{DATE_POLICY_SUMMARY}
+
+**Gather** → local market data for the listed symbols (not the full universe).  
+**Forecast** → TiDE for that list at the resolved week-aligned start.  
+**Preview start date** → see the snap/default without running the model.
             """
         )
         with gr.Row():
@@ -39,25 +50,25 @@ Enter one or more tickers (comma or newline separated).
                 label="Tickers",
                 lines=4,
                 placeholder="AAPL, MSFT\nNVDA",
-                info="Comma and/or newline separated. Max 50 symbols per run.",
+                info=TICKERS_HELP,
             )
         with gr.Row():
             self.forecastDate = gr.Textbox(
                 label="Forecast start date (optional YYYY-MM-DD)",
                 value="",
                 placeholder="Leave empty for live week-start default",
-                info=(
-                    "Past dates snap to the market week start on or before the pick. "
-                    "Empty or today → live default (week start after latest week-end close). "
-                    "Future dates beyond the live default are rejected."
-                ),
+                info=FORECAST_START_HELP,
             )
             self.resolveBtn = gr.Button("Preview start date", scale=0)
         with gr.Row():
             self.gatherBtn = gr.Button("Gather data", variant="secondary")
             self.forecastBtn = gr.Button("Run forecast", variant="primary")
         self.status = gr.Markdown(
-            value="_Enter tickers, then Gather and/or Run forecast._"
+            value=(
+                "_Enter tickers, then Gather and/or Run forecast. "
+                "CLI equivalent: `python -m canswim gatherdata --tickers '…'` / "
+                "`forecast --tickers '…' [--forecast_start_date YYYY-MM-DD]`._"
+            )
         )
 
         self.resolveBtn.click(

--- a/src/canswim/dashboard/run_tab.py
+++ b/src/canswim/dashboard/run_tab.py
@@ -70,12 +70,12 @@ def _forecast_summary(result: dict) -> str:
             "Skipped re-run — no new forecast files written."
         )
     if not result.get("ok"):
-        need = result.get("need_gather")
-        head = (
-            "❌ **Need more market data first.**"
-            if need
-            else "❌ **Forecast failed.**"
-        )
+        if result.get("need_covariates"):
+            head = "❌ **Forecast inputs incomplete.**"
+        elif result.get("need_gather"):
+            head = "❌ **Need more market data first.**"
+        else:
+            head = "❌ **Forecast failed.**"
         return f"{head}  \n{result.get('error') or 'Unknown error.'}"
     forecasted = result.get("forecasted") or []
     already = result.get("already_have_forecast") or []

--- a/src/canswim/dashboard/run_tab.py
+++ b/src/canswim/dashboard/run_tab.py
@@ -10,6 +10,7 @@ import json
 import gradio as gr
 from loguru import logger
 
+from canswim.db import list_tickers
 from canswim.run_triggers import (
     FORECAST_BUTTON,
     FORECAST_SECTION_HELP,
@@ -32,9 +33,15 @@ def _fmt_result(payload: dict) -> str:
 
 
 class RunTab:
-    def __init__(self, canswim_model=None, db_path=None):
+    def __init__(
+        self,
+        canswim_model=None,
+        db_path=None,
+        charts_ticker_dropdown=None,
+    ):
         self.canswim_model = canswim_model
         self.db_path = db_path
+        self.charts_ticker_dropdown = charts_ticker_dropdown
 
         gr.Markdown(
             """
@@ -53,9 +60,10 @@ Use the same stock symbols in both when you want a full path from download to pr
                 placeholder="AAPL, MSFT",
                 info=TICKERS_HELP,
             )
-            self.gatherBtn = gr.Button(GATHER_BUTTON, variant="secondary")
+            # primary (not secondary): Soft theme greys secondary and looks disabled
+            self.gatherBtn = gr.Button(GATHER_BUTTON, variant="primary")
             self.gatherStatus = gr.Markdown(
-                value="_Enter symbols, then update market data._"
+                value="_Enter symbols, then click Update market data._"
             )
 
         gr.Markdown("---")
@@ -82,10 +90,14 @@ Use the same stock symbols in both when you want a full path from download to pr
                 value="_Enter symbols, optionally check the start date, then run a forecast._"
             )
 
+        gather_outputs = [self.gatherStatus]
+        if self.charts_ticker_dropdown is not None:
+            gather_outputs.append(self.charts_ticker_dropdown)
+
         self.gatherBtn.click(
             fn=self.do_gather,
             inputs=[self.gatherTickers],
-            outputs=[self.gatherStatus],
+            outputs=gather_outputs,
         )
         self.resolveBtn.click(
             fn=self.preview_start,
@@ -97,6 +109,21 @@ Use the same stock symbols in both when you want a full path from download to pr
             inputs=[self.forecastTickers, self.forecastDate],
             outputs=[self.forecastStatus],
         )
+
+    def _charts_dropdown_update(self):
+        """Refresh Charts symbol list after search-DB sync."""
+        if self.charts_ticker_dropdown is None or not self.db_path:
+            return None
+        try:
+            choices = sorted(list_tickers(self.db_path))
+            current = None
+            # keep a sensible selection if possible
+            if choices:
+                current = choices[0]
+            return gr.update(choices=choices, value=current)
+        except Exception as e:
+            logger.warning(f"Could not refresh Charts dropdown: {e}")
+            return gr.update()
 
     def preview_start(self, forecast_date):
         info = resolve_start_for_run(forecast_date or None)
@@ -114,24 +141,40 @@ Use the same stock symbols in both when you want a full path from download to pr
     def do_gather(self, tickers_text):
         parsed = parse_ticker_list(tickers_text)
         if not parsed["ok"]:
-            return (
+            msg = (
                 f"**Update failed:** {parsed.get('error')}\n\n"
                 + _fmt_result(parsed)
             )
+            if self.charts_ticker_dropdown is not None:
+                return msg, gr.update()
+            return msg
         logger.info(f"Dashboard gather for {parsed['tickers']}")
         result = gather_for_tickers(tickers_text, force_allow=True)
         if result.get("ok"):
             skipped = result.get("skipped_remote") or []
             fetched = result.get("fetched") or []
             summary = (
-                f"**Market data updated** for `{', '.join(result.get('tickers') or [])}`"
+                f"**Market data updated** for "
+                f"`{', '.join(result.get('tickers') or [])}`"
             )
             if skipped:
                 summary += f"  \nAlready local: {', '.join(skipped)}"
             if fetched:
                 summary += f"  \nDownloaded/refreshed: {', '.join(fetched)}"
-            return summary + "\n\n" + _fmt_result(result)
-        return f"**Update failed:** {result.get('error')}\n\n{_fmt_result(result)}"
+            added = (result.get("db_sync") or {}).get("added") or []
+            if added:
+                summary += (
+                    f"  \n**Now in Charts list:** {', '.join(added)}"
+                )
+            msg = summary + "\n\n" + _fmt_result(result)
+        else:
+            msg = (
+                f"**Update failed:** {result.get('error')}\n\n"
+                + _fmt_result(result)
+            )
+        if self.charts_ticker_dropdown is not None:
+            return msg, self._charts_dropdown_update()
+        return msg
 
     def do_forecast(self, tickers_text, forecast_date):
         parsed = parse_ticker_list(tickers_text)

--- a/src/canswim/dashboard/run_tab.py
+++ b/src/canswim/dashboard/run_tab.py
@@ -1,8 +1,6 @@
-"""Dashboard Run tab: gather data + week-aligned forecast for user tickers.
+"""Dashboard: separate Get market data vs Run a forecast panels.
 
-Uses the same ``canswim.run_triggers`` orchestration as:
-- CLI: ``python -m canswim gatherdata|forecast --tickers …``
-- MCP: ``gather_tickers`` / ``forecast_tickers`` (opt-in)
+Uses the same ``canswim.run_triggers`` orchestration as CLI and MCP.
 """
 
 from __future__ import annotations
@@ -13,8 +11,14 @@ import gradio as gr
 from loguru import logger
 
 from canswim.run_triggers import (
-    DATE_POLICY_SUMMARY,
+    FORECAST_BUTTON,
+    FORECAST_SECTION_HELP,
+    FORECAST_SECTION_TITLE,
     FORECAST_START_HELP,
+    GATHER_BUTTON,
+    GATHER_SECTION_HELP,
+    GATHER_SECTION_TITLE,
+    PREVIEW_START_BUTTON,
     TICKERS_HELP,
     forecast_for_tickers,
     gather_for_tickers,
@@ -29,101 +33,122 @@ def _fmt_result(payload: dict) -> str:
 
 class RunTab:
     def __init__(self, canswim_model=None, db_path=None):
-        # model/db unused for triggers but kept for dashboard consistency
         self.canswim_model = canswim_model
         self.db_path = db_path
 
         gr.Markdown(
-            f"""
-### Run gather & forecast
-Same pipeline as **CLI** (`--tickers`) and **MCP** (`gather_tickers` / `forecast_tickers`).
-
-{DATE_POLICY_SUMMARY}
-
-**Gather** → local market data for the listed symbols (not the full universe).  
-**Forecast** → TiDE for that list at the resolved week-aligned start.  
-**Preview start date** → see the snap/default without running the model.
+            """
+## Update data & run forecasts
+Two separate steps: **get market data**, then **run a forecast**.  
+Use the same stock symbols in both when you want a full path from download to prediction.
             """
         )
-        with gr.Row():
-            self.tickers = gr.Textbox(
-                label="Tickers",
-                lines=4,
-                placeholder="AAPL, MSFT\nNVDA",
+
+        # ---- Gather panel ----
+        with gr.Group():
+            gr.Markdown(f"### {GATHER_SECTION_TITLE}\n{GATHER_SECTION_HELP}")
+            self.gatherTickers = gr.Textbox(
+                label="Symbols to update",
+                lines=3,
+                placeholder="AAPL, MSFT",
                 info=TICKERS_HELP,
             )
-        with gr.Row():
-            self.forecastDate = gr.Textbox(
-                label="Forecast start date (optional YYYY-MM-DD)",
-                value="",
-                placeholder="Leave empty for live week-start default",
-                info=FORECAST_START_HELP,
+            self.gatherBtn = gr.Button(GATHER_BUTTON, variant="secondary")
+            self.gatherStatus = gr.Markdown(
+                value="_Enter symbols, then update market data._"
             )
-            self.resolveBtn = gr.Button("Preview start date", scale=0)
-        with gr.Row():
-            self.gatherBtn = gr.Button("Gather data", variant="secondary")
-            self.forecastBtn = gr.Button("Run forecast", variant="primary")
-        self.status = gr.Markdown(
-            value=(
-                "_Enter tickers, then Gather and/or Run forecast. "
-                "CLI equivalent: `python -m canswim gatherdata --tickers '…'` / "
-                "`forecast --tickers '…' [--forecast_start_date YYYY-MM-DD]`._"
-            )
-        )
 
+        gr.Markdown("---")
+
+        # ---- Forecast panel ----
+        with gr.Group():
+            gr.Markdown(f"### {FORECAST_SECTION_TITLE}\n{FORECAST_SECTION_HELP}")
+            self.forecastTickers = gr.Textbox(
+                label="Symbols to forecast",
+                lines=3,
+                placeholder="AAPL, MSFT",
+                info=TICKERS_HELP,
+            )
+            with gr.Row():
+                self.forecastDate = gr.Textbox(
+                    label="Start date (optional)",
+                    value="",
+                    placeholder="YYYY-MM-DD — leave blank for the default",
+                    info=FORECAST_START_HELP,
+                )
+                self.resolveBtn = gr.Button(PREVIEW_START_BUTTON, scale=0)
+            self.forecastBtn = gr.Button(FORECAST_BUTTON, variant="primary")
+            self.forecastStatus = gr.Markdown(
+                value="_Enter symbols, optionally check the start date, then run a forecast._"
+            )
+
+        self.gatherBtn.click(
+            fn=self.do_gather,
+            inputs=[self.gatherTickers],
+            outputs=[self.gatherStatus],
+        )
         self.resolveBtn.click(
             fn=self.preview_start,
             inputs=[self.forecastDate],
-            outputs=[self.status],
-        )
-        self.gatherBtn.click(
-            fn=self.do_gather,
-            inputs=[self.tickers],
-            outputs=[self.status],
+            outputs=[self.forecastStatus],
         )
         self.forecastBtn.click(
             fn=self.do_forecast,
-            inputs=[self.tickers, self.forecastDate],
-            outputs=[self.status],
+            inputs=[self.forecastTickers, self.forecastDate],
+            outputs=[self.forecastStatus],
         )
 
     def preview_start(self, forecast_date):
         info = resolve_start_for_run(forecast_date or None)
         if info.get("ok"):
             return (
-                f"**Resolved start:** `{info.get('start')}` "
-                f"({info.get('reason')}) · live default `{info.get('live_default')}` · "
-                f"latest_close used `{info.get('latest_close_used')}`\n\n"
+                f"**Start date:** `{info.get('start')}`  \n"
+                f"Default if left blank: `{info.get('live_default')}`\n\n"
                 + _fmt_result(info)
             )
-        return f"**Could not resolve start:** {info.get('error')}\n\n{_fmt_result(info)}"
+        return (
+            f"**Could not use that date:** {info.get('error')}\n\n"
+            + _fmt_result(info)
+        )
 
     def do_gather(self, tickers_text):
         parsed = parse_ticker_list(tickers_text)
         if not parsed["ok"]:
-            return f"**Gather aborted:** {parsed.get('error')}\n\n{_fmt_result(parsed)}"
+            return (
+                f"**Update failed:** {parsed.get('error')}\n\n"
+                + _fmt_result(parsed)
+            )
         logger.info(f"Dashboard gather for {parsed['tickers']}")
-        # Dashboard is an explicit local user action
         result = gather_for_tickers(tickers_text, force_allow=True)
         if result.get("ok"):
-            return (
-                f"**Gather OK** for `{', '.join(result.get('tickers') or [])}`\n\n"
-                + _fmt_result(result)
+            skipped = result.get("skipped_remote") or []
+            fetched = result.get("fetched") or []
+            summary = (
+                f"**Market data updated** for `{', '.join(result.get('tickers') or [])}`"
             )
-        return f"**Gather failed:** {result.get('error')}\n\n{_fmt_result(result)}"
+            if skipped:
+                summary += f"  \nAlready local: {', '.join(skipped)}"
+            if fetched:
+                summary += f"  \nDownloaded/refreshed: {', '.join(fetched)}"
+            return summary + "\n\n" + _fmt_result(result)
+        return f"**Update failed:** {result.get('error')}\n\n{_fmt_result(result)}"
 
     def do_forecast(self, tickers_text, forecast_date):
         parsed = parse_ticker_list(tickers_text)
         if not parsed["ok"]:
-            return f"**Forecast aborted:** {parsed.get('error')}\n\n{_fmt_result(parsed)}"
+            return (
+                f"**Forecast failed:** {parsed.get('error')}\n\n"
+                + _fmt_result(parsed)
+            )
         start_preview = resolve_start_for_run(forecast_date or None)
         if not start_preview.get("ok"):
             return (
-                f"**Forecast aborted (start date):** {start_preview.get('error')}\n\n"
+                f"**Forecast failed (start date):** {start_preview.get('error')}\n\n"
                 + _fmt_result(start_preview)
             )
         logger.info(
-            f"Dashboard forecast for {parsed['tickers']} start={start_preview.get('start')}"
+            f"Dashboard forecast for {parsed['tickers']} "
+            f"start={start_preview.get('start')}"
         )
         result = forecast_for_tickers(
             tickers_text,
@@ -133,9 +158,10 @@ Same pipeline as **CLI** (`--tickers`) and **MCP** (`gather_tickers` / `forecast
         if result.get("ok"):
             rs = (result.get("resolved_start") or {}).get("start")
             return (
-                f"**Forecast OK** · resolved start `{rs}` · "
-                f"forecasted `{result.get('forecasted')}` · "
-                f"skipped `{result.get('skipped')}`\n\n"
+                f"**Forecast complete** · start `{rs}` · "
+                f"symbols `{result.get('forecasted')}`\n\n"
                 + _fmt_result(result)
             )
-        return f"**Forecast failed:** {result.get('error')}\n\n{_fmt_result(result)}"
+        need = result.get("need_gather")
+        prefix = "**Need more market data**" if need else "**Forecast failed**"
+        return f"{prefix}: {result.get('error')}\n\n{_fmt_result(result)}"

--- a/src/canswim/dashboard/run_tab.py
+++ b/src/canswim/dashboard/run_tab.py
@@ -1,6 +1,7 @@
 """Dashboard: separate Get market data vs Run a forecast panels.
 
 Uses the same ``canswim.run_triggers`` orchestration as CLI and MCP.
+Consumer UI shows a short status line; full JSON is under Advanced details.
 """
 
 from __future__ import annotations
@@ -28,8 +29,71 @@ from canswim.run_triggers import (
 )
 
 
-def _fmt_result(payload: dict) -> str:
-    return f"```json\n{json.dumps(payload, indent=2, default=str)}\n```"
+def _json_details(payload: dict) -> str:
+    return json.dumps(payload, indent=2, default=str)
+
+
+def _gather_summary(result: dict) -> str:
+    if not result.get("ok"):
+        return f"❌ **Could not update market data.**  \n{result.get('error') or 'Unknown error.'}"
+    tickers = result.get("tickers") or []
+    skipped = result.get("skipped_remote") or []
+    fetched = result.get("fetched") or []
+    added = (result.get("db_sync") or {}).get("added") or []
+    lines = [f"✅ **Market data ready** for {', '.join(tickers) or '—' }."]
+    if skipped and not fetched:
+        lines.append("Already up to date locally — no download needed.")
+    elif skipped:
+        lines.append(f"Already local: {', '.join(skipped)}.")
+    if fetched:
+        lines.append(f"Downloaded or refreshed: {', '.join(fetched)}.")
+    if added:
+        lines.append(f"Added to Charts list: {', '.join(added)}.")
+    return "  \n".join(lines)
+
+
+def _forecast_summary(result: dict) -> str:
+    start = (result.get("resolved_start") or {}).get("start") or "—"
+    if result.get("dry_run"):
+        already = result.get("already_have_forecast") or []
+        if already:
+            return (
+                f"ℹ️ **Check only** — start date `{start}`.  \n"
+                f"Already on file (would skip): {', '.join(already)}."
+            )
+        return f"ℹ️ **Check only** — start date `{start}`. No model run."
+    if result.get("already_saved") and not result.get("forecasted"):
+        already = result.get("already_have_forecast") or result.get("tickers") or []
+        return (
+            f"✅ **Already done** for {', '.join(already)} "
+            f"(start `{start}`).  \n"
+            "Skipped re-run — no new forecast files written."
+        )
+    if not result.get("ok"):
+        need = result.get("need_gather")
+        head = (
+            "❌ **Need more market data first.**"
+            if need
+            else "❌ **Forecast failed.**"
+        )
+        return f"{head}  \n{result.get('error') or 'Unknown error.'}"
+    forecasted = result.get("forecasted") or []
+    already = result.get("already_have_forecast") or []
+    lines = [f"✅ **Forecast complete** (start `{start}`)."]
+    if forecasted:
+        lines.append(f"New: {', '.join(forecasted)}.")
+    if already:
+        lines.append(f"Already on file (skipped): {', '.join(already)}.")
+    return "  \n".join(lines)
+
+
+def _start_summary(info: dict) -> str:
+    if info.get("ok"):
+        return (
+            f"✅ **Start date:** `{info.get('start')}`  \n"
+            f"Default if left blank: `{info.get('live_default')}`."
+        )
+    return f"❌ **Could not use that date.**  \n{info.get('error') or ''}"
 
 
 class RunTab:
@@ -46,8 +110,7 @@ class RunTab:
         gr.Markdown(
             """
 ## Update data & run forecasts
-Two separate steps: **get market data**, then **run a forecast**.  
-Use the same stock symbols in both when you want a full path from download to prediction.
+Two separate steps: **get market data**, then **run a forecast**.
             """
         )
 
@@ -60,11 +123,18 @@ Use the same stock symbols in both when you want a full path from download to pr
                 placeholder="AAPL, MSFT",
                 info=TICKERS_HELP,
             )
-            # primary (not secondary): Soft theme greys secondary and looks disabled
             self.gatherBtn = gr.Button(GATHER_BUTTON, variant="primary")
             self.gatherStatus = gr.Markdown(
                 value="_Enter symbols, then click Update market data._"
             )
+            with gr.Accordion("Advanced details", open=False):
+                self.gatherDetails = gr.Code(
+                    label="Technical log",
+                    language="json",
+                    lines=8,
+                    interactive=False,
+                    value="",
+                )
 
         gr.Markdown("---")
 
@@ -89,8 +159,16 @@ Use the same stock symbols in both when you want a full path from download to pr
             self.forecastStatus = gr.Markdown(
                 value="_Enter symbols, optionally check the start date, then run a forecast._"
             )
+            with gr.Accordion("Advanced details", open=False):
+                self.forecastDetails = gr.Code(
+                    label="Technical log",
+                    language="json",
+                    lines=8,
+                    interactive=False,
+                    value="",
+                )
 
-        gather_outputs = [self.gatherStatus]
+        gather_outputs = [self.gatherStatus, self.gatherDetails]
         if self.charts_ticker_dropdown is not None:
             gather_outputs.append(self.charts_ticker_dropdown)
 
@@ -102,24 +180,20 @@ Use the same stock symbols in both when you want a full path from download to pr
         self.resolveBtn.click(
             fn=self.preview_start,
             inputs=[self.forecastDate],
-            outputs=[self.forecastStatus],
+            outputs=[self.forecastStatus, self.forecastDetails],
         )
         self.forecastBtn.click(
             fn=self.do_forecast,
             inputs=[self.forecastTickers, self.forecastDate],
-            outputs=[self.forecastStatus],
+            outputs=[self.forecastStatus, self.forecastDetails],
         )
 
     def _charts_dropdown_update(self):
-        """Refresh Charts symbol list after search-DB sync."""
         if self.charts_ticker_dropdown is None or not self.db_path:
             return None
         try:
             choices = sorted(list_tickers(self.db_path))
-            current = None
-            # keep a sensible selection if possible
-            if choices:
-                current = choices[0]
+            current = choices[0] if choices else None
             return gr.update(choices=choices, value=current)
         except Exception as e:
             logger.warning(f"Could not refresh Charts dropdown: {e}")
@@ -127,67 +201,40 @@ Use the same stock symbols in both when you want a full path from download to pr
 
     def preview_start(self, forecast_date):
         info = resolve_start_for_run(forecast_date or None)
-        if info.get("ok"):
-            return (
-                f"**Start date:** `{info.get('start')}`  \n"
-                f"Default if left blank: `{info.get('live_default')}`\n\n"
-                + _fmt_result(info)
-            )
-        return (
-            f"**Could not use that date:** {info.get('error')}\n\n"
-            + _fmt_result(info)
-        )
+        return _start_summary(info), _json_details(info)
 
     def do_gather(self, tickers_text):
         parsed = parse_ticker_list(tickers_text)
         if not parsed["ok"]:
-            msg = (
-                f"**Update failed:** {parsed.get('error')}\n\n"
-                + _fmt_result(parsed)
+            status = (
+                f"❌ **Could not update market data.**  \n"
+                f"{parsed.get('error') or 'Invalid symbols.'}"
             )
+            details = _json_details(parsed)
             if self.charts_ticker_dropdown is not None:
-                return msg, gr.update()
-            return msg
+                return status, details, gr.update()
+            return status, details
         logger.info(f"Dashboard gather for {parsed['tickers']}")
         result = gather_for_tickers(tickers_text, force_allow=True)
-        if result.get("ok"):
-            skipped = result.get("skipped_remote") or []
-            fetched = result.get("fetched") or []
-            summary = (
-                f"**Market data updated** for "
-                f"`{', '.join(result.get('tickers') or [])}`"
-            )
-            if skipped:
-                summary += f"  \nAlready local: {', '.join(skipped)}"
-            if fetched:
-                summary += f"  \nDownloaded/refreshed: {', '.join(fetched)}"
-            added = (result.get("db_sync") or {}).get("added") or []
-            if added:
-                summary += (
-                    f"  \n**Now in Charts list:** {', '.join(added)}"
-                )
-            msg = summary + "\n\n" + _fmt_result(result)
-        else:
-            msg = (
-                f"**Update failed:** {result.get('error')}\n\n"
-                + _fmt_result(result)
-            )
+        status = _gather_summary(result)
+        details = _json_details(result)
         if self.charts_ticker_dropdown is not None:
-            return msg, self._charts_dropdown_update()
-        return msg
+            return status, details, self._charts_dropdown_update()
+        return status, details
 
     def do_forecast(self, tickers_text, forecast_date):
         parsed = parse_ticker_list(tickers_text)
         if not parsed["ok"]:
             return (
-                f"**Forecast failed:** {parsed.get('error')}\n\n"
-                + _fmt_result(parsed)
+                f"❌ **Forecast failed.**  \n{parsed.get('error') or 'Invalid symbols.'}",
+                _json_details(parsed),
             )
         start_preview = resolve_start_for_run(forecast_date or None)
         if not start_preview.get("ok"):
             return (
-                f"**Forecast failed (start date):** {start_preview.get('error')}\n\n"
-                + _fmt_result(start_preview)
+                f"❌ **Forecast failed (start date).**  \n"
+                f"{start_preview.get('error') or ''}",
+                _json_details(start_preview),
             )
         logger.info(
             f"Dashboard forecast for {parsed['tickers']} "
@@ -198,13 +245,4 @@ Use the same stock symbols in both when you want a full path from download to pr
             forecast_start_date=forecast_date or None,
             force_allow=True,
         )
-        if result.get("ok"):
-            rs = (result.get("resolved_start") or {}).get("start")
-            return (
-                f"**Forecast complete** · start `{rs}` · "
-                f"symbols `{result.get('forecasted')}`\n\n"
-                + _fmt_result(result)
-            )
-        need = result.get("need_gather")
-        prefix = "**Need more market data**" if need else "**Forecast failed**"
-        return f"{prefix}: {result.get('error')}\n\n{_fmt_result(result)}"
+        return _forecast_summary(result), _json_details(result)

--- a/src/canswim/dashboard/run_tab.py
+++ b/src/canswim/dashboard/run_tab.py
@@ -1,0 +1,130 @@
+"""Dashboard Run tab: gather data + week-aligned forecast for user tickers."""
+
+from __future__ import annotations
+
+import json
+
+import gradio as gr
+from loguru import logger
+
+from canswim.run_triggers import (
+    forecast_for_tickers,
+    gather_for_tickers,
+    parse_ticker_list,
+    resolve_start_for_run,
+)
+
+
+def _fmt_result(payload: dict) -> str:
+    return f"```json\n{json.dumps(payload, indent=2, default=str)}\n```"
+
+
+class RunTab:
+    def __init__(self, canswim_model=None, db_path=None):
+        # model/db unused for triggers but kept for dashboard consistency
+        self.canswim_model = canswim_model
+        self.db_path = db_path
+
+        gr.Markdown(
+            """
+### Run gather & forecast
+Enter one or more tickers (comma or newline separated).  
+**Gather** pulls local market data for those symbols.  
+**Forecast** runs TiDE for that list with a **week-aligned** start date
+(snapped to the first NYSE session of the market week; default / today → live week origin).
+            """
+        )
+        with gr.Row():
+            self.tickers = gr.Textbox(
+                label="Tickers",
+                lines=4,
+                placeholder="AAPL, MSFT\nNVDA",
+                info="Comma and/or newline separated. Max 50 symbols per run.",
+            )
+        with gr.Row():
+            self.forecastDate = gr.Textbox(
+                label="Forecast start date (optional YYYY-MM-DD)",
+                value="",
+                placeholder="Leave empty for live week-start default",
+                info=(
+                    "Past dates snap to the market week start on or before the pick. "
+                    "Empty or today → live default (week start after latest week-end close). "
+                    "Future dates beyond the live default are rejected."
+                ),
+            )
+            self.resolveBtn = gr.Button("Preview start date", scale=0)
+        with gr.Row():
+            self.gatherBtn = gr.Button("Gather data", variant="secondary")
+            self.forecastBtn = gr.Button("Run forecast", variant="primary")
+        self.status = gr.Markdown(
+            value="_Enter tickers, then Gather and/or Run forecast._"
+        )
+
+        self.resolveBtn.click(
+            fn=self.preview_start,
+            inputs=[self.forecastDate],
+            outputs=[self.status],
+        )
+        self.gatherBtn.click(
+            fn=self.do_gather,
+            inputs=[self.tickers],
+            outputs=[self.status],
+        )
+        self.forecastBtn.click(
+            fn=self.do_forecast,
+            inputs=[self.tickers, self.forecastDate],
+            outputs=[self.status],
+        )
+
+    def preview_start(self, forecast_date):
+        info = resolve_start_for_run(forecast_date or None)
+        if info.get("ok"):
+            return (
+                f"**Resolved start:** `{info.get('start')}` "
+                f"({info.get('reason')}) · live default `{info.get('live_default')}` · "
+                f"latest_close used `{info.get('latest_close_used')}`\n\n"
+                + _fmt_result(info)
+            )
+        return f"**Could not resolve start:** {info.get('error')}\n\n{_fmt_result(info)}"
+
+    def do_gather(self, tickers_text):
+        parsed = parse_ticker_list(tickers_text)
+        if not parsed["ok"]:
+            return f"**Gather aborted:** {parsed.get('error')}\n\n{_fmt_result(parsed)}"
+        logger.info(f"Dashboard gather for {parsed['tickers']}")
+        # Dashboard is an explicit local user action
+        result = gather_for_tickers(tickers_text, force_allow=True)
+        if result.get("ok"):
+            return (
+                f"**Gather OK** for `{', '.join(result.get('tickers') or [])}`\n\n"
+                + _fmt_result(result)
+            )
+        return f"**Gather failed:** {result.get('error')}\n\n{_fmt_result(result)}"
+
+    def do_forecast(self, tickers_text, forecast_date):
+        parsed = parse_ticker_list(tickers_text)
+        if not parsed["ok"]:
+            return f"**Forecast aborted:** {parsed.get('error')}\n\n{_fmt_result(parsed)}"
+        start_preview = resolve_start_for_run(forecast_date or None)
+        if not start_preview.get("ok"):
+            return (
+                f"**Forecast aborted (start date):** {start_preview.get('error')}\n\n"
+                + _fmt_result(start_preview)
+            )
+        logger.info(
+            f"Dashboard forecast for {parsed['tickers']} start={start_preview.get('start')}"
+        )
+        result = forecast_for_tickers(
+            tickers_text,
+            forecast_start_date=forecast_date or None,
+            force_allow=True,
+        )
+        if result.get("ok"):
+            rs = (result.get("resolved_start") or {}).get("start")
+            return (
+                f"**Forecast OK** · resolved start `{rs}` · "
+                f"forecasted `{result.get('forecasted')}` · "
+                f"skipped `{result.get('skipped')}`\n\n"
+                + _fmt_result(result)
+            )
+        return f"**Forecast failed:** {result.get('error')}\n\n{_fmt_result(result)}"

--- a/src/canswim/db.py
+++ b/src/canswim/db.py
@@ -375,6 +375,116 @@ def sync_gathered_symbols(
     }
 
 
+def sync_forecasts_to_search_db(
+    db_path: str,
+    symbols: Sequence[str],
+    *,
+    forecast_path: Optional[str] = None,
+) -> dict[str, Any]:
+    """Load forecast parquet partitions for symbols into the DuckDB search table.
+
+    Charts/Scans read ``forecast`` / ``latest_forecast`` from DuckDB. Scoped
+    forecast runs write hive parquet only; with ``--same_data`` the search DB
+    is not rebuilt, so charts would stay empty of forecast lines without this.
+    """
+    import glob
+
+    syms = sorted({str(s).strip().upper() for s in symbols if s and str(s).strip()})
+    if not syms:
+        return {"ok": True, "symbols": [], "forecast_rows": 0}
+
+    paths = DataPaths.from_env()
+    fpath = forecast_path or paths.forecast_path
+    # Normalize trailing slash
+    fpath = str(fpath)
+    if not fpath.endswith("/"):
+        fpath = fpath + "/"
+    forecast_glob = f"{fpath}**/*.parquet"
+    if not glob.glob(forecast_glob, recursive=True):
+        return {
+            "ok": True,
+            "symbols": syms,
+            "forecast_rows": 0,
+            "message": "No forecast parquet files found",
+        }
+
+    in_list = ", ".join("'" + s.replace("'", "''") + "'" for s in syms)
+    with connect_readwrite(db_path) as db_con:
+        # Ensure symbols exist in stock_tickers
+        cols = [r[0] for r in db_con.execute("DESCRIBE stock_tickers").fetchall()]
+        sym_col = "Symbol" if "Symbol" in cols else "symbol"
+        existing = {
+            str(r[0]).upper()
+            for r in db_con.execute(
+                f'SELECT "{sym_col}" FROM stock_tickers WHERE "{sym_col}" IS NOT NULL'
+            ).fetchall()
+            if r[0] is not None
+        }
+        for s in syms:
+            if s not in existing:
+                db_con.execute(
+                    f'INSERT INTO stock_tickers ("{sym_col}") VALUES (?)', [s]
+                )
+
+        db_con.execute(
+            f"""--sql
+            DELETE FROM forecast
+            WHERE upper(CAST(symbol AS VARCHAR)) IN ({in_list})
+            """
+        )
+        # Hive parquet: time column may be "time" or already "date"
+        # Darts forecast parquet uses time index column "time" + hive partition cols
+        db_con.execute(
+            f"""--sql
+            INSERT INTO forecast
+            SELECT
+                CAST(f.time AS DATE) AS date,
+                upper(CAST(f.symbol AS VARCHAR)) AS symbol,
+                CAST(
+                    make_date(
+                        CAST(f.forecast_start_year AS INTEGER),
+                        CAST(f.forecast_start_month AS INTEGER),
+                        CAST(f.forecast_start_day AS INTEGER)
+                    ) AS DATE
+                ) AS start_date,
+                f."close_quantile_0.01",
+                f."close_quantile_0.05",
+                f."close_quantile_0.2",
+                f."close_quantile_0.5",
+                f."close_quantile_0.8",
+                f."close_quantile_0.95",
+                f."close_quantile_0.99"
+            FROM read_parquet('{forecast_glob}', hive_partitioning = 1) AS f
+            WHERE upper(CAST(f.symbol AS VARCHAR)) IN ({in_list})
+            """
+        )
+        n = db_con.execute(
+            f"""--sql
+            SELECT count(*) FROM forecast
+            WHERE upper(CAST(symbol AS VARCHAR)) IN ({in_list})
+            """
+        ).fetchone()[0]
+        # Refresh latest_forecast for these symbols
+        db_con.execute(
+            f"""--sql
+            DELETE FROM latest_forecast
+            WHERE upper(CAST(symbol AS VARCHAR)) IN ({in_list})
+            """
+        )
+        db_con.execute(
+            f"""--sql
+            INSERT INTO latest_forecast
+            SELECT symbol, max(start_date) AS date
+            FROM forecast
+            WHERE upper(CAST(symbol AS VARCHAR)) IN ({in_list})
+            GROUP BY symbol
+            """
+        )
+
+    logger.info(f"Synced forecast search rows={n} for {syms}")
+    return {"ok": True, "symbols": syms, "forecast_rows": int(n)}
+
+
 def get_reward_risk(
     db_path: str,
     symbol: str,

--- a/src/canswim/db.py
+++ b/src/canswim/db.py
@@ -265,6 +265,116 @@ def list_tickers(db_path: str) -> list[str]:
     return stock_list
 
 
+def sync_gathered_symbols(
+    db_path: str,
+    symbols: Sequence[str],
+    *,
+    stocks_price_path: Optional[str] = None,
+    target_column: str = "Close",
+) -> dict[str, Any]:
+    """Add gathered symbols to the search DB (Charts/Scans dropdown source).
+
+    Dashboard init with ``--same_data True`` reuses DuckDB and never reloads
+    ``stock_tickers`` / ``close_price`` from parquet. After a scoped gather,
+    call this so new symbols (e.g. QLYS) appear in Charts without a full rebuild.
+    """
+    syms = sorted({str(s).strip().upper() for s in symbols if s and str(s).strip()})
+    if not syms:
+        return {"ok": True, "added": [], "symbols": [], "close_rows": 0}
+
+    paths = DataPaths.from_env()
+    price_path = stocks_price_path or paths.stocks_price_path
+    if not Path(price_path).is_file():
+        return {
+            "ok": False,
+            "error": f"Price parquet not found: {price_path}",
+            "added": [],
+            "symbols": syms,
+            "close_rows": 0,
+        }
+
+    # Escape for SQL string list
+    in_list = ", ".join("'" + s.replace("'", "''") + "'" for s in syms)
+    added: list[str] = []
+    close_rows = 0
+
+    with connect_readwrite(db_path) as db_con:
+        # Detect symbol column casing
+        cols = [
+            r[0]
+            for r in db_con.execute("DESCRIBE stock_tickers").fetchall()
+        ]
+        sym_col = "Symbol" if "Symbol" in cols else "symbol"
+
+        existing = {
+            str(r[0]).upper()
+            for r in db_con.execute(
+                f'SELECT "{sym_col}" FROM stock_tickers WHERE "{sym_col}" IS NOT NULL'
+            ).fetchall()
+            if r[0] is not None
+        }
+        to_add = [s for s in syms if s not in existing]
+        for s in to_add:
+            db_con.execute(
+                f'INSERT INTO stock_tickers ("{sym_col}") VALUES (?)',
+                [s],
+            )
+            added.append(s)
+
+        # Refresh close prices for all requested symbols from parquet
+        # (replace rows so incremental gather is reflected)
+        db_con.execute(
+            f"""--sql
+            DELETE FROM close_price
+            WHERE upper(CAST(Symbol AS VARCHAR)) IN ({in_list})
+            """
+        )
+        # Parquet may use Close or Adj Close; prefer requested target_column
+        pq_cols = db_con.execute(
+            f"DESCRIBE SELECT * FROM read_parquet('{price_path}') LIMIT 0"
+        ).fetchall()
+        pq_names = {r[0] for r in pq_cols}
+        price_col = target_column if target_column in pq_names else (
+            "Close" if "Close" in pq_names else None
+        )
+        if price_col is None:
+            return {
+                "ok": False,
+                "error": f"No price column in {price_path}; cols={sorted(pq_names)}",
+                "added": added,
+                "symbols": syms,
+                "close_rows": 0,
+            }
+        db_con.execute(
+            f"""--sql
+            INSERT INTO close_price (Date, Symbol, Close)
+            SELECT CAST(Date AS TIMESTAMP) AS Date,
+                   upper(CAST(Symbol AS VARCHAR)) AS Symbol,
+                   CAST("{price_col}" AS DOUBLE) AS Close
+            FROM read_parquet('{price_path}')
+            WHERE upper(CAST(Symbol AS VARCHAR)) IN ({in_list})
+              AND "{price_col}" IS NOT NULL
+            """
+        )
+        close_rows = db_con.execute(
+            f"""--sql
+            SELECT count(*) FROM close_price
+            WHERE upper(CAST(Symbol AS VARCHAR)) IN ({in_list})
+            """
+        ).fetchone()[0]
+
+    logger.info(
+        f"Synced search DB symbols: added={added}, "
+        f"close_rows={close_rows} for {syms}"
+    )
+    return {
+        "ok": True,
+        "added": added,
+        "symbols": syms,
+        "close_rows": int(close_rows),
+    }
+
+
 def get_reward_risk(
     db_path: str,
     symbol: str,

--- a/src/canswim/forecast.py
+++ b/src/canswim/forecast.py
@@ -95,13 +95,14 @@ class CanswimForecaster:
                         after_date=ts.end_time()
                     )
                     if fsd > cutoff_forecast_start_date:
+                        # Pull start back to the latest legal origin for this series
+                        # (common when live week default is after cov-aligned end)
                         logger.info(
-                            f"Skipping {tickers_list[i]}: forecast start {fsd.date()} "
-                            f"is after next open market day after last bar "
-                            f"({cutoff_forecast_start_date}; series ends {ts.end_time()}). "
-                            f"Gather more recent ground-truth prices first."
+                            f"{tickers_list[i]}: forecast start {fsd.date()} is after "
+                            f"next open after last bar ({cutoff_forecast_start_date}; "
+                            f"series ends {ts.end_time()}). Using {cutoff_forecast_start_date}."
                         )
-                        continue
+                        fsd = pd.Timestamp(cutoff_forecast_start_date).normalize()
 
                     if fsd == pd.Timestamp(cutoff_forecast_start_date).normalize():
                         # Forecast from end of available history (no truncation)

--- a/src/canswim/gather_data.py
+++ b/src/canswim/gather_data.py
@@ -322,16 +322,33 @@ class MarketDataGatherer:
         """True if few-symbol scope should reuse an existing multi-index yf parquet.
 
         Avoids long yfinance rate-limit hangs on broad/sectors/industry during
-        scoped verification runs while still refreshing stock prices (yf/FMP).
+        scoped runs **only when the file is still fresh**. Stale broad market
+        truncates stock series at align time and blocks live forecast starts.
         """
         n = len(getattr(self, "stocks_ticker_set", []) or [])
         p = Path(data_file)
-        if n <= 20 and p.is_file() and p.stat().st_size > 0:
+        if not (n <= 20 and p.is_file() and p.stat().st_size > 0):
+            return False
+        try:
+            df = pd.read_parquet(p)
+            if df is None or df.empty:
+                return False
+            last = pd.Timestamp(df.index.max()).normalize()
+            age = (pd.Timestamp.now().normalize() - last).days
+            if age <= 5:
+                logger.info(
+                    f"Scoped gather ({n} stocks): keeping fresh {label} file "
+                    f"{data_file} (last={last.date()}, age={age}d)"
+                )
+                return True
             logger.info(
-                f"Scoped gather ({n} stocks): keeping existing {label} file {data_file}"
+                f"Scoped gather: refreshing stale {label} "
+                f"(last={last.date()}, age={age}d)"
             )
-            return True
-        return False
+            return False
+        except Exception as e:
+            logger.info(f"Scoped gather: will refresh {label} ({e})")
+            return False
 
     def gather_broad_market_data(self):
         ## Prepare data for broad market indicies
@@ -641,6 +658,35 @@ class MarketDataGatherer:
             f"latest={merged_df.index.get_level_values('Date').max()})"
         )
 
+    def _merge_symbol_date_parquet(
+        self, path: str, new_df: pd.DataFrame
+    ) -> pd.DataFrame:
+        """Merge refreshed Symbol/Date rows into an existing multi-index parquet."""
+        if new_df is None or new_df.empty:
+            return new_df
+        new_df = new_df.copy()
+        if list(new_df.index.names) != ["Symbol", "Date"]:
+            new_df.index.names = ["Symbol", "Date"]
+        try:
+            old_df = pd.read_parquet(path)
+            if old_df is not None and not old_df.empty:
+                if list(old_df.index.names) != ["Symbol", "Date"]:
+                    old_df.index.names = ["Symbol", "Date"]
+                refreshed = set(
+                    new_df.index.get_level_values(0).astype(str).str.upper()
+                )
+                keep = old_df[
+                    ~old_df.index.get_level_values(0)
+                    .astype(str)
+                    .str.upper()
+                    .isin(refreshed)
+                ]
+                new_df = pd.concat([keep, new_df], axis=0)
+        except Exception as e:
+            logger.info(f"No existing file to merge at {path} ({e})")
+        new_df = new_df[~new_df.index.duplicated(keep="last")]
+        return new_df.sort_index()
+
     def gather_earnings_data(self):
         logger.info("Gathering earnings and sales data...")
         earnings_all_df = None
@@ -672,14 +718,17 @@ class MarketDataGatherer:
         logger.info(f"Earnings sample report for last ticker: \n{last_raw}")
         earnings_all_df.index.names = ["Symbol", "Date"]
         earnings_all_df = earnings_all_df.sort_index()
-        logger.info(
-            f"Total number of earnings records for all stocks: \n{len(earnings_all_df)}"
-        )
         earnings_file = self._data_file("earnings_calendar.parquet")
         # Remove broken symlink if present
         p = Path(earnings_file)
         if p.is_symlink() and not p.exists():
             p.unlink()
+        earnings_all_df = self._merge_symbol_date_parquet(
+            earnings_file, earnings_all_df
+        )
+        logger.info(
+            f"Total number of earnings records for all stocks: \n{len(earnings_all_df)}"
+        )
         earnings_all_df.to_parquet(earnings_file)
         tmp_earn_df = pd.read_parquet(earnings_file)
         pd.testing.assert_frame_equal(tmp_earn_df, earnings_all_df)
@@ -723,6 +772,9 @@ class MarketDataGatherer:
         p = Path(kms_file)
         if p.is_symlink() and not p.exists():
             p.unlink()
+        keymetrics_all_df = self._merge_symbol_date_parquet(
+            kms_file, keymetrics_all_df
+        )
         keymetrics_all_df.to_parquet(kms_file, engine="pyarrow")
         temp_kms_df = pd.read_parquet(kms_file)
         pd.testing.assert_frame_equal(temp_kms_df, keymetrics_all_df)
@@ -806,6 +858,20 @@ class MarketDataGatherer:
 
     def gather_institutional_stock_ownership(self):
         logger.info("Gathering institutional ownership data...")
+        inst_ownership_file = self._data_file("institutional_symbol_ownership.parquet")
+        old_df = None
+        try:
+            old_df = pd.read_parquet(inst_ownership_file)
+            if old_df is not None and not old_df.empty:
+                if list(old_df.index.names) != ["Symbol", "Date"]:
+                    old_df.index.names = ["Symbol", "Date"]
+                logger.info(
+                    f"Loaded existing ownership for "
+                    f"{old_df.index.get_level_values(0).nunique()} symbols"
+                )
+        except Exception as e:
+            logger.info(f"No existing institutional ownership file ({e})")
+
         inst_ownership_all_df = None
         for ticker in self.stocks_ticker_set:
             inst_ownership = institutional_symbol_ownership(
@@ -814,12 +880,15 @@ class MarketDataGatherer:
                 limit=-1,
                 includeCurrentQuarter=False,
             )
-            # logger.info("inst_ownership: ", inst_ownership)
             if inst_ownership is not None and len(inst_ownership) > 0:
                 inst_ownership_df = pd.DataFrame(inst_ownership)
                 inst_ownership_df["date"] = pd.to_datetime(inst_ownership_df["date"])
+                # normalize symbol casing for MultiIndex join
+                if "symbol" in inst_ownership_df.columns:
+                    inst_ownership_df["symbol"] = (
+                        inst_ownership_df["symbol"].astype(str).str.upper()
+                    )
                 inst_ownership_df = inst_ownership_df.set_index(["symbol", "date"])
-                # logger.info(f"Institutional ownership for {ticker} # columns: \n{len(inst_ownership_df.columns)}")
                 n_iown = len(inst_ownership_df)
                 logger.info(
                     f"Total institutional ownership reports for {ticker}: {n_iown}"
@@ -827,68 +896,67 @@ class MarketDataGatherer:
                 inst_ownership_all_df = pd.concat(
                     [inst_ownership_all_df, inst_ownership_df]
                 )
-                # logger.info(f"Institutional ownership concatenated {ticker} # columns: \n{inst_ownership_all_df.columns}")
             else:
                 logger.info(
-                    f"No {ticker} institutional ownership reports: inst_ownership={inst_ownership}"
+                    f"No {ticker} institutional ownership reports: "
+                    f"inst_ownership={inst_ownership}"
                 )
+
+        if inst_ownership_all_df is None or inst_ownership_all_df.empty:
+            if old_df is not None and not old_df.empty:
+                logger.warning(
+                    "No new institutional ownership fetched; keeping existing file"
+                )
+                return
+            logger.warning("No institutional ownership data gathered")
+            return
+
         inst_own_df = inst_ownership_all_df.copy()
         # prevent parquet serialization issues
-        inst_own_df["totalInvestedChange"] = pd.to_numeric(
-            inst_own_df["totalInvestedChange"],
-            dtype_backend="pyarrow",
-            downcast="integer",
-        )
+        if "totalInvestedChange" in inst_own_df.columns:
+            inst_own_df["totalInvestedChange"] = pd.to_numeric(
+                inst_own_df["totalInvestedChange"],
+                errors="coerce",
+            ).fillna(0)
 
-        def find_bad_cell():
-            for index, row in inst_own_df.iterrows():
-                try:
-                    x = row["totalPutsChange"]
-                    assert isinstance(x, int)
-                except Exception as e:
-                    logger.info(
-                        f"Unable to convert to numeric type value:({x}), type({type(x)}), index({index}, \nerror:{e}\nrow:{row})"
-                    )
-                    break
-
-        find_bad_cell()
-        # type(inst_own_df["totalInvestedChange"][0])
         # clean up bad data from the third party source feed
-        inst_own_df["totalInvestedChange"] = inst_own_df["totalInvestedChange"].astype(
-            "float64"
-        )
-        inst_own_df["totalInvestedChange"] = inst_own_df["totalInvestedChange"].astype(
-            "int64"
-        )
-        inst_own_df["cik"] = inst_own_df["cik"].replace("", -1)
-        inst_own_df["cik"] = inst_own_df["cik"].astype("int64")
-        inst_own_df["totalPutsChange"] = inst_own_df["totalPutsChange"].astype(
-            "float64"
-        )
-        inst_own_df["totalPutsChange"] = inst_own_df["totalPutsChange"].astype("int64")
-        # inst_own_df["totalPutsChange"] = pd.to_numeric(inst_own_df["totalPutsChange"], dtype_backend="pyarrow", downcast = 'integer')
-        inst_own_df["totalCallsChange"] = inst_own_df["totalCallsChange"].astype(
-            "float64"
-        )
-        inst_own_df["totalCallsChange"] = inst_own_df["totalCallsChange"].astype(
-            "int64"
-        )
-        # inst_own_df.dtypes
-        # inst_own_df
-        inst_own_df.index.names = ["Symbol", "Date"]
-        inst_own_df = inst_own_df.sort_index()
-        # inst_own_df.index.names
-        inst_ownership_file = (
-            self._data_file("institutional_symbol_ownership.parquet")
-        )
-        inst_own_df.to_parquet(inst_ownership_file, engine="pyarrow")
+        for col, default in (
+            ("totalInvestedChange", 0),
+            ("totalPutsChange", 0),
+            ("totalCallsChange", 0),
+            ("cik", -1),
+        ):
+            if col not in inst_own_df.columns:
+                continue
+            if col == "cik":
+                inst_own_df[col] = inst_own_df[col].replace("", -1)
+            inst_own_df[col] = (
+                pd.to_numeric(inst_own_df[col], errors="coerce")
+                .fillna(default)
+                .astype("int64")
+            )
 
-        ### Read back data and verify it
+        inst_own_df.index.names = ["Symbol", "Date"]
+        # Merge with existing so scoped gather does not wipe other symbols
+        if old_df is not None and not old_df.empty:
+            # Drop old rows for symbols we just refreshed
+            refreshed = set(inst_own_df.index.get_level_values(0).astype(str).str.upper())
+            keep = old_df[
+                ~old_df.index.get_level_values(0)
+                .astype(str)
+                .str.upper()
+                .isin(refreshed)
+            ]
+            inst_own_df = pd.concat([keep, inst_own_df], axis=0)
+        inst_own_df = inst_own_df[~inst_own_df.index.duplicated(keep="last")]
+        inst_own_df = inst_own_df.sort_index()
+
+        inst_own_df.to_parquet(inst_ownership_file, engine="pyarrow")
         tmp_int_own_df = pd.read_parquet(inst_ownership_file)
-        logger.info(f"tmp_int_own_df: \n{tmp_int_own_df}")
         pd.testing.assert_frame_equal(tmp_int_own_df, inst_own_df)
         logger.info(
-            f"Sanity check passed for institutional ownership data. Loaded OK from file: {inst_ownership_file}"
+            f"Saved institutional ownership to {inst_ownership_file} "
+            f"({inst_own_df.index.get_level_values(0).nunique()} symbols)"
         )
 
     def gather_analyst_estimates(self):
@@ -938,12 +1006,12 @@ class MarketDataGatherer:
                 continue
             estimates_all_df.index.names = ["Symbol", "Date"]
             estimates_all_df = estimates_all_df.sort_index()
-            # est_file_name= f'data/analyst_estimates_{p}.csv.bz2'
-            # estimates_all_df.to_csv(est_file_name)
+            estimates_all_df = self._merge_symbol_date_parquet(
+                est_file_name, estimates_all_df
+            )
             estimates_all_df.to_parquet(est_file_name)
             logger.info(f"Saved analyst estimates to: {est_file_name}")
             logger.info(f"all {p} estimates count: {len(estimates_all_df)}")
-            # logger.info(f"{p} estimates sample:\n{estimates_all_df}")
             tmp_est_df = pd.read_parquet(est_file_name)
             pd.testing.assert_frame_equal(tmp_est_df, estimates_all_df)
             logger.info(

--- a/src/canswim/gather_data.py
+++ b/src/canswim/gather_data.py
@@ -96,8 +96,14 @@ class MarketDataGatherer:
         self.min_start_date = os.getenv("train_date_start", "1991-01-01")
         # Optional scope: gather only tickers from this CSV (under symbol_lists/)
         self.stock_tickers_list = os.getenv("stock_tickers_list")
+        # "train" = long history; "forecast" = ~2y missing-only (scoped GUI/MCP/CLI)
+        self.gather_mode = os.getenv("gather_mode", "train").strip().lower()
+        if self.gather_mode not in ("train", "forecast"):
+            self.gather_mode = "train"
         # Never use multi-GB SQLite yfinance cache unless explicitly enabled
         self.use_yfinance_cache = _env_bool("YFINANCE_USE_CACHE", default=False)
+        # Last per-symbol fetch plan (for tests / result reporting)
+        self.last_price_fetch_plans = []
 
     def _yfinance_session(self):
         """Rate-limited session. Avoids SQLite cache hang by default.
@@ -411,14 +417,23 @@ class MarketDataGatherer:
             new_df = new_df.dropna(subset=ohlcv, how="any")
         return new_df
 
-    def _fetch_stock_prices_fmp(self, start_date) -> pd.DataFrame:
-        """Fallback when yfinance is empty/rate-limited: FMP historical-price-full."""
+    def _fetch_stock_prices_fmp(
+        self, start_date, tickers=None, per_symbol_start=None
+    ) -> pd.DataFrame:
+        """Fallback when yfinance is empty/rate-limited: FMP historical-price-full.
+
+        ``per_symbol_start`` maps symbol → ISO start (missing-only). When set,
+        each ticker uses its own from_date instead of the shared ``start_date``.
+        """
         if not self.FMP_API_KEY:
             logger.warning("FMP_API_KEY missing; cannot fallback stock prices via FMP")
             return pd.DataFrame()
-        from_date = pd.Timestamp(start_date).strftime("%Y-%m-%d")
+        default_from = pd.Timestamp(start_date).strftime("%Y-%m-%d")
         frames = []
-        for ticker in sorted(self.stocks_ticker_set):
+        symbols = sorted(tickers if tickers is not None else self.stocks_ticker_set)
+        per = per_symbol_start or {}
+        for ticker in symbols:
+            from_date = per.get(ticker, default_from)
             try:
                 # fmpsdk historical_price_full(symbol, from_date=..., to_date=...)
                 records = fmpsdk.historical_price_full(
@@ -448,39 +463,78 @@ class MarketDataGatherer:
         return out
 
     def gather_stock_price_data(self):
+        """Refresh stock OHLCV parquet with missing-only remote calls when possible.
+
+        * ``gather_mode=forecast`` (scoped runs): ~2y window; skip symbols that
+          already have complete, fresh local history; otherwise fetch only the
+          missing/stale range.
+        * ``gather_mode=train``: long history from ``train_date_start``.
+        """
+        from canswim.gather_policy import (
+            aggregate_fetch_start,
+            plan_stock_price_fetches,
+        )
+
         data_file = self._data_file(
             f"all_stocks_price_hist_{self.price_frequency}.parquet"
         )
-        start_date = self.min_start_date
+        mode = "forecast" if self.gather_mode == "forecast" else "train"
         old_df = None
         try:
             old_df = pd.read_parquet(data_file)
             logger.info("Loaded saved data. Sample: \n{df}", df=old_df)
-            all_tickers = set(self.stocks_ticker_set)
-            old_tickers = set(old_df.index.get_level_values("Symbol"))
-            new_tickers = all_tickers - old_tickers
-            if not new_tickers:
-                start_date = get_latest_date(
-                    old_df.index.get_level_values("Date")
-                ) - pd.Timedelta(1, "d")
-                logger.info(f"Columns: \n{old_df.columns}")
-                logger.info(f"Latest saved record is after {start_date}")
-            else:
-                logger.info(
-                    f"Not all tickers found in saved data. Missing: {new_tickers}"
-                )
         except Exception as e:
             logger.warning(f"Could not load data from file: {data_file}. Error: {e}")
+
+        tickers = list(self.stocks_ticker_set)
+        plans = plan_stock_price_fetches(
+            tickers,
+            old_df,
+            mode=mode,
+            train_min_start=self.min_start_date,
+        )
+        self.last_price_fetch_plans = plans
+        to_fetch = [p for p in plans if p.action == "fetch"]
+        skipped = [p for p in plans if p.action == "skip"]
+        for p in plans:
+            logger.info(
+                f"Price plan {p.symbol}: {p.action} "
+                f"start={p.fetch_start} ({p.reason})"
+            )
+        if skipped:
+            logger.info(
+                f"Skipping remote price fetch for {len(skipped)} symbol(s) "
+                f"with complete local history: {[p.symbol for p in skipped]}"
+            )
+        if not to_fetch:
+            if old_df is None or old_df.empty:
+                raise RuntimeError("No stock price data gathered; aborting")
+            logger.info("All requested symbols already covered locally; no remote call")
+            return
+
+        per_start = {p.symbol: p.fetch_start for p in to_fetch if p.fetch_start}
+        start_date = aggregate_fetch_start(to_fetch) or self.min_start_date
+        fetch_syms = [p.symbol for p in to_fetch]
 
         # Prefer FMP for stock OHLCV when key is present (reliable under yfinance
         # rate limits); fall back to yfinance if FMP returns nothing.
         new_df = pd.DataFrame()
         if self.FMP_API_KEY:
             logger.info(
-                f"Gathering stock prices via FMP historical-price-full for "
-                f"{len(self.stocks_ticker_set)} tickers from {start_date}"
+                f"Gathering stock prices via FMP for {len(fetch_syms)} tickers "
+                f"(mode={mode}, earliest start={start_date})"
             )
-            new_df = self._fetch_stock_prices_fmp(start_date=start_date)
+            # Temporarily restrict set for yfinance fallback path consistency
+            prev_set = self.stocks_ticker_set
+            self.stocks_ticker_set = fetch_syms
+            try:
+                new_df = self._fetch_stock_prices_fmp(
+                    start_date=start_date,
+                    tickers=fetch_syms,
+                    per_symbol_start=per_start,
+                )
+            finally:
+                self.stocks_ticker_set = prev_set
             if not new_df.empty:
                 logger.info(
                     f"FMP stock prices returned {len(new_df)} bars for "
@@ -488,13 +542,20 @@ class MarketDataGatherer:
                 )
         if new_df is None or new_df.empty:
             logger.info(
-                f"Gathering stock prices via yfinance for {len(self.stocks_ticker_set)} "
+                f"Gathering stock prices via yfinance for {len(fetch_syms)} "
                 f"tickers from {start_date}"
             )
-            new_df = self._fetch_stock_prices_yfinance(start_date=start_date)
+            prev_set = self.stocks_ticker_set
+            self.stocks_ticker_set = fetch_syms
+            try:
+                new_df = self._fetch_stock_prices_yfinance(start_date=start_date)
+            finally:
+                self.stocks_ticker_set = prev_set
             if new_df is None or new_df.empty:
                 logger.warning("yfinance stock prices empty/failed after FMP miss")
-        logger.info(f"Stock price data index: {new_df.index.names if not new_df.empty else None}")
+        logger.info(
+            f"Stock price data index: {new_df.index.names if not new_df.empty else None}"
+        )
         logger.info("New data gathered. Sample: \n{df}", df=new_df)
         if old_df is not None and not new_df.empty:
             cols = [c for c in old_df.columns if c in new_df.columns]

--- a/src/canswim/gather_data.py
+++ b/src/canswim/gather_data.py
@@ -466,12 +466,14 @@ class MarketDataGatherer:
         """Refresh stock OHLCV parquet with missing-only remote calls when possible.
 
         * ``gather_mode=forecast`` (scoped runs): ~2y window; skip symbols that
-          already have complete, fresh local history; otherwise fetch only the
-          missing/stale range.
+          already have complete, full-window, fresh local history; otherwise fetch
+          only the missing/stale range. After remote attempt, re-check coverage
+          and raise if any requested symbol is still incomplete.
         * ``gather_mode=train``: long history from ``train_date_start``.
         """
         from canswim.gather_policy import (
             aggregate_fetch_start,
+            evaluate_symbol_coverage,
             plan_stock_price_fetches,
         )
 
@@ -494,6 +496,7 @@ class MarketDataGatherer:
             train_min_start=self.min_start_date,
         )
         self.last_price_fetch_plans = plans
+        self.last_remote_symbols_written = []
         to_fetch = [p for p in plans if p.action == "fetch"]
         skipped = [p for p in plans if p.action == "skip"]
         for p in plans:
@@ -509,6 +512,20 @@ class MarketDataGatherer:
         if not to_fetch:
             if old_df is None or old_df.empty:
                 raise RuntimeError("No stock price data gathered; aborting")
+            # Still verify all requested symbols are complete
+            cov = evaluate_symbol_coverage(
+                tickers,
+                old_df,
+                mode=mode,
+                train_min_start=self.min_start_date,
+            )
+            self.last_post_fetch_plans = cov["plans"]
+            if not cov["ok"]:
+                raise RuntimeError(
+                    "Market history is incomplete for: "
+                    f"{', '.join(cov['incomplete'])}. "
+                    "Could not skip remote fetch and local data is insufficient."
+                )
             logger.info("All requested symbols already covered locally; no remote call")
             return
 
@@ -524,7 +541,6 @@ class MarketDataGatherer:
                 f"Gathering stock prices via FMP for {len(fetch_syms)} tickers "
                 f"(mode={mode}, earliest start={start_date})"
             )
-            # Temporarily restrict set for yfinance fallback path consistency
             prev_set = self.stocks_ticker_set
             self.stocks_ticker_set = fetch_syms
             try:
@@ -557,7 +573,21 @@ class MarketDataGatherer:
             f"Stock price data index: {new_df.index.names if not new_df.empty else None}"
         )
         logger.info("New data gathered. Sample: \n{df}", df=new_df)
-        if old_df is not None and not new_df.empty:
+
+        written: list[str] = []
+        if new_df is not None and not new_df.empty:
+            try:
+                written = sorted(
+                    {
+                        str(s).upper()
+                        for s in new_df.index.get_level_values("Symbol").unique()
+                    }
+                )
+            except Exception:
+                written = []
+        self.last_remote_symbols_written = written
+
+        if old_df is not None and new_df is not None and not new_df.empty:
             cols = [c for c in old_df.columns if c in new_df.columns]
             if not cols:
                 cols = list(new_df.columns)
@@ -571,9 +601,36 @@ class MarketDataGatherer:
             )
             merged_df = merged_df[~merged_df.index.duplicated(keep="last")]
         else:
-            merged_df = new_df if not new_df.empty else old_df
+            merged_df = new_df if new_df is not None and not new_df.empty else old_df
+
         if merged_df is None or merged_df.empty:
-            raise RuntimeError("No stock price data gathered; aborting")
+            raise RuntimeError(
+                "No stock price data gathered; remote returned empty and no local "
+                f"history for: {', '.join(fetch_syms)}"
+            )
+
+        # Scoped forecast gather: fail if any planned fetch symbol is still incomplete
+        cov = evaluate_symbol_coverage(
+            tickers,
+            merged_df,
+            mode=mode,
+            train_min_start=self.min_start_date,
+        )
+        self.last_post_fetch_plans = cov["plans"]
+        still_bad = cov["incomplete"]
+        if still_bad:
+            # Do not silently keep old_df as success when requested symbols failed
+            if mode == "forecast":
+                raise RuntimeError(
+                    "Could not obtain complete market history for: "
+                    f"{', '.join(still_bad)}. "
+                    "Remote download returned no usable bars for those symbols. "
+                    "Check the symbol and try again later (rate limits / API keys)."
+                )
+            logger.warning(
+                f"Train gather: still incomplete after fetch: {still_bad}"
+            )
+
         assert merged_df.index.is_unique
         Path(data_file).parent.mkdir(parents=True, exist_ok=True)
         merged_df.to_parquet(data_file)

--- a/src/canswim/gather_policy.py
+++ b/src/canswim/gather_policy.py
@@ -4,8 +4,9 @@ Forecast-scoped gathers (GUI / MCP / CLI ``--tickers``) only need about the last
 **two years** of history—enough for model lookback + horizon—not multi-decade
 training archives. Train-mode gathers still use the long ``train_date_start``.
 
-Decisions never invent prices: if local history is short or gappy, we plan a
-remote fetch for the missing window; if coverage is complete and fresh, we skip.
+Skip is allowed only when local history **covers the full required window**
+(first bar near window start, enough eligible bars, and recent enough).
+Partial tails (e.g. 350 bars starting mid-window) must still fetch.
 """
 
 from __future__ import annotations
@@ -26,6 +27,12 @@ FORECAST_LOOKBACK_YEARS = 2
 DEFAULT_FRESHNESS_DAYS = 5
 # Minimum complete OHLCV bars for forecast-only path (252+42+42) with small pad
 DEFAULT_FORECAST_MIN_BARS = 350
+# Train needs long history before we skip remote (not the same as forecast)
+DEFAULT_TRAIN_MIN_BARS = 1500
+# First bar may lag window_start by weekends/holidays only
+DEFAULT_MAX_WINDOW_START_LAG_DAYS = 10
+# Train: allow a slightly larger lag after train_date_start (NYSE holidays)
+DEFAULT_TRAIN_MAX_START_LAG_DAYS = 14
 
 
 def _ts(d: Optional[DateLike] = None) -> pd.Timestamp:
@@ -62,6 +69,15 @@ class SymbolFetchPlan:
             "reason": self.reason,
         }
 
+    @property
+    def is_incomplete(self) -> bool:
+        """True if local data is missing or insufficient (not merely stale)."""
+        if self.action == "skip":
+            return False
+        if self.reason == "local_complete_but_stale":
+            return False
+        return True
+
 
 def _symbol_ohlcv(
     price_df: Optional[pd.DataFrame],
@@ -94,6 +110,13 @@ def _symbol_ohlcv(
         return None
 
 
+def _ohlcv_cols(df: pd.DataFrame) -> tuple[str, ...]:
+    cols = tuple(c for c in PRICE_OHLCV_COLS if c in df.columns)
+    if len(cols) >= 5:
+        return cols
+    return PRICE_OHLCV_COLS
+
+
 def plan_symbol_price_fetch(
     symbol: str,
     price_df: Optional[pd.DataFrame],
@@ -101,52 +124,94 @@ def plan_symbol_price_fetch(
     mode: Literal["forecast", "train"] = "forecast",
     asof: Optional[DateLike] = None,
     train_min_start: DateLike = "1991-01-01",
-    min_bars: int = DEFAULT_FORECAST_MIN_BARS,
+    min_bars: Optional[int] = None,
     freshness_days: int = DEFAULT_FRESHNESS_DAYS,
     lookback_years: int = FORECAST_LOOKBACK_YEARS,
+    max_window_start_lag_days: Optional[int] = None,
 ) -> SymbolFetchPlan:
-    """Decide skip vs remote fetch start for one symbol (pure)."""
+    """Decide skip vs remote fetch start for one symbol (pure).
+
+    Skip only when:
+    - history covers from near *window_start* through asof (not a late-starting tail),
+    - enough eligible bars for the mode,
+    - last bar is fresh enough.
+    """
     sym = str(symbol).strip().upper()
     asof_ts = _ts(asof)
     if mode == "train":
         window_start = train_window_start(train_min_start)
+        need_bars = (
+            int(min_bars)
+            if min_bars is not None
+            else DEFAULT_TRAIN_MIN_BARS
+        )
+        start_lag = (
+            int(max_window_start_lag_days)
+            if max_window_start_lag_days is not None
+            else DEFAULT_TRAIN_MAX_START_LAG_DAYS
+        )
+        hist_for_check = None  # set below from full series in window
     else:
         window_start = forecast_window_start(asof=asof_ts, years=lookback_years)
+        need_bars = (
+            int(min_bars)
+            if min_bars is not None
+            else DEFAULT_FORECAST_MIN_BARS
+        )
+        start_lag = (
+            int(max_window_start_lag_days)
+            if max_window_start_lag_days is not None
+            else DEFAULT_MAX_WINDOW_START_LAG_DAYS
+        )
 
+    window_iso = window_start.strftime("%Y-%m-%d")
     sub = _symbol_ohlcv(price_df, sym)
     if sub is None or sub.empty:
         return SymbolFetchPlan(
             symbol=sym,
             action="fetch",
-            fetch_start=window_start.strftime("%Y-%m-%d"),
+            fetch_start=window_iso,
             reason="missing_local_symbol",
         )
 
-    # Restrict to window for forecast mode eligibility
     in_window = sub[sub.index >= window_start]
     if in_window.empty:
         return SymbolFetchPlan(
             symbol=sym,
             action="fetch",
-            fetch_start=window_start.strftime("%Y-%m-%d"),
+            fetch_start=window_iso,
             reason="no_bars_in_window",
         )
 
+    first = pd.Timestamp(in_window.index.min()).normalize()
+    last = pd.Timestamp(in_window.index.max()).normalize()
+    # Must reach back to the start of the required window (not a mid-window tail)
+    if first > window_start + pd.Timedelta(days=start_lag):
+        return SymbolFetchPlan(
+            symbol=sym,
+            action="fetch",
+            fetch_start=window_iso,
+            reason=(
+                f"window_starts_late:first={first.strftime('%Y-%m-%d')}"
+                f",need_near={window_iso}"
+            ),
+        )
+
+    cols = _ohlcv_cols(in_window)
     ok, why = price_history_is_eligible(
-        in_window if mode == "forecast" else sub,
-        min_samples=min_bars if mode == "forecast" else min_bars,
-        required_cols=tuple(c for c in PRICE_OHLCV_COLS if c in in_window.columns)
-        or PRICE_OHLCV_COLS,
+        in_window,
+        min_samples=need_bars,
+        required_cols=cols,
     )
-    # If column names differ slightly, try with whatever OHLCV-like cols exist
     if not ok and "missing columns" in why:
-        cols = [c for c in ("Open", "High", "Low", "Close", "Volume") if c in in_window.columns]
-        if len(cols) >= 5:
+        alt = tuple(
+            c for c in ("Open", "High", "Low", "Close", "Volume") if c in in_window.columns
+        )
+        if len(alt) >= 5:
             ok, why = price_history_is_eligible(
-                in_window, min_samples=min_bars, required_cols=tuple(cols)
+                in_window, min_samples=need_bars, required_cols=alt
             )
 
-    last = pd.Timestamp(in_window.index.max()).normalize()
     stale = (asof_ts - last).days > int(freshness_days)
 
     if ok and not stale:
@@ -158,7 +223,6 @@ def plan_symbol_price_fetch(
         )
 
     if ok and stale:
-        # Tail refresh only
         fetch_start = (last - pd.Timedelta(days=1)).strftime("%Y-%m-%d")
         return SymbolFetchPlan(
             symbol=sym,
@@ -167,11 +231,10 @@ def plan_symbol_price_fetch(
             reason="local_complete_but_stale",
         )
 
-    # Incomplete / gappy: re-pull from window start (forecast) or train min
     return SymbolFetchPlan(
         symbol=sym,
         action="fetch",
-        fetch_start=window_start.strftime("%Y-%m-%d"),
+        fetch_start=window_iso,
         reason=f"local_incomplete:{why}",
     )
 
@@ -183,7 +246,7 @@ def plan_stock_price_fetches(
     mode: Literal["forecast", "train"] = "forecast",
     asof: Optional[DateLike] = None,
     train_min_start: DateLike = "1991-01-01",
-    min_bars: int = DEFAULT_FORECAST_MIN_BARS,
+    min_bars: Optional[int] = None,
     freshness_days: int = DEFAULT_FRESHNESS_DAYS,
 ) -> list[SymbolFetchPlan]:
     """Plan per-symbol skip/fetch for a ticker list."""
@@ -207,3 +270,38 @@ def aggregate_fetch_start(plans: Sequence[SymbolFetchPlan]) -> Optional[str]:
     if not starts:
         return None
     return min(starts)
+
+
+def incomplete_symbols(plans: Sequence[SymbolFetchPlan]) -> list[str]:
+    """Symbols still missing or insufficient after planning (not mere staleness)."""
+    return [p.symbol for p in plans if p.is_incomplete]
+
+
+def evaluate_symbol_coverage(
+    tickers: Sequence[str],
+    price_df: Optional[pd.DataFrame],
+    *,
+    mode: Literal["forecast", "train"] = "forecast",
+    asof: Optional[DateLike] = None,
+    train_min_start: DateLike = "1991-01-01",
+) -> dict:
+    """Post-fetch (or any-time) coverage report for requested tickers."""
+    plans = plan_stock_price_fetches(
+        tickers,
+        price_df,
+        mode=mode,
+        asof=asof,
+        train_min_start=train_min_start,
+    )
+    incomplete = incomplete_symbols(plans)
+    skipped = [p.symbol for p in plans if p.action == "skip"]
+    stale_only = [
+        p.symbol for p in plans if p.reason == "local_complete_but_stale"
+    ]
+    return {
+        "plans": plans,
+        "incomplete": incomplete,
+        "skipped": skipped,
+        "stale_only": stale_only,
+        "ok": len(incomplete) == 0,
+    }

--- a/src/canswim/gather_policy.py
+++ b/src/canswim/gather_policy.py
@@ -1,0 +1,209 @@
+"""Pure decisions for lean, missing-only market data gathers (no network).
+
+Forecast-scoped gathers (GUI / MCP / CLI ``--tickers``) only need about the last
+**two years** of history—enough for model lookback + horizon—not multi-decade
+training archives. Train-mode gathers still use the long ``train_date_start``.
+
+Decisions never invent prices: if local history is short or gappy, we plan a
+remote fetch for the missing window; if coverage is complete and fresh, we skip.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime
+from typing import Literal, Optional, Sequence, Union
+
+import pandas as pd
+
+from canswim.eligibility import PRICE_OHLCV_COLS, price_history_is_eligible
+
+DateLike = Union[str, date, datetime, pd.Timestamp]
+
+# ~2 calendar years of sessions; enough for input_chunk(252)+horizons with margin
+FORECAST_LOOKBACK_YEARS = 2
+# Treat local prices as fresh if last bar is within this many calendar days of asof
+DEFAULT_FRESHNESS_DAYS = 5
+# Minimum complete OHLCV bars for forecast-only path (252+42+42) with small pad
+DEFAULT_FORECAST_MIN_BARS = 350
+
+
+def _ts(d: Optional[DateLike] = None) -> pd.Timestamp:
+    if d is None:
+        return pd.Timestamp.now().normalize()
+    return pd.Timestamp(d).tz_localize(None).normalize()
+
+
+def forecast_window_start(
+    *,
+    asof: Optional[DateLike] = None,
+    years: int = FORECAST_LOOKBACK_YEARS,
+) -> pd.Timestamp:
+    """Earliest date needed for a forecast-scoped gather."""
+    return _ts(asof) - pd.DateOffset(years=int(years))
+
+
+def train_window_start(min_start: DateLike = "1991-01-01") -> pd.Timestamp:
+    return _ts(min_start)
+
+
+@dataclass(frozen=True)
+class SymbolFetchPlan:
+    symbol: str
+    action: Literal["skip", "fetch"]
+    fetch_start: Optional[str]  # ISO date when action=fetch
+    reason: str
+
+    def as_dict(self) -> dict:
+        return {
+            "symbol": self.symbol,
+            "action": self.action,
+            "fetch_start": self.fetch_start,
+            "reason": self.reason,
+        }
+
+
+def _symbol_ohlcv(
+    price_df: Optional[pd.DataFrame],
+    symbol: str,
+) -> Optional[pd.DataFrame]:
+    """Extract single-symbol OHLCV with DatetimeIndex from multi-index parquet."""
+    if price_df is None or price_df.empty:
+        return None
+    sym = symbol.upper()
+    try:
+        if isinstance(price_df.index, pd.MultiIndex):
+            names = [str(n).lower() if n is not None else "" for n in price_df.index.names]
+            # Common: (Symbol, Date) or (Date, Symbol)
+            if "symbol" in names:
+                si = names.index("symbol")
+                level = price_df.index.names[si]
+                sub = price_df.xs(sym, level=level, drop_level=True)
+            else:
+                # assume level 0 is symbol
+                if sym not in price_df.index.get_level_values(0):
+                    return None
+                sub = price_df.loc[sym]
+            if not isinstance(sub.index, pd.DatetimeIndex):
+                sub = sub.copy()
+                sub.index = pd.to_datetime(sub.index)
+            return sub.sort_index()
+        # wide format fallback
+        return None
+    except (KeyError, TypeError, ValueError):
+        return None
+
+
+def plan_symbol_price_fetch(
+    symbol: str,
+    price_df: Optional[pd.DataFrame],
+    *,
+    mode: Literal["forecast", "train"] = "forecast",
+    asof: Optional[DateLike] = None,
+    train_min_start: DateLike = "1991-01-01",
+    min_bars: int = DEFAULT_FORECAST_MIN_BARS,
+    freshness_days: int = DEFAULT_FRESHNESS_DAYS,
+    lookback_years: int = FORECAST_LOOKBACK_YEARS,
+) -> SymbolFetchPlan:
+    """Decide skip vs remote fetch start for one symbol (pure)."""
+    sym = str(symbol).strip().upper()
+    asof_ts = _ts(asof)
+    if mode == "train":
+        window_start = train_window_start(train_min_start)
+    else:
+        window_start = forecast_window_start(asof=asof_ts, years=lookback_years)
+
+    sub = _symbol_ohlcv(price_df, sym)
+    if sub is None or sub.empty:
+        return SymbolFetchPlan(
+            symbol=sym,
+            action="fetch",
+            fetch_start=window_start.strftime("%Y-%m-%d"),
+            reason="missing_local_symbol",
+        )
+
+    # Restrict to window for forecast mode eligibility
+    in_window = sub[sub.index >= window_start]
+    if in_window.empty:
+        return SymbolFetchPlan(
+            symbol=sym,
+            action="fetch",
+            fetch_start=window_start.strftime("%Y-%m-%d"),
+            reason="no_bars_in_window",
+        )
+
+    ok, why = price_history_is_eligible(
+        in_window if mode == "forecast" else sub,
+        min_samples=min_bars if mode == "forecast" else min_bars,
+        required_cols=tuple(c for c in PRICE_OHLCV_COLS if c in in_window.columns)
+        or PRICE_OHLCV_COLS,
+    )
+    # If column names differ slightly, try with whatever OHLCV-like cols exist
+    if not ok and "missing columns" in why:
+        cols = [c for c in ("Open", "High", "Low", "Close", "Volume") if c in in_window.columns]
+        if len(cols) >= 5:
+            ok, why = price_history_is_eligible(
+                in_window, min_samples=min_bars, required_cols=tuple(cols)
+            )
+
+    last = pd.Timestamp(in_window.index.max()).normalize()
+    stale = (asof_ts - last).days > int(freshness_days)
+
+    if ok and not stale:
+        return SymbolFetchPlan(
+            symbol=sym,
+            action="skip",
+            fetch_start=None,
+            reason="local_complete_and_fresh",
+        )
+
+    if ok and stale:
+        # Tail refresh only
+        fetch_start = (last - pd.Timedelta(days=1)).strftime("%Y-%m-%d")
+        return SymbolFetchPlan(
+            symbol=sym,
+            action="fetch",
+            fetch_start=fetch_start,
+            reason="local_complete_but_stale",
+        )
+
+    # Incomplete / gappy: re-pull from window start (forecast) or train min
+    return SymbolFetchPlan(
+        symbol=sym,
+        action="fetch",
+        fetch_start=window_start.strftime("%Y-%m-%d"),
+        reason=f"local_incomplete:{why}",
+    )
+
+
+def plan_stock_price_fetches(
+    tickers: Sequence[str],
+    price_df: Optional[pd.DataFrame],
+    *,
+    mode: Literal["forecast", "train"] = "forecast",
+    asof: Optional[DateLike] = None,
+    train_min_start: DateLike = "1991-01-01",
+    min_bars: int = DEFAULT_FORECAST_MIN_BARS,
+    freshness_days: int = DEFAULT_FRESHNESS_DAYS,
+) -> list[SymbolFetchPlan]:
+    """Plan per-symbol skip/fetch for a ticker list."""
+    return [
+        plan_symbol_price_fetch(
+            t,
+            price_df,
+            mode=mode,
+            asof=asof,
+            train_min_start=train_min_start,
+            min_bars=min_bars,
+            freshness_days=freshness_days,
+        )
+        for t in tickers
+    ]
+
+
+def aggregate_fetch_start(plans: Sequence[SymbolFetchPlan]) -> Optional[str]:
+    """Earliest fetch_start among symbols that need a remote pull (or None if all skip)."""
+    starts = [p.fetch_start for p in plans if p.action == "fetch" and p.fetch_start]
+    if not starts:
+        return None
+    return min(starts)

--- a/src/canswim/mcp/server.py
+++ b/src/canswim/mcp/server.py
@@ -158,10 +158,11 @@ def run_select(sql: str, row_limit: int = 5000) -> dict[str, Any]:
 @mcp.tool(
     name="resolve_forecast_start",
     description=(
-        "Preview the week-aligned forecast start date. "
-        "Optional start_date (YYYY-MM-DD) is snapped to the market week start "
-        "on or before the pick; empty/today → live default after latest week-end close. "
-        "Read-only (always available)."
+        "Preview week-aligned forecast start (same policy as CLI resolve_start "
+        "and Dashboard Run → Preview start date). "
+        "Optional start_date YYYY-MM-DD: past → first NYSE session of that market week "
+        "(holiday Monday → next open that week); empty/today → live default after "
+        "latest week-end close. Read-only; always available."
     ),
 )
 def resolve_forecast_start(start_date: Optional[str] = None) -> dict[str, Any]:
@@ -172,6 +173,7 @@ def resolve_forecast_start(start_date: Optional[str] = None) -> dict[str, Any]:
     name="gather_tickers",
     description=(
         "Gather local market data for a ticker list (comma/newline separated). "
+        "Same orchestration as CLI `gatherdata --tickers` and Dashboard Run → Gather. "
         "Requires MCP_ALLOW_RUNS=1. Local-first (hfhub_sync off by default)."
     ),
 )
@@ -187,10 +189,11 @@ def gather_tickers(
 @mcp.tool(
     name="forecast_tickers",
     description=(
-        "Run TiDE forecast for a ticker list with week-aligned start date. "
+        "Run TiDE forecast for a ticker list with week-aligned start. "
+        "Same orchestration as CLI `forecast --tickers` and Dashboard Run → Forecast. "
         "Requires MCP_ALLOW_RUNS=1. May load torch and take minutes. "
-        "Optional start_date (YYYY-MM-DD); empty → live week-start default. "
-        "dry_run=true only resolves start and validates tickers."
+        "Optional start_date YYYY-MM-DD (shared snap/default policy). "
+        "dry_run=true → validate tickers + resolve start only (CLI: --dry_run)."
     ),
 )
 def forecast_tickers(

--- a/src/canswim/mcp/server.py
+++ b/src/canswim/mcp/server.py
@@ -158,11 +158,9 @@ def run_select(sql: str, row_limit: int = 5000) -> dict[str, Any]:
 @mcp.tool(
     name="resolve_forecast_start",
     description=(
-        "Preview week-aligned forecast start (same policy as CLI resolve_start "
-        "and Dashboard Run → Preview start date). "
-        "Optional start_date YYYY-MM-DD: past → first NYSE session of that market week "
-        "(holiday Monday → next open that week); empty/today → live default after "
-        "latest week-end close. Read-only; always available."
+        "Check which forecast start date will be used. "
+        "Optional start_date (YYYY-MM-DD); blank uses the default next market-week start. "
+        "Same as CLI resolve_start and dashboard “Check start date”. Read-only."
     ),
 )
 def resolve_forecast_start(start_date: Optional[str] = None) -> dict[str, Any]:
@@ -172,9 +170,10 @@ def resolve_forecast_start(start_date: Optional[str] = None) -> dict[str, Any]:
 @mcp.tool(
     name="gather_tickers",
     description=(
-        "Gather local market data for a ticker list (comma/newline separated). "
-        "Same orchestration as CLI `gatherdata --tickers` and Dashboard Run → Gather. "
-        "Requires MCP_ALLOW_RUNS=1. Local-first (hfhub_sync off by default)."
+        "Get / update market data for listed stock symbols (comma or newline separated). "
+        "Only downloads what is missing or out of date (~last 2 years for forecast use). "
+        "Same as CLI `gatherdata --tickers` and dashboard “Update market data”. "
+        "Requires MCP_ALLOW_RUNS=1."
     ),
 )
 def gather_tickers(
@@ -189,11 +188,11 @@ def gather_tickers(
 @mcp.tool(
     name="forecast_tickers",
     description=(
-        "Run TiDE forecast for a ticker list with week-aligned start. "
-        "Same orchestration as CLI `forecast --tickers` and Dashboard Run → Forecast. "
-        "Requires MCP_ALLOW_RUNS=1. May load torch and take minutes. "
-        "Optional start_date YYYY-MM-DD (shared snap/default policy). "
-        "dry_run=true → validate tickers + resolve start only (CLI: --dry_run)."
+        "Run a forecast for listed stock symbols. "
+        "Fails clearly if market history is incomplete—update market data first. "
+        "Same as CLI `forecast --tickers` and dashboard “Run forecast”. "
+        "Requires MCP_ALLOW_RUNS=1. May take several minutes. "
+        "Optional start_date (YYYY-MM-DD). dry_run=true only checks symbols and start date."
     ),
 )
 def forecast_tickers(

--- a/src/canswim/mcp/server.py
+++ b/src/canswim/mcp/server.py
@@ -1,8 +1,8 @@
 """CANSWIM MCP server entrypoint.
 
-READ-ONLY — exposes precomputed TiDE forecasts and market data from the local
-DuckDB search database used by the Gradio dashboard. Does not load the torch
-model or run train/gather/forecast tasks.
+Default is READ-ONLY — precomputed TiDE forecasts and market data from the
+local DuckDB search database. Optional write tools (gather/forecast) are
+registered for discoverability but require ``MCP_ALLOW_RUNS=1`` to execute.
 """
 
 from __future__ import annotations
@@ -18,11 +18,21 @@ from mcp.server.fastmcp import FastMCP  # noqa: E402
 
 from canswim.mcp import __version__ as SERVER_VERSION  # noqa: E402
 from canswim.mcp.tools import forecasts, meta, prices, query, tickers  # noqa: E402
+from canswim.mcp.tools import runs as run_tools  # noqa: E402
+from canswim.run_triggers import runs_allowed  # noqa: E402
 
-logger.warning(
-    "canswim-mcp starting in READ-ONLY MODE. "
-    "NOT FINANCIAL OR INVESTMENT ADVICE. USE AT YOUR OWN RISK."
-)
+if runs_allowed():
+    logger.warning(
+        "canswim-mcp starting with MCP_ALLOW_RUNS enabled "
+        "(gather/forecast tools may mutate local data and load torch). "
+        "NOT FINANCIAL OR INVESTMENT ADVICE. USE AT YOUR OWN RISK."
+    )
+else:
+    logger.warning(
+        "canswim-mcp starting in READ-ONLY MODE "
+        "(set MCP_ALLOW_RUNS=1 to enable gather/forecast triggers). "
+        "NOT FINANCIAL OR INVESTMENT ADVICE. USE AT YOUR OWN RISK."
+    )
 
 mcp: FastMCP = FastMCP("canswim-mcp")
 mcp._mcp_server.version = SERVER_VERSION
@@ -143,6 +153,54 @@ def get_backtest_error(
 )
 def run_select(sql: str, row_limit: int = 5000) -> dict[str, Any]:
     return query.run_select_impl(sql=sql, row_limit=row_limit)
+
+
+@mcp.tool(
+    name="resolve_forecast_start",
+    description=(
+        "Preview the week-aligned forecast start date. "
+        "Optional start_date (YYYY-MM-DD) is snapped to the market week start "
+        "on or before the pick; empty/today → live default after latest week-end close. "
+        "Read-only (always available)."
+    ),
+)
+def resolve_forecast_start(start_date: Optional[str] = None) -> dict[str, Any]:
+    return run_tools.resolve_forecast_start_impl(start_date=start_date)
+
+
+@mcp.tool(
+    name="gather_tickers",
+    description=(
+        "Gather local market data for a ticker list (comma/newline separated). "
+        "Requires MCP_ALLOW_RUNS=1. Local-first (hfhub_sync off by default)."
+    ),
+)
+def gather_tickers(
+    tickers: str,
+    include_covariates: bool = True,
+) -> dict[str, Any]:
+    return run_tools.gather_tickers_impl(
+        tickers=tickers, include_covariates=include_covariates
+    )
+
+
+@mcp.tool(
+    name="forecast_tickers",
+    description=(
+        "Run TiDE forecast for a ticker list with week-aligned start date. "
+        "Requires MCP_ALLOW_RUNS=1. May load torch and take minutes. "
+        "Optional start_date (YYYY-MM-DD); empty → live week-start default. "
+        "dry_run=true only resolves start and validates tickers."
+    ),
+)
+def forecast_tickers(
+    tickers: str,
+    start_date: Optional[str] = None,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    return run_tools.forecast_tickers_impl(
+        tickers=tickers, start_date=start_date, dry_run=dry_run
+    )
 
 
 def main() -> None:

--- a/src/canswim/mcp/tools/meta.py
+++ b/src/canswim/mcp/tools/meta.py
@@ -9,9 +9,11 @@ from typing import Any
 from canswim.db import SEARCH_TABLES, get_db_path, tables_present
 from canswim.mcp import __version__
 from canswim.mcp.tools._common import err_result, ok_result, resolve_db_path
+from canswim.run_triggers import runs_allowed
 
 
-TOOL_NAMES = [
+# Always-registered tools (read path + start-date preview)
+READ_TOOL_NAMES = [
     "health_check",
     "get_server_info",
     "list_tickers",
@@ -21,19 +23,30 @@ TOOL_NAMES = [
     "get_close_price",
     "get_backtest_error",
     "run_select",
+    "resolve_forecast_start",
 ]
+
+# Mutation tools (registered always for discoverability; gated at invoke time)
+WRITE_TOOL_NAMES = [
+    "gather_tickers",
+    "forecast_tickers",
+]
+
+TOOL_NAMES = READ_TOOL_NAMES + WRITE_TOOL_NAMES
 
 
 def health_check_impl() -> dict[str, Any]:
     db_path = resolve_db_path()
     exists = Path(db_path).is_file()
     ready = tables_present(db_path)
+    allow_runs = runs_allowed()
     payload = {
         "db_path": db_path,
         "db_file_exists": exists,
         "tables_ready": ready,
         "expected_tables": list(SEARCH_TABLES),
-        "is_read_only": True,
+        "is_read_only": not allow_runs,
+        "runs_allowed": allow_runs,
         "disclaimer": "NOT FINANCIAL OR INVESTMENT ADVICE. USE AT YOUR OWN RISK.",
     }
     if not ready:
@@ -45,18 +58,27 @@ def health_check_impl() -> dict[str, Any]:
 
 
 def get_server_info_impl() -> dict[str, Any]:
+    allow_runs = runs_allowed()
     return ok_result(
         {
             "name": "canswim-mcp",
             "version": __version__,
-            "is_read_only": True,
-            "model": "TiDE (precomputed forecasts only; model not loaded in MCP process)",
+            "is_read_only": not allow_runs,
+            "runs_allowed": allow_runs,
+            "model": (
+                "TiDE precomputed forecasts (read tools). "
+                "Write tools gather_tickers/forecast_tickers require MCP_ALLOW_RUNS=1 "
+                "and may load torch for forecast."
+            ),
             "db_path": get_db_path(),
             "tools": TOOL_NAMES,
+            "read_tools": READ_TOOL_NAMES,
+            "write_tools": WRITE_TOOL_NAMES,
             "env": {
                 "data_dir": os.getenv("data_dir", "data"),
                 "db_file": os.getenv("db_file", "local.duckdb"),
                 "MCP_INIT_DB": os.getenv("MCP_INIT_DB", ""),
+                "MCP_ALLOW_RUNS": os.getenv("MCP_ALLOW_RUNS", ""),
             },
             "disclaimer": "NOT FINANCIAL OR INVESTMENT ADVICE. USE AT YOUR OWN RISK.",
         }

--- a/src/canswim/mcp/tools/runs.py
+++ b/src/canswim/mcp/tools/runs.py
@@ -1,0 +1,82 @@
+"""Opt-in MCP tools to trigger gather / forecast runs."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from canswim.run_triggers import (
+    forecast_for_tickers,
+    gather_for_tickers,
+    parse_ticker_list,
+    require_runs_allowed,
+    resolve_start_for_run,
+    runs_allowed,
+)
+from canswim.mcp.tools._common import err_result, ok_result
+
+
+RUN_TOOL_NAMES = [
+    "resolve_forecast_start",
+    "gather_tickers",
+    "forecast_tickers",
+]
+
+
+def resolve_forecast_start_impl(
+    start_date: Optional[str] = None,
+) -> dict[str, Any]:
+    """Preview week-aligned start (read-only; always available)."""
+    info = resolve_start_for_run(start_date)
+    if info.get("ok"):
+        return ok_result(info)
+    return err_result(info.get("error") or "resolve failed", data=info)
+
+
+def gather_tickers_impl(
+    tickers: str,
+    include_covariates: bool = True,
+) -> dict[str, Any]:
+    blocked = require_runs_allowed()
+    if blocked is not None:
+        return err_result(blocked["error"], runs_allowed=False)
+
+    parsed = parse_ticker_list(tickers)
+    if not parsed["ok"]:
+        return err_result(parsed.get("error") or "bad tickers", data=parsed)
+
+    result = gather_for_tickers(
+        tickers,
+        include_covariates=include_covariates,
+        force_allow=False,
+    )
+    if result.get("ok"):
+        return ok_result(result)
+    return err_result(result.get("error") or "gather failed", data=result)
+
+
+def forecast_tickers_impl(
+    tickers: str,
+    start_date: Optional[str] = None,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    blocked = require_runs_allowed()
+    if blocked is not None:
+        return err_result(blocked["error"], runs_allowed=False)
+
+    parsed = parse_ticker_list(tickers)
+    if not parsed["ok"]:
+        return err_result(parsed.get("error") or "bad tickers", data=parsed)
+
+    result = forecast_for_tickers(
+        tickers,
+        forecast_start_date=start_date,
+        dry_run=dry_run,
+        force_allow=False,
+    )
+    if result.get("ok"):
+        return ok_result(result)
+    return err_result(result.get("error") or "forecast failed", data=result)
+
+
+def runs_enabled() -> bool:
+    return runs_allowed()

--- a/src/canswim/model.py
+++ b/src/canswim/model.py
@@ -705,7 +705,10 @@ class CanswimModel:
         self.hfhub.download_data(repo_id=repo_id)
 
     def load_data(
-        self, stock_tickers: List[str] = None, start_date: pd.Timestamp = None
+        self,
+        stock_tickers: List[str] = None,
+        start_date: pd.Timestamp = None,
+        min_samples: int = None,
     ):
         assert (
             self.torch_model is not None
@@ -734,9 +737,11 @@ class CanswimModel:
             f"Training loop stock subset has {len(self.stock_tickers)} tickers: ",
             self.stock_tickers,
         )
+        # Charting / forecast-scoped loads may pass a lower floor than full train min_samples
+        ms = self.min_samples if min_samples is None else int(min_samples)
         self.targets.load_data(
             stock_tickers=self.stock_tickers,
-            min_samples=self.min_samples,
+            min_samples=ms,
             start_date=start_date,
         )
         self.covariates.load_data(

--- a/src/canswim/run_triggers.py
+++ b/src/canswim/run_triggers.py
@@ -16,6 +16,7 @@ returns structured dicts consumed by all three surfaces.
 
 from __future__ import annotations
 
+import glob
 import os
 import re
 import tempfile
@@ -75,10 +76,66 @@ INCOMPLETE_DATA_MSG = (
     "Forecasts never invent missing prices."
 )
 
+ALREADY_FORECAST_MSG = (
+    "Forecast already on file for {symbols} (start {start}). "
+    "Skipped re-run to save time and avoid duplicate data."
+)
+
 RUNS_OPT_IN_HELP = (
     "MCP data/forecast tools need MCP_ALLOW_RUNS=1. "
     "CLI and the dashboard do not. MCP stays read-only by default."
 )
+
+# Default min rows in a saved forecast partition (= typical pred_horizon)
+DEFAULT_MIN_FORECAST_ROWS = 42
+
+
+def list_symbols_with_saved_forecast(
+    tickers: Sequence[str],
+    start_date: str,
+    *,
+    data_dir: Optional[str] = None,
+    forecast_subdir: Optional[str] = None,
+    min_horizon_rows: int = DEFAULT_MIN_FORECAST_ROWS,
+) -> set[str]:
+    """Return symbols that already have a complete forecast partition for start_date.
+
+    Lightweight (duckdb + parquet only) — no torch / model load. Used to skip
+    expensive re-forecasts for the same origin.
+    """
+    import duckdb
+
+    syms = sorted({str(t).strip().upper() for t in tickers if t and str(t).strip()})
+    if not syms:
+        return set()
+    data_dir = data_dir or os.getenv("data_dir", "data")
+    forecast_subdir = forecast_subdir or os.getenv("forecast_subdir", "forecast/")
+    fsd = pd.Timestamp(start_date).tz_localize(None).normalize()
+    y, m, d = int(fsd.year), int(fsd.month), int(fsd.day)
+    forecast_glob = f"{data_dir}/{forecast_subdir}**/*.parquet"
+    if not glob.glob(forecast_glob, recursive=True):
+        return set()
+    in_list = ", ".join("'" + s.replace("'", "''") + "'" for s in syms)
+    try:
+        df = duckdb.sql(
+            f"""--sql
+            SELECT upper(cast(symbol AS VARCHAR)) AS symbol, count(*) AS n
+            FROM read_parquet('{forecast_glob}', hive_partitioning = 1) AS f
+            WHERE upper(cast(f.symbol AS VARCHAR)) IN ({in_list})
+              AND forecast_start_year = {y}
+              AND forecast_start_month = {m}
+              AND forecast_start_day = {d}
+            GROUP BY 1
+            HAVING count(*) >= {int(min_horizon_rows)}
+            """
+        ).df()
+    except Exception as e:
+        logger.warning(f"Could not scan existing forecasts ({e}); will not skip")
+        return set()
+    if df is None or df.empty:
+        return set()
+    col = "symbol" if "symbol" in df.columns else df.columns[0]
+    return {str(s).upper() for s in df[col].tolist()}
 
 
 def parse_ticker_list(
@@ -449,7 +506,11 @@ def forecast_for_tickers(
         }
 
     resolved = start_info["start"]
+    messages: list[str] = list(parsed.get("messages") or [])
+    messages.append(f"Using start date {resolved}.")
+
     if dry_run:
+        already = list_symbols_with_saved_forecast(tickers, resolved)
         return {
             "ok": True,
             "dry_run": True,
@@ -458,32 +519,61 @@ def forecast_for_tickers(
             "resolved_start": start_info,
             "forecasted": [],
             "skipped": [],
-            "messages": ["Check only: no forecast model was run."],
+            "already_have_forecast": sorted(already),
+            "messages": [
+                "Check only: no forecast model was run.",
+                (
+                    ALREADY_FORECAST_MSG.format(
+                        symbols=", ".join(sorted(already)), start=resolved
+                    )
+                    if already
+                    else "No existing forecast found for this start; a full run would load the model."
+                ),
+            ],
         }
 
-    # Write a temporary symbol list and point stock_tickers_list at it
-    tmp_dir = Path(tempfile.mkdtemp(prefix="canswim_fc_"))
-    list_path = tmp_dir / "run_tickers.csv"
-    pd.DataFrame({"Symbol": tickers}).to_csv(list_path, index=False)
+    # --- Skip expensive model work when partitions already exist ---
+    already = list_symbols_with_saved_forecast(tickers, resolved)
+    to_run = [t for t in tickers if t not in already]
+    if already:
+        messages.append(
+            ALREADY_FORECAST_MSG.format(
+                symbols=", ".join(sorted(already)), start=resolved
+            )
+        )
+    if not to_run:
+        return {
+            "ok": True,
+            "tickers": tickers,
+            "rejected": parsed.get("rejected", []),
+            "resolved_start": start_info,
+            "forecasted": [],
+            "skipped": [],
+            "already_have_forecast": sorted(already),
+            "messages": messages,
+            "already_saved": True,
+            "model_loaded": False,
+        }
 
-    # CanswimForecaster reads data_dir/data-3rd-party/stock_tickers_list
+    messages.append(
+        f"Will forecast (not on file yet): {', '.join(to_run)}"
+    )
+
+    # Write a temporary symbol list and point stock_tickers_list at it
     data_dir = os.getenv("data_dir", "data")
     third = os.getenv("data-3rd-party", "data-3rd-party")
     dest_dir = Path(data_dir) / third
     dest_dir.mkdir(parents=True, exist_ok=True)
     dest_list = dest_dir / "run_tickers.csv"
-    pd.DataFrame({"Symbol": tickers}).to_csv(dest_list, index=False)
+    pd.DataFrame({"Symbol": to_run}).to_csv(dest_list, index=False)
 
     prev_list = os.environ.get("stock_tickers_list")
     os.environ["stock_tickers_list"] = "run_tickers.csv"
-    # Keep n_stocks large enough for the batch
     prev_n = os.environ.get("n_stocks")
-    os.environ["n_stocks"] = str(max(len(tickers), 1))
+    os.environ["n_stocks"] = str(max(len(to_run), 1))
 
     forecasted: list[str] = []
     skipped: list[str] = []
-    messages: list[str] = list(parsed.get("messages") or [])
-    messages.append(f"Using start date {resolved}.")
 
     def _incomplete_result(
         *,
@@ -503,9 +593,11 @@ def forecast_for_tickers(
             "resolved_start": start_info,
             "forecasted": forecasted_syms,
             "skipped": incomplete_syms,
+            "already_have_forecast": sorted(already),
             "messages": messages,
             "already_saved": already_saved,
             "need_gather": True,
+            "model_loaded": True,
         }
 
     try:
@@ -541,10 +633,13 @@ def forecast_for_tickers(
                     forecasted.extend(clean.keys())
                     any_saved = True
             else:
-                messages.append("No symbols had enough complete history in this batch.")
+                messages.append(
+                    "No symbols had enough complete history in this batch."
+                )
 
         if not any_group:
             if getattr(cf, "all_already_saved", False):
+                # Race: files appeared after our pre-check
                 messages.append("Forecasts for this start date already exist.")
                 return {
                     "ok": True,
@@ -553,30 +648,31 @@ def forecast_for_tickers(
                     "resolved_start": start_info,
                     "forecasted": [],
                     "skipped": [],
+                    "already_have_forecast": sorted(set(already) | set(to_run)),
                     "messages": messages,
                     "already_saved": True,
+                    "model_loaded": True,
                 }
             return _incomplete_result(
                 forecasted_syms=[],
-                incomplete_syms=list(tickers),
+                incomplete_syms=list(to_run),
                 extra_error=INCOMPLETE_DATA_MSG.format(
-                    symbols=", ".join(tickers)
+                    symbols=", ".join(to_run)
                 ),
             )
         if not any_saved:
             return _incomplete_result(
                 forecasted_syms=[],
-                incomplete_syms=[t for t in tickers if t not in forecasted],
+                incomplete_syms=[t for t in to_run if t not in forecasted],
             )
 
-        # Optional HF upload only if enabled
         try:
             cf.upload_data()
         except Exception as e:
             messages.append(f"Cloud upload skipped: {e}")
 
-        incomplete = [t for t in tickers if t not in set(forecasted)]
-        # Hard-fail: do not report success if any requested symbol lacked clean data
+        # Incomplete only among symbols we tried to run (not ones already on file)
+        incomplete = [t for t in to_run if t not in set(forecasted)]
         if incomplete:
             return _incomplete_result(
                 forecasted_syms=list(forecasted),
@@ -590,7 +686,9 @@ def forecast_for_tickers(
             "resolved_start": start_info,
             "forecasted": forecasted,
             "skipped": [],
+            "already_have_forecast": sorted(already),
             "messages": messages,
+            "model_loaded": True,
         }
     except Exception as e:
         logger.exception("forecast_for_tickers failed")

--- a/src/canswim/run_triggers.py
+++ b/src/canswim/run_triggers.py
@@ -1,0 +1,459 @@
+"""Shared GUI/MCP orchestration for scoped gather and forecast runs.
+
+Pure helpers (parse + calendar) stay free of torch/network. Orchestration
+functions return structured dicts and are the single entry used by dashboard
+and MCP write tools.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import tempfile
+from pathlib import Path
+from typing import Any, Optional, Sequence, Union
+
+import pandas as pd
+from loguru import logger
+
+from canswim.calendar_weeks import resolve_forecast_start
+from canswim.eligibility import is_valid_ticker_symbol
+from canswim.hfhub import _env_bool
+
+# Soft cap so GUI/MCP accidental pastes do not launch huge jobs
+DEFAULT_MAX_TICKERS = 50
+
+
+def parse_ticker_list(
+    text: Union[str, Sequence[str], None],
+    *,
+    max_tickers: int = DEFAULT_MAX_TICKERS,
+) -> dict[str, Any]:
+    """Parse comma- and/or newline-separated ticker text.
+
+    Returns
+    -------
+    dict with keys:
+      ok, tickers (accepted unique upper), rejected (list of {token, reason}),
+      truncated (bool), messages (list[str])
+    """
+    if text is None:
+        return {
+            "ok": False,
+            "tickers": [],
+            "rejected": [],
+            "truncated": False,
+            "messages": ["No tickers provided."],
+            "error": "No tickers provided.",
+        }
+
+    if isinstance(text, (list, tuple, set)):
+        raw_tokens = [str(x) for x in text]
+    else:
+        # Split on comma, semicolon, whitespace/newlines
+        raw_tokens = re.split(r"[\s,;]+", str(text).strip())
+
+    accepted: list[str] = []
+    seen: set[str] = set()
+    rejected: list[dict[str, str]] = []
+
+    for tok in raw_tokens:
+        t = tok.strip().upper()
+        if not t:
+            continue
+        if not is_valid_ticker_symbol(t):
+            rejected.append({"token": tok.strip(), "reason": "invalid_symbol"})
+            continue
+        if t in seen:
+            rejected.append({"token": t, "reason": "duplicate"})
+            continue
+        seen.add(t)
+        accepted.append(t)
+
+    truncated = False
+    if len(accepted) > max_tickers:
+        truncated = True
+        accepted = accepted[:max_tickers]
+
+    messages: list[str] = []
+    if not accepted:
+        messages.append("No valid tickers after parsing.")
+        return {
+            "ok": False,
+            "tickers": [],
+            "rejected": rejected,
+            "truncated": truncated,
+            "messages": messages,
+            "error": "No valid tickers after parsing.",
+        }
+    if rejected:
+        messages.append(f"{len(rejected)} token(s) rejected.")
+    if truncated:
+        messages.append(f"Truncated to first {max_tickers} tickers.")
+
+    return {
+        "ok": True,
+        "tickers": accepted,
+        "rejected": rejected,
+        "truncated": truncated,
+        "messages": messages,
+    }
+
+
+def runs_allowed() -> bool:
+    """True when MCP/GUI write triggers are enabled via env."""
+    return _env_bool("MCP_ALLOW_RUNS", default=False) or _env_bool(
+        "CANSWIM_ALLOW_RUNS", default=False
+    )
+
+
+def require_runs_allowed() -> Optional[dict[str, Any]]:
+    """Return an error result dict if runs are disabled, else None."""
+    if runs_allowed():
+        return None
+    return {
+        "ok": False,
+        "error": (
+            "Run triggers are disabled. Set MCP_ALLOW_RUNS=1 (or CANSWIM_ALLOW_RUNS=1) "
+            "to enable gather/forecast tools. Default remains read-only."
+        ),
+        "runs_allowed": False,
+    }
+
+
+def _latest_close_from_local() -> Optional[pd.Timestamp]:
+    """Best-effort latest close from DuckDB or price parquet (no network)."""
+    try:
+        from canswim.db import connect_readonly, get_db_path, tables_present
+
+        db_path = get_db_path()
+        if tables_present(db_path):
+            with connect_readonly(db_path) as con:
+                row = con.execute(
+                    "SELECT max(CAST(Date AS DATE)) FROM close_price"
+                ).fetchone()
+            if row and row[0] is not None:
+                return pd.Timestamp(row[0]).normalize()
+    except Exception as e:
+        logger.debug(f"latest_close from DuckDB skipped: {e}")
+
+    try:
+        data_dir = os.getenv("data_dir", "data")
+        third = os.getenv("data-3rd-party", "data-3rd-party")
+        path = Path(data_dir) / third / "all_stocks_price_hist_1d.parquet"
+        if path.is_file():
+            # Only need max date — duckdb or pyarrow
+            import duckdb
+
+            row = duckdb.sql(
+                f"SELECT max(Date) FROM read_parquet('{path}')"
+            ).fetchone()
+            if row and row[0] is not None:
+                return pd.Timestamp(row[0]).normalize()
+    except Exception as e:
+        logger.debug(f"latest_close from parquet skipped: {e}")
+    return None
+
+
+def resolve_start_for_run(
+    user_date: Optional[str] = None,
+    *,
+    asof: Optional[str] = None,
+    latest_close: Optional[str] = None,
+) -> dict[str, Any]:
+    """Public resolve wrapper for GUI/MCP preview (uses local latest close)."""
+    lc = latest_close
+    if lc is None:
+        ts = _latest_close_from_local()
+        lc = ts.strftime("%Y-%m-%d") if ts is not None else None
+    resolved = resolve_forecast_start(user_date, asof=asof, latest_close=lc)
+    out = resolved.as_dict()
+    out["latest_close_used"] = lc
+    return out
+
+
+def gather_for_tickers(
+    tickers_text: Union[str, Sequence[str], None],
+    *,
+    include_covariates: bool = True,
+    max_tickers: int = DEFAULT_MAX_TICKERS,
+    force_allow: bool = False,
+) -> dict[str, Any]:
+    """Gather market data for an explicit ticker list (local-first).
+
+    ``force_allow=True`` skips the MCP_ALLOW_RUNS gate (used by dashboard which
+    is an explicit user action in a local process).
+    """
+    if not force_allow:
+        blocked = require_runs_allowed()
+        if blocked is not None:
+            return blocked
+
+    parsed = parse_ticker_list(tickers_text, max_tickers=max_tickers)
+    if not parsed["ok"]:
+        return {
+            "ok": False,
+            "error": parsed.get("error", "Invalid tickers"),
+            "tickers": [],
+            "rejected": parsed.get("rejected", []),
+            "messages": parsed.get("messages", []),
+        }
+
+    tickers: list[str] = parsed["tickers"]
+    messages = list(parsed.get("messages") or [])
+
+    # Local-first defaults
+    if not _env_bool("hfhub_sync", default=False):
+        messages.append("hfhub_sync off (local-first gather).")
+
+    try:
+        from canswim.gather_data import MarketDataGatherer
+
+        g = MarketDataGatherer()
+        g.stocks_ticker_set = list(tickers)
+
+        # Broad market / sectors are small and needed as covariates
+        try:
+            g.gather_broad_market_data()
+        except Exception as e:
+            messages.append(f"broad_market warning: {e}")
+        try:
+            g.gather_sectors_data()
+        except Exception as e:
+            messages.append(f"sectors warning: {e}")
+
+        g.gather_stock_price_data()
+
+        if include_covariates:
+            for name, fn in (
+                ("dividends", g.gather_stock_dividends),
+                ("splits", g.gather_stock_splits),
+                ("earnings", g.gather_earnings_data),
+                ("key_metrics", g.gather_stock_key_metrics),
+            ):
+                try:
+                    fn()
+                except Exception as e:
+                    messages.append(f"{name} warning: {e}")
+
+        # Ensure symbols appear on a stock list CSV for forecast path
+        _ensure_symbols_on_list(tickers)
+
+        return {
+            "ok": True,
+            "tickers": tickers,
+            "rejected": parsed.get("rejected", []),
+            "messages": messages,
+            "processed": tickers,
+        }
+    except Exception as e:
+        logger.exception("gather_for_tickers failed")
+        return {
+            "ok": False,
+            "error": str(e),
+            "tickers": tickers,
+            "rejected": parsed.get("rejected", []),
+            "messages": messages,
+        }
+
+
+def _ensure_symbols_on_list(tickers: Sequence[str]) -> Path:
+    """Append symbols to watchlist (and data-3rd-party copy) if missing."""
+    from canswim.paths import data_3rd_party_dir, symbol_lists_dir
+
+    rows = sorted({t.upper() for t in tickers})
+    for base in (symbol_lists_dir(), data_3rd_party_dir()):
+        base.mkdir(parents=True, exist_ok=True)
+        path = base / "watchlist.csv"
+        existing: set[str] = set()
+        if path.is_file():
+            try:
+                df = pd.read_csv(path, dtype=str)
+                if "Symbol" in df.columns:
+                    existing = set(df["Symbol"].dropna().astype(str).str.upper())
+            except Exception:
+                pass
+        merged = sorted(existing | set(rows))
+        pd.DataFrame({"Symbol": merged}).to_csv(path, index=False)
+    return symbol_lists_dir() / "watchlist.csv"
+
+
+def forecast_for_tickers(
+    tickers_text: Union[str, Sequence[str], None],
+    forecast_start_date: Optional[str] = None,
+    *,
+    max_tickers: int = DEFAULT_MAX_TICKERS,
+    force_allow: bool = False,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    """Run forecast for an explicit ticker list with week-aligned start.
+
+    ``dry_run=True`` only resolves start + validates tickers (no torch).
+    """
+    if not force_allow:
+        blocked = require_runs_allowed()
+        if blocked is not None:
+            return blocked
+
+    parsed = parse_ticker_list(tickers_text, max_tickers=max_tickers)
+    if not parsed["ok"]:
+        return {
+            "ok": False,
+            "error": parsed.get("error", "Invalid tickers"),
+            "tickers": [],
+            "rejected": parsed.get("rejected", []),
+            "resolved_start": None,
+        }
+
+    tickers: list[str] = parsed["tickers"]
+    start_info = resolve_start_for_run(forecast_start_date)
+    if not start_info.get("ok"):
+        return {
+            "ok": False,
+            "error": start_info.get("error") or "Could not resolve forecast start",
+            "tickers": tickers,
+            "rejected": parsed.get("rejected", []),
+            "resolved_start": start_info,
+        }
+
+    resolved = start_info["start"]
+    if dry_run:
+        return {
+            "ok": True,
+            "dry_run": True,
+            "tickers": tickers,
+            "rejected": parsed.get("rejected", []),
+            "resolved_start": start_info,
+            "forecasted": [],
+            "skipped": [],
+            "messages": ["dry_run: no model load / forecast executed"],
+        }
+
+    # Write a temporary symbol list and point stock_tickers_list at it
+    tmp_dir = Path(tempfile.mkdtemp(prefix="canswim_fc_"))
+    list_path = tmp_dir / "run_tickers.csv"
+    pd.DataFrame({"Symbol": tickers}).to_csv(list_path, index=False)
+
+    # CanswimForecaster reads data_dir/data-3rd-party/stock_tickers_list
+    data_dir = os.getenv("data_dir", "data")
+    third = os.getenv("data-3rd-party", "data-3rd-party")
+    dest_dir = Path(data_dir) / third
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    dest_list = dest_dir / "run_tickers.csv"
+    pd.DataFrame({"Symbol": tickers}).to_csv(dest_list, index=False)
+
+    prev_list = os.environ.get("stock_tickers_list")
+    os.environ["stock_tickers_list"] = "run_tickers.csv"
+    # Keep n_stocks large enough for the batch
+    prev_n = os.environ.get("n_stocks")
+    os.environ["n_stocks"] = str(max(len(tickers), 1))
+
+    forecasted: list[str] = []
+    skipped: list[str] = []
+    messages: list[str] = list(parsed.get("messages") or [])
+    messages.append(f"resolved_start={resolved} ({start_info.get('reason')})")
+
+    try:
+        from canswim.forecast import CanswimForecaster
+
+        cf = CanswimForecaster()
+        cf.all_already_saved = False
+        cf.download_model()
+        cf.download_data()
+        fsd = pd.Timestamp(resolved)
+        any_saved = False
+        any_group = False
+        for _pos in cf.prep_next_stock_group(forecast_start_date=fsd):
+            any_group = True
+            forecasts = cf.get_forecast(forecast_start_date=fsd)
+            if forecasts:
+                clean = {}
+                for t, ts in forecasts.items():
+                    try:
+                        qdf = (
+                            ts.quantile_df(0.5)
+                            if hasattr(ts, "quantile_df")
+                            else ts.pd_dataframe()
+                        )
+                        if qdf.isna().all().all():
+                            skipped.append(t)
+                            continue
+                    except Exception:
+                        pass
+                    clean[t] = ts
+                if clean:
+                    cf.save_forecast(clean, asof_start=fsd)
+                    forecasted.extend(clean.keys())
+                    any_saved = True
+            else:
+                messages.append("No eligible tickers in batch.")
+
+        if not any_group:
+            if getattr(cf, "all_already_saved", False):
+                messages.append("All symbols already had forecasts for this start.")
+                return {
+                    "ok": True,
+                    "tickers": tickers,
+                    "rejected": parsed.get("rejected", []),
+                    "resolved_start": start_info,
+                    "forecasted": [],
+                    "skipped": list(tickers),
+                    "messages": messages,
+                    "already_saved": True,
+                }
+            return {
+                "ok": False,
+                "error": "No stock groups prepared. Check local price data / list.",
+                "tickers": tickers,
+                "resolved_start": start_info,
+                "forecasted": [],
+                "skipped": tickers,
+                "messages": messages,
+            }
+        if not any_saved:
+            return {
+                "ok": False,
+                "error": "No forecasts saved (insufficient ground-truth history).",
+                "tickers": tickers,
+                "resolved_start": start_info,
+                "forecasted": forecasted,
+                "skipped": [t for t in tickers if t not in forecasted],
+                "messages": messages,
+            }
+
+        # Optional HF upload only if enabled
+        try:
+            cf.upload_data()
+        except Exception as e:
+            messages.append(f"upload skipped/failed: {e}")
+
+        skipped = [t for t in tickers if t not in set(forecasted)]
+        return {
+            "ok": True,
+            "tickers": tickers,
+            "rejected": parsed.get("rejected", []),
+            "resolved_start": start_info,
+            "forecasted": forecasted,
+            "skipped": skipped,
+            "messages": messages,
+        }
+    except Exception as e:
+        logger.exception("forecast_for_tickers failed")
+        return {
+            "ok": False,
+            "error": str(e),
+            "tickers": tickers,
+            "resolved_start": start_info,
+            "forecasted": forecasted,
+            "skipped": skipped,
+            "messages": messages,
+        }
+    finally:
+        if prev_list is None:
+            os.environ.pop("stock_tickers_list", None)
+        else:
+            os.environ["stock_tickers_list"] = prev_list
+        if prev_n is None:
+            os.environ.pop("n_stocks", None)
+        else:
+            os.environ["n_stocks"] = prev_n

--- a/src/canswim/run_triggers.py
+++ b/src/canswim/run_triggers.py
@@ -32,33 +32,52 @@ from canswim.hfhub import _env_bool
 # Soft cap so accidental pastes do not launch huge jobs
 DEFAULT_MAX_TICKERS = 50
 
-# --- UX copy shared by CLI help, GUI labels, MCP tool descriptions -----------
+# --- Consumer-facing copy (CLI help, GUI, MCP). Operator detail → docs. --------
 
 TICKERS_HELP = (
-    "One or more stock symbols, comma and/or newline (or space) separated. "
-    f"Example: 'AAPL, MSFT' or multiline. Max {DEFAULT_MAX_TICKERS} per run. "
-    "Invalid tokens are reported and skipped."
+    "Stock symbols separated by commas or new lines. "
+    f"Example: AAPL, MSFT. Up to {DEFAULT_MAX_TICKERS} at a time."
 )
 
 FORECAST_START_HELP = (
-    "Optional forecast origin as YYYY-MM-DD. "
-    "Past dates snap to the first NYSE session of that market week "
-    "(usually Monday; Tuesday if Monday is a holiday). "
-    "Empty or today → live default: first session after the latest completed "
-    "week-end close (usually Monday after Friday), using local latest close when known. "
-    "Dates after the allowed live origin are rejected."
+    "Optional start date (YYYY-MM-DD). Leave blank to use the next available "
+    "market-week start after the latest completed trading week. "
+    "Past dates are moved to the start of that market week "
+    "(if Monday is a holiday, the next open day that week is used). "
+    "Future dates are not allowed."
 )
 
+# Kept for docs/CLI epilog only — not primary GUI body copy
 DATE_POLICY_SUMMARY = (
-    "**Week-aligned starts:** backtest picks → first NYSE session of that ISO week; "
-    "holiday Mondays → next open that week (not prior week); "
-    "empty/today → live week origin after last week-end close; no pure-future origins."
+    "Start dates use market weeks (see docs/run_triggers.md)."
+)
+
+GATHER_SECTION_TITLE = "Get market data"
+GATHER_SECTION_HELP = (
+    "Download recent prices for the symbols you list. "
+    "Uses local files when they already cover about the last two years; "
+    "only requests from the internet what is missing or out of date."
+)
+GATHER_BUTTON = "Update market data"
+
+FORECAST_SECTION_TITLE = "Run a forecast"
+FORECAST_SECTION_HELP = (
+    "Create forecasts for the symbols you list. "
+    "Needs complete local market history—if anything is missing, "
+    "update market data first, then try again."
+)
+FORECAST_BUTTON = "Run forecast"
+PREVIEW_START_BUTTON = "Check start date"
+
+INCOMPLETE_DATA_MSG = (
+    "Market history is incomplete or not ready for: {symbols}. "
+    "Use Get market data / gather for these symbols, then run the forecast again. "
+    "Forecasts never invent missing prices."
 )
 
 RUNS_OPT_IN_HELP = (
-    "MCP write tools require MCP_ALLOW_RUNS=1 (or CANSWIM_ALLOW_RUNS=1). "
-    "CLI --tickers and the Dashboard Run tab are explicit local actions and do not "
-    "need that flag. Default MCP mode stays read-only."
+    "MCP data/forecast tools need MCP_ALLOW_RUNS=1. "
+    "CLI and the dashboard do not. MCP stays read-only by default."
 )
 
 
@@ -242,25 +261,38 @@ def gather_for_tickers(
 
     # Local-first defaults
     if not _env_bool("hfhub_sync", default=False):
-        messages.append("hfhub_sync off (local-first gather).")
+        messages.append("Using local files first (no cloud dataset sync).")
 
     try:
         from canswim.gather_data import MarketDataGatherer
 
         g = MarketDataGatherer()
         g.stocks_ticker_set = list(tickers)
+        # Scoped user runs: ~2y missing-only (not multi-decade train history)
+        g.gather_mode = "forecast"
 
-        # Broad market / sectors are small and needed as covariates
+        # Broad market / sectors: reuse local files on small scopes
         try:
             g.gather_broad_market_data()
         except Exception as e:
-            messages.append(f"broad_market warning: {e}")
+            messages.append(f"Broad market data note: {e}")
         try:
             g.gather_sectors_data()
         except Exception as e:
-            messages.append(f"sectors warning: {e}")
+            messages.append(f"Sector data note: {e}")
 
         g.gather_stock_price_data()
+        plans = getattr(g, "last_price_fetch_plans", []) or []
+        skipped = [p.symbol for p in plans if p.action == "skip"]
+        fetched = [p.symbol for p in plans if p.action == "fetch"]
+        if skipped:
+            messages.append(
+                f"Already up to date locally (no download): {', '.join(skipped)}"
+            )
+        if fetched:
+            messages.append(f"Downloaded or refreshed: {', '.join(fetched)}")
+        if plans and not fetched:
+            messages.append("No remote price download needed.")
 
         if include_covariates:
             for name, fn in (
@@ -272,7 +304,7 @@ def gather_for_tickers(
                 try:
                     fn()
                 except Exception as e:
-                    messages.append(f"{name} warning: {e}")
+                    messages.append(f"{name} note: {e}")
 
         # Ensure symbols appear on a stock list CSV for forecast path
         _ensure_symbols_on_list(tickers)
@@ -283,6 +315,9 @@ def gather_for_tickers(
             "rejected": parsed.get("rejected", []),
             "messages": messages,
             "processed": tickers,
+            "price_plans": [p.as_dict() for p in plans],
+            "fetched": fetched,
+            "skipped_remote": skipped,
         }
     except Exception as e:
         logger.exception("gather_for_tickers failed")
@@ -364,7 +399,7 @@ def forecast_for_tickers(
             "resolved_start": start_info,
             "forecasted": [],
             "skipped": [],
-            "messages": ["dry_run: no model load / forecast executed"],
+            "messages": ["Check only: no forecast model was run."],
         }
 
     # Write a temporary symbol list and point stock_tickers_list at it
@@ -389,7 +424,30 @@ def forecast_for_tickers(
     forecasted: list[str] = []
     skipped: list[str] = []
     messages: list[str] = list(parsed.get("messages") or [])
-    messages.append(f"resolved_start={resolved} ({start_info.get('reason')})")
+    messages.append(f"Using start date {resolved}.")
+
+    def _incomplete_result(
+        *,
+        forecasted_syms: list[str],
+        incomplete_syms: list[str],
+        extra_error: Optional[str] = None,
+        already_saved: bool = False,
+    ) -> dict[str, Any]:
+        err = extra_error or INCOMPLETE_DATA_MSG.format(
+            symbols=", ".join(incomplete_syms) or "requested symbols"
+        )
+        return {
+            "ok": False,
+            "error": err,
+            "tickers": tickers,
+            "rejected": parsed.get("rejected", []),
+            "resolved_start": start_info,
+            "forecasted": forecasted_syms,
+            "skipped": incomplete_syms,
+            "messages": messages,
+            "already_saved": already_saved,
+            "need_gather": True,
+        }
 
     try:
         from canswim.forecast import CanswimForecaster
@@ -424,55 +482,55 @@ def forecast_for_tickers(
                     forecasted.extend(clean.keys())
                     any_saved = True
             else:
-                messages.append("No eligible tickers in batch.")
+                messages.append("No symbols had enough complete history in this batch.")
 
         if not any_group:
             if getattr(cf, "all_already_saved", False):
-                messages.append("All symbols already had forecasts for this start.")
+                messages.append("Forecasts for this start date already exist.")
                 return {
                     "ok": True,
                     "tickers": tickers,
                     "rejected": parsed.get("rejected", []),
                     "resolved_start": start_info,
                     "forecasted": [],
-                    "skipped": list(tickers),
+                    "skipped": [],
                     "messages": messages,
                     "already_saved": True,
                 }
-            return {
-                "ok": False,
-                "error": "No stock groups prepared. Check local price data / list.",
-                "tickers": tickers,
-                "resolved_start": start_info,
-                "forecasted": [],
-                "skipped": tickers,
-                "messages": messages,
-            }
+            return _incomplete_result(
+                forecasted_syms=[],
+                incomplete_syms=list(tickers),
+                extra_error=INCOMPLETE_DATA_MSG.format(
+                    symbols=", ".join(tickers)
+                ),
+            )
         if not any_saved:
-            return {
-                "ok": False,
-                "error": "No forecasts saved (insufficient ground-truth history).",
-                "tickers": tickers,
-                "resolved_start": start_info,
-                "forecasted": forecasted,
-                "skipped": [t for t in tickers if t not in forecasted],
-                "messages": messages,
-            }
+            return _incomplete_result(
+                forecasted_syms=[],
+                incomplete_syms=[t for t in tickers if t not in forecasted],
+            )
 
         # Optional HF upload only if enabled
         try:
             cf.upload_data()
         except Exception as e:
-            messages.append(f"upload skipped/failed: {e}")
+            messages.append(f"Cloud upload skipped: {e}")
 
-        skipped = [t for t in tickers if t not in set(forecasted)]
+        incomplete = [t for t in tickers if t not in set(forecasted)]
+        # Hard-fail: do not report success if any requested symbol lacked clean data
+        if incomplete:
+            return _incomplete_result(
+                forecasted_syms=list(forecasted),
+                incomplete_syms=incomplete,
+            )
+
         return {
             "ok": True,
             "tickers": tickers,
             "rejected": parsed.get("rejected", []),
             "resolved_start": start_info,
             "forecasted": forecasted,
-            "skipped": skipped,
+            "skipped": [],
             "messages": messages,
         }
     except Exception as e:

--- a/src/canswim/run_triggers.py
+++ b/src/canswim/run_triggers.py
@@ -542,6 +542,16 @@ def forecast_for_tickers(
             )
         )
     if not to_run:
+        try:
+            from canswim.db import get_db_path, sync_forecasts_to_search_db
+
+            sync_fc = sync_forecasts_to_search_db(get_db_path(), list(already))
+            if sync_fc.get("ok") and sync_fc.get("forecast_rows"):
+                messages.append(
+                    f"Charts updated with {sync_fc.get('forecast_rows')} forecast rows."
+                )
+        except Exception as e:
+            messages.append(f"Charts forecast sync note: {e}")
         return {
             "ok": True,
             "tickers": tickers,
@@ -678,6 +688,20 @@ def forecast_for_tickers(
                 forecasted_syms=list(forecasted),
                 incomplete_syms=incomplete,
             )
+
+        # Push new forecast parquet into DuckDB so Charts/Scans see lines
+        try:
+            from canswim.db import get_db_path, sync_forecasts_to_search_db
+
+            sync_fc = sync_forecasts_to_search_db(
+                get_db_path(), list(set(forecasted) | set(already))
+            )
+            if sync_fc.get("ok"):
+                messages.append(
+                    f"Charts updated with {sync_fc.get('forecast_rows', 0)} forecast rows."
+                )
+        except Exception as e:
+            messages.append(f"Charts forecast sync note: {e}")
 
         return {
             "ok": True,

--- a/src/canswim/run_triggers.py
+++ b/src/canswim/run_triggers.py
@@ -282,17 +282,47 @@ def gather_for_tickers(
             messages.append(f"Sector data note: {e}")
 
         g.gather_stock_price_data()
-        plans = getattr(g, "last_price_fetch_plans", []) or []
-        skipped = [p.symbol for p in plans if p.action == "skip"]
-        fetched = [p.symbol for p in plans if p.action == "fetch"]
+        pre_plans = getattr(g, "last_price_fetch_plans", []) or []
+        post_plans = getattr(g, "last_post_fetch_plans", None) or pre_plans
+        written = list(getattr(g, "last_remote_symbols_written", None) or [])
+
+        from canswim.gather_policy import incomplete_symbols
+
+        skipped = [p.symbol for p in pre_plans if p.action == "skip"]
+        # Only count as downloaded when remote actually returned bars for the symbol
+        planned_fetch = {p.symbol for p in pre_plans if p.action == "fetch"}
+        fetched = sorted(planned_fetch & set(written))
+        still_incomplete = incomplete_symbols(post_plans)
+
         if skipped:
             messages.append(
                 f"Already up to date locally (no download): {', '.join(skipped)}"
             )
         if fetched:
             messages.append(f"Downloaded or refreshed: {', '.join(fetched)}")
-        if plans and not fetched:
+        planned_but_empty = sorted(planned_fetch - set(written))
+        if planned_but_empty and still_incomplete:
+            messages.append(
+                "No usable download for: " + ", ".join(planned_but_empty)
+            )
+        if pre_plans and not planned_fetch:
             messages.append("No remote price download needed.")
+
+        if still_incomplete:
+            return {
+                "ok": False,
+                "error": INCOMPLETE_DATA_MSG.format(
+                    symbols=", ".join(still_incomplete)
+                ),
+                "tickers": tickers,
+                "rejected": parsed.get("rejected", []),
+                "messages": messages,
+                "price_plans": [p.as_dict() for p in post_plans],
+                "fetched": fetched,
+                "skipped_remote": skipped,
+                "incomplete": still_incomplete,
+                "need_gather": True,
+            }
 
         if include_covariates:
             for name, fn in (
@@ -315,9 +345,10 @@ def gather_for_tickers(
             "rejected": parsed.get("rejected", []),
             "messages": messages,
             "processed": tickers,
-            "price_plans": [p.as_dict() for p in plans],
+            "price_plans": [p.as_dict() for p in post_plans],
             "fetched": fetched,
             "skipped_remote": skipped,
+            "incomplete": [],
         }
     except Exception as e:
         logger.exception("gather_for_tickers failed")
@@ -327,6 +358,7 @@ def gather_for_tickers(
             "tickers": tickers,
             "rejected": parsed.get("rejected", []),
             "messages": messages,
+            "need_gather": True,
         }
 
 

--- a/src/canswim/run_triggers.py
+++ b/src/canswim/run_triggers.py
@@ -76,6 +76,18 @@ INCOMPLETE_DATA_MSG = (
     "Forecasts never invent missing prices."
 )
 
+COVARIATE_FAIL_MSG = (
+    "Could not build a forecast for: {symbols}. "
+    "Prices may be fine, but model inputs (ownership, estimates, or other fundamentals) "
+    "are missing or could not be aligned. "
+    "Try Update market data again (includes fundamentals), then re-run the forecast."
+)
+
+STALE_PRICE_START_MSG = (
+    "Could not forecast {symbols} for start {start}: local prices end before that date. "
+    "Update market data for a fresher close, or pick an earlier start date."
+)
+
 ALREADY_FORECAST_MSG = (
     "Forecast already on file for {symbols} (start {start}). "
     "Skipped re-run to save time and avoid duplicate data."
@@ -88,6 +100,49 @@ RUNS_OPT_IN_HELP = (
 
 # Default min rows in a saved forecast partition (= typical pred_horizon)
 DEFAULT_MIN_FORECAST_ROWS = 42
+
+
+def _cap_start_to_local_prices(
+    tickers: Sequence[str],
+    resolved_start: str,
+) -> tuple[str, Optional[str]]:
+    """If resolved start is after next open following latest local close, pull it back.
+
+    Returns (possibly_adjusted_iso_start, optional_note).
+    """
+    import duckdb
+    from canswim.forecast import get_next_open_market_day
+
+    data_dir = os.getenv("data_dir", "data")
+    third = os.getenv("data-3rd-party", "data-3rd-party")
+    price_name = os.getenv("price_data", "all_stocks_price_hist_1d.parquet")
+    path = Path(data_dir) / third / price_name
+    if not path.is_file():
+        return resolved_start, None
+    syms = sorted({str(t).upper() for t in tickers})
+    in_list = ", ".join("'" + s.replace("'", "''") + "'" for s in syms)
+    row = duckdb.sql(
+        f"""--sql
+        SELECT max(CAST(Date AS DATE))
+        FROM read_parquet('{path}')
+        WHERE upper(CAST(Symbol AS VARCHAR)) IN ({in_list})
+        """
+    ).fetchone()
+    if not row or row[0] is None:
+        return resolved_start, None
+    last_close = pd.Timestamp(row[0]).normalize()
+    cutoff = get_next_open_market_day(after_date=last_close)
+    if cutoff is None:
+        return resolved_start, None
+    cutoff = pd.Timestamp(cutoff).tz_localize(None).normalize()
+    fsd = pd.Timestamp(resolved_start).normalize()
+    if fsd <= cutoff:
+        return resolved_start, None
+    note = (
+        f"Start {resolved_start} is after the next session following your latest "
+        f"local close ({last_close.date()}); using {cutoff.date()} instead."
+    )
+    return cutoff.strftime("%Y-%m-%d"), note
 
 
 def list_symbols_with_saved_forecast(
@@ -382,11 +437,14 @@ def gather_for_tickers(
             }
 
         if include_covariates:
+            # Fundamentals required by the model stack (not just OHLCV)
             for name, fn in (
                 ("dividends", g.gather_stock_dividends),
                 ("splits", g.gather_stock_splits),
                 ("earnings", g.gather_earnings_data),
                 ("key_metrics", g.gather_stock_key_metrics),
+                ("institutional_ownership", g.gather_institutional_stock_ownership),
+                ("analyst_estimates", g.gather_analyst_estimates),
             ):
                 try:
                     fn()
@@ -509,6 +567,19 @@ def forecast_for_tickers(
     messages: list[str] = list(parsed.get("messages") or [])
     messages.append(f"Using start date {resolved}.")
 
+    # Cap start to what local prices can support (live week default can land
+    # after the latest close; the model refuses pure-future origins).
+    try:
+        adj, adj_note = _cap_start_to_local_prices(tickers, resolved)
+        if adj != resolved:
+            messages.append(adj_note or f"Adjusted start to {adj} for local prices.")
+            resolved = adj
+            start_info = dict(start_info)
+            start_info["start"] = resolved
+            start_info["reason"] = (start_info.get("reason") or "") + "+capped_to_prices"
+    except Exception as e:
+        logger.debug(f"start cap skipped: {e}")
+
     if dry_run:
         already = list_symbols_with_saved_forecast(tickers, resolved)
         return {
@@ -591,10 +662,18 @@ def forecast_for_tickers(
         incomplete_syms: list[str],
         extra_error: Optional[str] = None,
         already_saved: bool = False,
+        reason: str = "prices",
     ) -> dict[str, Any]:
-        err = extra_error or INCOMPLETE_DATA_MSG.format(
-            symbols=", ".join(incomplete_syms) or "requested symbols"
-        )
+        if extra_error:
+            err = extra_error
+        elif reason == "covariates":
+            err = COVARIATE_FAIL_MSG.format(
+                symbols=", ".join(incomplete_syms) or "requested symbols"
+            )
+        else:
+            err = INCOMPLETE_DATA_MSG.format(
+                symbols=", ".join(incomplete_syms) or "requested symbols"
+            )
         return {
             "ok": False,
             "error": err,
@@ -606,8 +685,11 @@ def forecast_for_tickers(
             "already_have_forecast": sorted(already),
             "messages": messages,
             "already_saved": already_saved,
-            "need_gather": True,
+            # True only when price history is the likely gap
+            "need_gather": reason == "prices",
+            "need_covariates": reason == "covariates",
             "model_loaded": True,
+            "fail_reason": reason,
         }
 
     try:
@@ -666,14 +748,14 @@ def forecast_for_tickers(
             return _incomplete_result(
                 forecasted_syms=[],
                 incomplete_syms=list(to_run),
-                extra_error=INCOMPLETE_DATA_MSG.format(
-                    symbols=", ".join(to_run)
-                ),
+                reason="covariates",
             )
         if not any_saved:
+            # Prices often present; model dropped symbols during covariate align
             return _incomplete_result(
                 forecasted_syms=[],
                 incomplete_syms=[t for t in to_run if t not in forecasted],
+                reason="covariates",
             )
 
         try:

--- a/src/canswim/run_triggers.py
+++ b/src/canswim/run_triggers.py
@@ -339,6 +339,32 @@ def gather_for_tickers(
         # Ensure symbols appear on a stock list CSV for forecast path
         _ensure_symbols_on_list(tickers)
 
+        # Sync DuckDB search tables so Charts/Scans dropdown includes new symbols
+        # (dashboard --same_data reuses DB and would otherwise stay on old list)
+        db_sync: dict[str, Any] | None = None
+        try:
+            from canswim.db import sync_gathered_symbols, get_db_path
+
+            db_sync = sync_gathered_symbols(get_db_path(), tickers)
+            if db_sync.get("ok"):
+                if db_sync.get("added"):
+                    messages.append(
+                        "Added to Charts symbol list: "
+                        + ", ".join(db_sync["added"])
+                    )
+                else:
+                    messages.append("Charts symbol list already included these.")
+                messages.append(
+                    f"Synced {db_sync.get('close_rows', 0)} local close prices "
+                    "into search DB."
+                )
+            else:
+                messages.append(
+                    f"Could not update Charts list: {db_sync.get('error')}"
+                )
+        except Exception as e:
+            messages.append(f"Charts list sync note: {e}")
+
         return {
             "ok": True,
             "tickers": tickers,
@@ -349,6 +375,7 @@ def gather_for_tickers(
             "fetched": fetched,
             "skipped_remote": skipped,
             "incomplete": [],
+            "db_sync": db_sync,
         }
     except Exception as e:
         logger.exception("gather_for_tickers failed")

--- a/src/canswim/run_triggers.py
+++ b/src/canswim/run_triggers.py
@@ -1,8 +1,17 @@
-"""Shared GUI/MCP orchestration for scoped gather and forecast runs.
+"""Shared CLI / GUI / MCP orchestration for scoped gather and forecast runs.
+
+One contract, three surfaces
+----------------------------
+- **CLI** — ``python -m canswim gatherdata|forecast --tickers "AAPL,MSFT"``
+- **GUI** — Dashboard **Run** tab (same functions; always allowed in-process)
+- **MCP** — ``gather_tickers`` / ``forecast_tickers`` (require ``MCP_ALLOW_RUNS=1``)
+
+Without ``--tickers``, CLI ``gatherdata`` / ``forecast`` keep their legacy
+full-universe behavior (symbol list env / all stocks; forecast start = next
+open after latest bar when date omitted).
 
 Pure helpers (parse + calendar) stay free of torch/network. Orchestration
-functions return structured dicts and are the single entry used by dashboard
-and MCP write tools.
+returns structured dicts consumed by all three surfaces.
 """
 
 from __future__ import annotations
@@ -20,8 +29,37 @@ from canswim.calendar_weeks import resolve_forecast_start
 from canswim.eligibility import is_valid_ticker_symbol
 from canswim.hfhub import _env_bool
 
-# Soft cap so GUI/MCP accidental pastes do not launch huge jobs
+# Soft cap so accidental pastes do not launch huge jobs
 DEFAULT_MAX_TICKERS = 50
+
+# --- UX copy shared by CLI help, GUI labels, MCP tool descriptions -----------
+
+TICKERS_HELP = (
+    "One or more stock symbols, comma and/or newline (or space) separated. "
+    f"Example: 'AAPL, MSFT' or multiline. Max {DEFAULT_MAX_TICKERS} per run. "
+    "Invalid tokens are reported and skipped."
+)
+
+FORECAST_START_HELP = (
+    "Optional forecast origin as YYYY-MM-DD. "
+    "Past dates snap to the first NYSE session of that market week "
+    "(usually Monday; Tuesday if Monday is a holiday). "
+    "Empty or today → live default: first session after the latest completed "
+    "week-end close (usually Monday after Friday), using local latest close when known. "
+    "Dates after the allowed live origin are rejected."
+)
+
+DATE_POLICY_SUMMARY = (
+    "**Week-aligned starts:** backtest picks → first NYSE session of that ISO week; "
+    "holiday Mondays → next open that week (not prior week); "
+    "empty/today → live week origin after last week-end close; no pure-future origins."
+)
+
+RUNS_OPT_IN_HELP = (
+    "MCP write tools require MCP_ALLOW_RUNS=1 (or CANSWIM_ALLOW_RUNS=1). "
+    "CLI --tickers and the Dashboard Run tab are explicit local actions and do not "
+    "need that flag. Default MCP mode stays read-only."
+)
 
 
 def parse_ticker_list(

--- a/tests/canswim/test_calendar_weeks.py
+++ b/tests/canswim/test_calendar_weeks.py
@@ -34,6 +34,51 @@ def test_snap_friday_to_same_week_start():
     )
 
 
+def test_snap_holiday_monday_memorial_day_2026():
+    """Memorial Day Mon 2026-05-25 closed → week start is Tue 2026-05-26."""
+    mon = snap_to_week_start_on_or_before("2026-05-25")
+    tue = snap_to_week_start_on_or_before("2026-05-26")
+    wed = snap_to_week_start_on_or_before("2026-05-27")
+    assert mon.strftime("%Y-%m-%d") == "2026-05-26"
+    assert tue.strftime("%Y-%m-%d") == "2026-05-26"
+    assert wed.strftime("%Y-%m-%d") == "2026-05-26"
+    # Same ISO week Mon vs Tue must agree
+    assert mon == tue == wed
+
+
+def test_snap_holiday_monday_mlk_2026():
+    """MLK Day Mon 2026-01-19 closed → week start Tue 2026-01-20."""
+    assert (
+        snap_to_week_start_on_or_before("2026-01-19").strftime("%Y-%m-%d")
+        == "2026-01-20"
+    )
+    assert (
+        snap_to_week_start_on_or_before("2026-01-20").strftime("%Y-%m-%d")
+        == "2026-01-20"
+    )
+
+
+def test_snap_holiday_monday_labor_day_2026():
+    """Labor Day Mon 2026-09-07 closed → week start Tue 2026-09-08."""
+    assert (
+        snap_to_week_start_on_or_before("2026-09-07").strftime("%Y-%m-%d")
+        == "2026-09-08"
+    )
+    assert (
+        snap_to_week_start_on_or_before("2026-09-08").strftime("%Y-%m-%d")
+        == "2026-09-08"
+    )
+
+
+def test_resolve_holiday_monday_backtest():
+    r = resolve_forecast_start(
+        "2026-05-25", asof="2026-07-10", latest_close="2026-07-09"
+    )
+    assert r.ok
+    assert r.start == "2026-05-26"
+    assert r.reason == "snapped_week_start"
+
+
 def test_july4_week_start_is_first_session():
     # 2026-07-03 is Friday; week of July 4 holiday: Mon 6/29? check
     # ISO week of 2026-07-03: Mon 2026-06-29

--- a/tests/canswim/test_calendar_weeks.py
+++ b/tests/canswim/test_calendar_weeks.py
@@ -1,0 +1,104 @@
+"""Unit tests for NYSE week-start snap and default live origin (no network)."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from canswim.calendar_weeks import (
+    default_live_forecast_start,
+    first_session_of_iso_week,
+    last_completed_week_end,
+    resolve_forecast_start,
+    snap_to_week_start_on_or_before,
+)
+
+
+def test_first_session_of_iso_week_monday():
+    # 2026-03-04 is Wednesday; week starts Mon 2026-03-02 (NYSE open)
+    assert first_session_of_iso_week("2026-03-04").strftime("%Y-%m-%d") == "2026-03-02"
+    assert first_session_of_iso_week("2026-03-02").strftime("%Y-%m-%d") == "2026-03-02"
+
+
+def test_snap_midweek_to_week_start():
+    assert (
+        snap_to_week_start_on_or_before("2026-03-05").strftime("%Y-%m-%d")
+        == "2026-03-02"
+    )
+
+
+def test_snap_friday_to_same_week_start():
+    assert (
+        snap_to_week_start_on_or_before("2026-03-06").strftime("%Y-%m-%d")
+        == "2026-03-02"
+    )
+
+
+def test_july4_week_start_is_first_session():
+    # 2026-07-03 is Friday; week of July 4 holiday: Mon 6/29? check
+    # ISO week of 2026-07-03: Mon 2026-06-29
+    ws = first_session_of_iso_week("2026-07-03")
+    assert ws.strftime("%Y-%m-%d") == "2026-06-29"
+    # Week containing July 6 (Mon after holiday July 3 close path)
+    # 2026-07-06 is Monday and NYSE open
+    assert first_session_of_iso_week("2026-07-07").strftime("%Y-%m-%d") == "2026-07-06"
+
+
+def test_last_completed_week_end_on_friday():
+    # On Friday close date itself, EOW is that Friday if session
+    eow = last_completed_week_end(latest_close="2026-03-06")  # Friday
+    assert eow.strftime("%Y-%m-%d") == "2026-03-06"
+
+
+def test_last_completed_week_end_midweek_uses_prior_or_same_week():
+    # Wednesday 2026-03-04: last completed EOW of current week is Friday 3/6
+    # but Friday is still in the future relative to Wed — so prior week EOW
+    eow = last_completed_week_end(latest_close="2026-03-04")
+    # Week of 3/4 ends Fri 3/6 > ref → previous week end Fri 2/27
+    assert eow.strftime("%Y-%m-%d") == "2026-02-27"
+
+
+def test_default_live_after_friday_close():
+    # After Friday 2026-03-06 close → next week start Mon 2026-03-09
+    live = default_live_forecast_start(latest_close="2026-03-06", asof="2026-03-06")
+    assert live.strftime("%Y-%m-%d") == "2026-03-09"
+
+
+def test_default_live_midweek_after_prior_eow():
+    # latest close Wed 2026-03-04 → prior EOW Fri 2026-02-27 → next week Mon 3/2
+    live = default_live_forecast_start(latest_close="2026-03-04", asof="2026-03-04")
+    assert live.strftime("%Y-%m-%d") == "2026-03-02"
+
+
+def test_resolve_empty_is_live():
+    r = resolve_forecast_start(None, asof="2026-03-06", latest_close="2026-03-06")
+    assert r.ok
+    assert r.start == "2026-03-09"
+    assert r.reason == "default_live"
+
+
+def test_resolve_today_uses_live():
+    r = resolve_forecast_start("2026-03-06", asof="2026-03-06", latest_close="2026-03-06")
+    assert r.ok
+    assert r.start == "2026-03-09"
+    assert r.reason == "today_or_default"
+
+
+def test_resolve_past_snaps():
+    r = resolve_forecast_start("2026-03-05", asof="2026-07-10", latest_close="2026-07-10")
+    assert r.ok
+    assert r.start == "2026-03-02"
+    assert r.reason == "snapped_week_start"
+
+
+def test_resolve_future_rejected():
+    r = resolve_forecast_start("2026-12-01", asof="2026-03-06", latest_close="2026-03-06")
+    assert not r.ok
+    assert r.reason == "future_rejected"
+    assert r.error
+
+
+def test_resolve_as_dict_keys():
+    r = resolve_forecast_start(None, asof="2026-03-06", latest_close="2026-03-06")
+    d = r.as_dict()
+    assert set(d) >= {"ok", "start", "reason", "live_default", "input", "error"}

--- a/tests/canswim/test_cli_run.py
+++ b/tests/canswim/test_cli_run.py
@@ -1,0 +1,98 @@
+"""CLI scoped gather/forecast routes through shared run_triggers."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from canswim.cli_run import run_forecast_tickers, run_gather_tickers, run_resolve_start
+from canswim.run_triggers import FORECAST_START_HELP, TICKERS_HELP
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_shared_help_strings_nonempty():
+    assert "YYYY-MM-DD" in FORECAST_START_HELP
+    assert "comma" in TICKERS_HELP.lower() or "Comma" in TICKERS_HELP
+
+
+def test_cli_help_lists_tickers_and_resolve(tmp_path):
+    proc = subprocess.run(
+        [sys.executable, "-m", "canswim", "-h"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert proc.returncode == 0
+    out = proc.stdout + proc.stderr
+    assert "--tickers" in out
+    assert "resolve_start" in out
+    assert "dry_run" in out or "--dry_run" in out
+
+
+def test_run_gather_tickers_force_allow(monkeypatch, capsys):
+    with patch(
+        "canswim.cli_run.gather_for_tickers",
+        return_value={"ok": True, "tickers": ["AAPL"], "rejected": [], "messages": []},
+    ) as g:
+        code = run_gather_tickers("aapl", include_covariates=False)
+    assert code == 0
+    g.assert_called_once()
+    assert g.call_args.kwargs.get("force_allow") is True
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is True
+    assert payload["tickers"] == ["AAPL"]
+
+
+def test_run_forecast_dry_run(monkeypatch, capsys):
+    with patch(
+        "canswim.cli_run.forecast_for_tickers",
+        return_value={
+            "ok": True,
+            "dry_run": True,
+            "tickers": ["MSFT"],
+            "resolved_start": {"ok": True, "start": "2026-03-02"},
+        },
+    ) as f:
+        code = run_forecast_tickers(
+            "MSFT", forecast_start_date="2026-03-05", dry_run=True
+        )
+    assert code == 0
+    assert f.call_args.kwargs["dry_run"] is True
+    assert f.call_args.kwargs["force_allow"] is True
+    assert f.call_args.kwargs["forecast_start_date"] == "2026-03-05"
+
+
+def test_run_resolve_start(capsys):
+    with patch(
+        "canswim.cli_run.resolve_start_for_run",
+        return_value={
+            "ok": True,
+            "start": "2026-03-02",
+            "reason": "snapped_week_start",
+            "live_default": "2026-07-13",
+            "input": "2026-03-05",
+            "error": None,
+            "latest_close_used": None,
+        },
+    ):
+        code = run_resolve_start("2026-03-05")
+    assert code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["start"] == "2026-03-02"
+
+
+def test_docs_run_triggers_exists():
+    doc = ROOT / "docs" / "run_triggers.md"
+    assert doc.is_file()
+    text = doc.read_text()
+    assert "CLI" in text and "GUI" in text and "MCP" in text
+    assert "run_triggers" in text
+    assert "MCP_ALLOW_RUNS" in text

--- a/tests/canswim/test_covariates_stack.py
+++ b/tests/canswim/test_covariates_stack.py
@@ -1,0 +1,114 @@
+"""Tests for covariate stack / ownership zero-fill (model feature dim)."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+from darts import TimeSeries
+
+from canswim.covariates import Covariates
+from canswim.eligibility import timeseries_from_observed_df
+
+
+def _price_ts(n: int = 20, start: str = "2024-01-02") -> TimeSeries:
+    idx = pd.bdate_range(start, periods=n)
+    df = pd.DataFrame(
+        {
+            "Open": range(n),
+            "High": range(1, n + 1),
+            "Low": range(n),
+            "Close": range(n),
+            "Volume": [1000] * n,
+        },
+        index=idx,
+    )
+    return timeseries_from_observed_df(df)
+
+
+def test_zero_ownership_series_has_fixed_columns():
+    c = Covariates()
+    prices = _price_ts()
+    z = c._zero_ownership_series(prices)
+    assert len(z) == len(prices)
+    assert list(z.components) == list(Covariates.INST_OWNERSHIP_COLS)
+    assert (z.pd_dataframe().values == 0).all()
+
+
+def test_prepare_ownership_zero_fills_missing_ticker():
+    c = Covariates()
+    # Empty multi-index with expected columns (no rows for QLYS)
+    cols = list(Covariates.INST_OWNERSHIP_COLS)
+    idx = pd.MultiIndex.from_tuples([], names=["Symbol", "Date"])
+    c.inst_symbol_ownership_df = pd.DataFrame(columns=cols, index=idx)
+
+    prices = _price_ts()
+    out = c.prepare_institutional_symbol_ownership_series(
+        stock_price_series={"QLYS": prices}
+    )
+    assert "QLYS" in out
+    assert len(out["QLYS"].components) == len(Covariates.INST_OWNERSHIP_COLS)
+
+
+def test_stack_zero_fills_missing_ticker_not_drop():
+    c = Covariates()
+    base = _price_ts().drop_columns(["Close"])  # Open/High/Low/Volume
+    # Only AAPL has new covs; QLYS should be zero-filled not dropped
+    new_aapl = timeseries_from_observed_df(
+        pd.DataFrame(
+            {"feat_a": 1.0, "feat_b": 2.0},
+            index=pd.DatetimeIndex(pd.to_datetime(base.time_index)).normalize(),
+        )
+    )
+    old = {"AAPL": base, "QLYS": base}
+    new = {"AAPL": new_aapl}
+    stacked = c.stack_covariates(old_covs=old, new_covs=new)
+    assert set(stacked.keys()) == {"AAPL", "QLYS"}
+    assert len(stacked["AAPL"].components) == len(base.components) + 2
+    assert len(stacked["QLYS"].components) == len(base.components) + 2
+    q = stacked["QLYS"].pd_dataframe()
+    assert (q["feat_a"] == 0).all()
+    assert (q["feat_b"] == 0).all()
+
+
+def test_stack_empty_new_with_column_template():
+    c = Covariates()
+    base = _price_ts().drop_columns(["Close"])
+    template = timeseries_from_observed_df(
+        pd.DataFrame(
+            {"own1": 0.0, "own2": 0.0},
+            index=pd.DatetimeIndex(pd.to_datetime(base.time_index)).normalize(),
+        )
+    )
+    old = {"QLYS": base}
+    stacked = c.stack_covariates(
+        old_covs=old, new_covs={}, column_template=template
+    )
+    assert "QLYS" in stacked
+    assert "own1" in stacked["QLYS"].components
+    assert "own2" in stacked["QLYS"].components
+
+
+def test_merge_symbol_date_parquet_keeps_other_symbols(tmp_path):
+    from canswim.gather_data import MarketDataGatherer
+
+    g = MarketDataGatherer.__new__(MarketDataGatherer)
+    path = tmp_path / "own.parquet"
+    old = pd.DataFrame(
+        {"cik": [1, 2]},
+        index=pd.MultiIndex.from_tuples(
+            [("AAPL", pd.Timestamp("2024-01-01")), ("MSFT", pd.Timestamp("2024-01-01"))],
+            names=["Symbol", "Date"],
+        ),
+    )
+    old.to_parquet(path)
+    new = pd.DataFrame(
+        {"cik": [9]},
+        index=pd.MultiIndex.from_tuples(
+            [("QLYS", pd.Timestamp("2024-06-01"))],
+            names=["Symbol", "Date"],
+        ),
+    )
+    merged = g._merge_symbol_date_parquet(str(path), new)
+    syms = set(merged.index.get_level_values(0).astype(str))
+    assert syms == {"AAPL", "MSFT", "QLYS"}
+    assert int(merged.loc[("QLYS", pd.Timestamp("2024-06-01")), "cik"]) == 9

--- a/tests/canswim/test_db.py
+++ b/tests/canswim/test_db.py
@@ -21,6 +21,7 @@ from canswim.db import (
     list_tickers,
     run_select,
     scan_forecasts,
+    sync_gathered_symbols,
     tables_present,
 )
 
@@ -95,6 +96,45 @@ def test_tables_present(mini_db):
 def test_list_tickers(mini_db):
     symbols = list_tickers(mini_db)
     assert symbols == ["AAA", "BBB"]
+
+
+def test_sync_gathered_symbols_adds_to_charts_list(mini_db, tmp_path: Path):
+    """Gathered symbols must land in stock_tickers + close_price for Charts."""
+    import numpy as np
+
+    price_path = tmp_path / "prices.parquet"
+    idx = pd.MultiIndex.from_product(
+        [["CCC"], pd.bdate_range("2025-01-02", periods=5)],
+        names=["Symbol", "Date"],
+    )
+    pdf = pd.DataFrame(
+        {
+            "Open": 1.0,
+            "High": 1.1,
+            "Low": 0.9,
+            "Close": np.linspace(10, 14, 5),
+            "Volume": 1000.0,
+        },
+        index=idx,
+    )
+    pdf.to_parquet(price_path)
+
+    before = list_tickers(mini_db)
+    assert "CCC" not in before
+    res = sync_gathered_symbols(
+        mini_db, ["CCC"], stocks_price_path=str(price_path)
+    )
+    assert res["ok"] is True
+    assert res["added"] == ["CCC"]
+    assert res["close_rows"] == 5
+    assert "CCC" in list_tickers(mini_db)
+    # Idempotent second call
+    res2 = sync_gathered_symbols(
+        mini_db, ["CCC"], stocks_price_path=str(price_path)
+    )
+    assert res2["ok"] is True
+    assert res2["added"] == []
+    assert "CCC" in list_tickers(mini_db)
 
 
 def test_get_forecast_rows_latest(mini_db):

--- a/tests/canswim/test_db.py
+++ b/tests/canswim/test_db.py
@@ -22,6 +22,7 @@ from canswim.db import (
     run_select,
     scan_forecasts,
     sync_gathered_symbols,
+    sync_forecasts_to_search_db,
     tables_present,
 )
 
@@ -141,6 +142,41 @@ def test_get_forecast_rows_latest(mini_db):
     df = get_forecast_rows(mini_db, "AAA", latest_only=True)
     assert len(df) == 2
     assert set(df["symbol"]) == {"AAA"}
+
+
+def test_sync_forecasts_to_search_db_from_hive_parquet(mini_db, tmp_path: Path):
+    """Forecast parquet must land in DuckDB so Charts can plot lines."""
+    # Build a tiny hive-style forecast partition for CCC
+    froot = tmp_path / "forecast" / "symbol=CCC" / "forecast_start_year=2026" / "forecast_start_month=3" / "forecast_start_day=2"
+    froot.mkdir(parents=True)
+    dates = pd.bdate_range("2026-03-02", periods=42)
+    fdf = pd.DataFrame(
+        {
+            "time": dates,
+            "symbol": "CCC",
+            "close_quantile_0.01": 90.0,
+            "close_quantile_0.05": 92.0,
+            "close_quantile_0.2": 95.0,
+            "close_quantile_0.5": 100.0,
+            "close_quantile_0.8": 105.0,
+            "close_quantile_0.95": 108.0,
+            "close_quantile_0.99": 110.0,
+            "forecast_start_year": 2026,
+            "forecast_start_month": 3,
+            "forecast_start_day": 2,
+        }
+    )
+    fdf.to_parquet(froot / "part.parquet", index=False)
+
+    before = get_forecast_rows(mini_db, "CCC", latest_only=False)
+    assert before is None or before.empty or len(before) == 0
+    res = sync_forecasts_to_search_db(
+        mini_db, ["CCC"], forecast_path=str(tmp_path / "forecast")
+    )
+    assert res["ok"] is True
+    assert res["forecast_rows"] == 42
+    after = get_forecast_rows(mini_db, "CCC", latest_only=False)
+    assert len(after) == 42
 
 
 def test_get_close_prices(mini_db):

--- a/tests/canswim/test_forecast_hard_fail.py
+++ b/tests/canswim/test_forecast_hard_fail.py
@@ -1,0 +1,81 @@
+"""Scoped forecast hard-fails when symbols lack complete data."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from canswim.run_triggers import INCOMPLETE_DATA_MSG, forecast_for_tickers
+
+
+def test_incomplete_data_message_is_consumer_friendly():
+    msg = INCOMPLETE_DATA_MSG.format(symbols="AAPL, MSFT")
+    assert "AAPL" in msg
+    assert "ISO" not in msg
+    assert "TiDE" not in msg
+    assert "gather" in msg.lower() or "market data" in msg.lower()
+
+
+def test_forecast_hard_fail_when_no_groups(monkeypatch):
+    monkeypatch.setenv("MCP_ALLOW_RUNS", "1")
+    cf = MagicMock()
+    cf.all_already_saved = False
+    cf.prep_next_stock_group.return_value = iter([])
+
+    with patch(
+        "canswim.run_triggers.resolve_start_for_run",
+        return_value={
+            "ok": True,
+            "start": "2026-03-02",
+            "reason": "snapped_week_start",
+            "live_default": "2026-07-13",
+            "input": None,
+            "error": None,
+            "latest_close_used": None,
+        },
+    ):
+        with patch("canswim.forecast.CanswimForecaster", return_value=cf):
+            r = forecast_for_tickers("AAPL", forecast_start_date="2026-03-02")
+
+    assert r["ok"] is False
+    assert r.get("need_gather") is True
+    assert "AAPL" in (r.get("error") or "")
+    assert "incomplete" in (r.get("error") or "").lower() or "market" in (
+        r.get("error") or ""
+    ).lower()
+
+
+def test_forecast_hard_fail_when_partial_skip(monkeypatch):
+    monkeypatch.setenv("MCP_ALLOW_RUNS", "1")
+    cf = MagicMock()
+    cf.all_already_saved = False
+    cf.prep_next_stock_group.return_value = iter([0])
+    qdf = MagicMock()
+    qdf.isna.return_value.all.return_value.all.return_value = False
+    mock_ts = MagicMock()
+    mock_ts.quantile_df.return_value = qdf
+    # Only AAPL succeeds; MSFT never appears in forecasts
+    cf.get_forecast.return_value = {"AAPL": mock_ts}
+
+    with patch(
+        "canswim.run_triggers.resolve_start_for_run",
+        return_value={
+            "ok": True,
+            "start": "2026-03-02",
+            "reason": "snapped_week_start",
+            "live_default": "2026-07-13",
+            "input": None,
+            "error": None,
+            "latest_close_used": None,
+        },
+    ):
+        with patch("canswim.forecast.CanswimForecaster", return_value=cf):
+            r = forecast_for_tickers(
+                "AAPL,MSFT", forecast_start_date="2026-03-02"
+            )
+
+    assert r["ok"] is False
+    assert r.get("need_gather") is True
+    assert "MSFT" in (r.get("error") or "")
+    assert "AAPL" in (r.get("forecasted") or [])

--- a/tests/canswim/test_forecast_hard_fail.py
+++ b/tests/canswim/test_forecast_hard_fail.py
@@ -35,8 +35,12 @@ def test_forecast_hard_fail_when_no_groups(monkeypatch):
             "latest_close_used": None,
         },
     ):
-        with patch("canswim.forecast.CanswimForecaster", return_value=cf):
-            r = forecast_for_tickers("AAPL", forecast_start_date="2026-03-02")
+        with patch(
+            "canswim.run_triggers.list_symbols_with_saved_forecast",
+            return_value=set(),
+        ):
+            with patch("canswim.forecast.CanswimForecaster", return_value=cf):
+                r = forecast_for_tickers("AAPL", forecast_start_date="2026-03-02")
 
     assert r["ok"] is False
     assert r.get("need_gather") is True
@@ -70,10 +74,14 @@ def test_forecast_hard_fail_when_partial_skip(monkeypatch):
             "latest_close_used": None,
         },
     ):
-        with patch("canswim.forecast.CanswimForecaster", return_value=cf):
-            r = forecast_for_tickers(
-                "AAPL,MSFT", forecast_start_date="2026-03-02"
-            )
+        with patch(
+            "canswim.run_triggers.list_symbols_with_saved_forecast",
+            return_value=set(),
+        ):
+            with patch("canswim.forecast.CanswimForecaster", return_value=cf):
+                r = forecast_for_tickers(
+                    "AAPL,MSFT", forecast_start_date="2026-03-02"
+                )
 
     assert r["ok"] is False
     assert r.get("need_gather") is True

--- a/tests/canswim/test_forecast_hard_fail.py
+++ b/tests/canswim/test_forecast_hard_fail.py
@@ -43,11 +43,11 @@ def test_forecast_hard_fail_when_no_groups(monkeypatch):
                 r = forecast_for_tickers("AAPL", forecast_start_date="2026-03-02")
 
     assert r["ok"] is False
-    assert r.get("need_gather") is True
+    # no groups prepared → covariate/align failure path (not pure price gap)
+    assert r.get("need_gather") or r.get("need_covariates")
     assert "AAPL" in (r.get("error") or "")
-    assert "incomplete" in (r.get("error") or "").lower() or "market" in (
-        r.get("error") or ""
-    ).lower()
+    err = (r.get("error") or "").lower()
+    assert "incomplete" in err or "market" in err or "forecast" in err or "inputs" in err
 
 
 def test_forecast_hard_fail_when_partial_skip(monkeypatch):
@@ -84,6 +84,6 @@ def test_forecast_hard_fail_when_partial_skip(monkeypatch):
                 )
 
     assert r["ok"] is False
-    assert r.get("need_gather") is True
+    assert r.get("need_gather") or r.get("need_covariates")
     assert "MSFT" in (r.get("error") or "")
     assert "AAPL" in (r.get("forecasted") or [])

--- a/tests/canswim/test_forecast_skip_existing.py
+++ b/tests/canswim/test_forecast_skip_existing.py
@@ -1,0 +1,104 @@
+"""Skip re-forecast when partitions already exist (no model load)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from canswim.run_triggers import (
+    ALREADY_FORECAST_MSG,
+    forecast_for_tickers,
+    list_symbols_with_saved_forecast,
+)
+
+
+def test_list_symbols_with_saved_forecast_empty_tree(tmp_path, monkeypatch):
+    monkeypatch.setenv("data_dir", str(tmp_path))
+    monkeypatch.setenv("forecast_subdir", "forecast/")
+    (tmp_path / "forecast").mkdir()
+    got = list_symbols_with_saved_forecast(["AAPL"], "2026-03-02")
+    assert got == set()
+
+
+def test_forecast_skips_model_when_all_already_saved(monkeypatch):
+    monkeypatch.setenv("MCP_ALLOW_RUNS", "1")
+    with patch(
+        "canswim.run_triggers.resolve_start_for_run",
+        return_value={
+            "ok": True,
+            "start": "2026-03-02",
+            "reason": "snapped_week_start",
+            "live_default": "2026-07-13",
+            "input": None,
+            "error": None,
+            "latest_close_used": None,
+        },
+    ):
+        with patch(
+            "canswim.run_triggers.list_symbols_with_saved_forecast",
+            return_value={"AAPL", "MSFT"},
+        ):
+            with patch("canswim.forecast.CanswimForecaster") as CF:
+                r = forecast_for_tickers(
+                    "AAPL,MSFT", forecast_start_date="2026-03-02"
+                )
+    assert r["ok"] is True
+    assert r.get("already_saved") is True
+    assert r.get("model_loaded") is False
+    assert set(r.get("already_have_forecast") or []) == {"AAPL", "MSFT"}
+    assert r.get("forecasted") == []
+    CF.assert_not_called()
+    assert "already" in " ".join(r.get("messages") or []).lower() or any(
+        "Skipped" in m or "already" in m.lower() for m in (r.get("messages") or [])
+    )
+
+
+def test_forecast_only_runs_missing_symbols(monkeypatch):
+    monkeypatch.setenv("MCP_ALLOW_RUNS", "1")
+    monkeypatch.setenv("data_dir", "/tmp/canswim_fc_skip_test")
+    monkeypatch.setenv("data-3rd-party", "data-3rd-party")
+
+    cf = MagicMock()
+    cf.all_already_saved = False
+    cf.prep_next_stock_group.return_value = iter([0])
+    qdf = MagicMock()
+    qdf.isna.return_value.all.return_value.all.return_value = False
+    mock_ts = MagicMock()
+    mock_ts.quantile_df.return_value = qdf
+    cf.get_forecast.return_value = {"MSFT": mock_ts}
+
+    with patch(
+        "canswim.run_triggers.resolve_start_for_run",
+        return_value={
+            "ok": True,
+            "start": "2026-03-02",
+            "reason": "snapped_week_start",
+            "live_default": "2026-07-13",
+            "input": None,
+            "error": None,
+            "latest_close_used": None,
+        },
+    ):
+        with patch(
+            "canswim.run_triggers.list_symbols_with_saved_forecast",
+            return_value={"AAPL"},  # AAPL done; only MSFT needs work
+        ):
+            with patch("canswim.forecast.CanswimForecaster", return_value=cf):
+                r = forecast_for_tickers(
+                    "AAPL,MSFT", forecast_start_date="2026-03-02"
+                )
+
+    assert r["ok"] is True
+    assert r.get("model_loaded") is True
+    assert r.get("forecasted") == ["MSFT"]
+    assert "AAPL" in (r.get("already_have_forecast") or [])
+    # Only MSFT should have been in the run list (prep still called once)
+    cf.prep_next_stock_group.assert_called_once()
+
+
+def test_consumer_already_msg_plain():
+    msg = ALREADY_FORECAST_MSG.format(symbols="QLYS", start="2026-07-06")
+    assert "QLYS" in msg
+    assert "TiDE" not in msg
+    assert "parquet" not in msg.lower()

--- a/tests/canswim/test_gather_policy.py
+++ b/tests/canswim/test_gather_policy.py
@@ -1,0 +1,142 @@
+"""Missing-only / 2y gather decisions (pure; no network)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from canswim.gather_policy import (
+    DEFAULT_FORECAST_MIN_BARS,
+    forecast_window_start,
+    plan_stock_price_fetches,
+    plan_symbol_price_fetch,
+)
+
+
+def _ohlcv_frame(symbol: str, start: str, n_bars: int) -> pd.DataFrame:
+    idx = pd.bdate_range(start=start, periods=n_bars)
+    data = {
+        "Open": np.linspace(100, 110, n_bars),
+        "High": np.linspace(101, 111, n_bars),
+        "Low": np.linspace(99, 109, n_bars),
+        "Close": np.linspace(100.5, 110.5, n_bars),
+        "Volume": np.full(n_bars, 1_000_000.0),
+    }
+    df = pd.DataFrame(data, index=idx)
+    df.index.name = "Date"
+    df["Symbol"] = symbol
+    df = df.reset_index().set_index(["Symbol", "Date"]).sort_index()
+    return df
+
+
+def test_forecast_window_is_about_two_years():
+    asof = pd.Timestamp("2026-07-10")
+    start = forecast_window_start(asof=asof)
+    assert start == pd.Timestamp("2024-07-10")
+
+
+def test_skip_when_local_complete_and_fresh():
+    # Long enough history; asof = last bar so coverage is fresh
+    df = _ohlcv_frame("AAPL", "2024-01-02", 600)
+    last = df.index.get_level_values("Date").max()
+    asof = pd.Timestamp(last).strftime("%Y-%m-%d")
+    plan = plan_symbol_price_fetch(
+        "AAPL",
+        df,
+        mode="forecast",
+        asof=asof,
+        min_bars=350,
+        freshness_days=5,
+    )
+    assert plan.action == "skip", plan
+    assert plan.fetch_start is None
+    assert "fresh" in plan.reason
+
+
+def test_fetch_when_missing_symbol():
+    df = _ohlcv_frame("MSFT", "2024-01-02", 600)
+    plan = plan_symbol_price_fetch(
+        "AAPL", df, mode="forecast", asof="2026-07-10", min_bars=350
+    )
+    assert plan.action == "fetch"
+    assert plan.fetch_start is not None
+    # Window start ~2y before asof
+    assert plan.fetch_start.startswith("2024-")
+    assert plan.reason == "missing_local_symbol"
+
+
+def test_fetch_stale_uses_tail_start():
+    # Complete window relative to last bar, but asof is much later → stale tail fetch
+    df = _ohlcv_frame("AAPL", "2024-01-02", 500)
+    last = pd.Timestamp(df.index.get_level_values("Date").max())
+    asof = last + pd.Timedelta(days=30)
+    plan = plan_symbol_price_fetch(
+        "AAPL",
+        df,
+        mode="forecast",
+        asof=asof,
+        min_bars=350,
+        freshness_days=5,
+    )
+    assert plan.action == "fetch", plan
+    assert plan.reason == "local_complete_but_stale", plan
+    assert plan.fetch_start is not None
+    assert pd.Timestamp(plan.fetch_start) >= last - pd.Timedelta(days=2)
+
+
+def test_short_history_fetches_from_window():
+    asof = "2026-07-10"
+    df = _ohlcv_frame("AAPL", "2026-01-02", 20)
+    plan = plan_symbol_price_fetch(
+        "AAPL", df, mode="forecast", asof=asof, min_bars=350
+    )
+    assert plan.action == "fetch"
+    assert plan.fetch_start == forecast_window_start(asof=asof).strftime("%Y-%m-%d")
+    assert "incomplete" in plan.reason or "no_bars" in plan.reason
+
+
+def test_train_mode_uses_long_start():
+    plan = plan_symbol_price_fetch(
+        "ZZZZ",
+        None,
+        mode="train",
+        asof="2026-07-10",
+        train_min_start="1991-01-01",
+    )
+    assert plan.action == "fetch"
+    assert plan.fetch_start == "1991-01-01"
+
+
+def test_gather_stock_price_skips_remote_when_all_skip():
+    """Shipped gather_stock_price_data must not call FMP/yf when plans are all skip."""
+    from canswim.gather_data import MarketDataGatherer
+    from canswim.gather_policy import SymbolFetchPlan
+
+    df = _ohlcv_frame("AAPL", "2024-01-02", 600)
+    g = MarketDataGatherer()
+    g.gather_mode = "forecast"
+    g.stocks_ticker_set = ["AAPL"]
+    g.FMP_API_KEY = "fake"
+    skip_plan = [
+        SymbolFetchPlan(
+            symbol="AAPL",
+            action="skip",
+            fetch_start=None,
+            reason="local_complete_and_fresh",
+        )
+    ]
+
+    with patch.object(g, "_data_file", return_value="/tmp/fake_prices.parquet"):
+        with patch("pandas.read_parquet", return_value=df):
+            with patch.object(g, "_fetch_stock_prices_fmp") as fmp:
+                with patch.object(g, "_fetch_stock_prices_yfinance") as yf:
+                    with patch(
+                        "canswim.gather_policy.plan_stock_price_fetches",
+                        return_value=skip_plan,
+                    ):
+                        g.gather_stock_price_data()
+                    fmp.assert_not_called()
+                    yf.assert_not_called()

--- a/tests/canswim/test_gather_policy.py
+++ b/tests/canswim/test_gather_policy.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import numpy as np
 import pandas as pd
@@ -10,7 +10,10 @@ import pytest
 
 from canswim.gather_policy import (
     DEFAULT_FORECAST_MIN_BARS,
+    DEFAULT_TRAIN_MIN_BARS,
+    evaluate_symbol_coverage,
     forecast_window_start,
+    incomplete_symbols,
     plan_stock_price_fetches,
     plan_symbol_price_fetch,
 )
@@ -39,8 +42,8 @@ def test_forecast_window_is_about_two_years():
 
 
 def test_skip_when_local_complete_and_fresh():
-    # Long enough history; asof = last bar so coverage is fresh
-    df = _ohlcv_frame("AAPL", "2024-01-02", 600)
+    # Full ~2y+ window ending at asof
+    df = _ohlcv_frame("AAPL", "2024-01-02", 650)
     last = df.index.get_level_values("Date").max()
     asof = pd.Timestamp(last).strftime("%Y-%m-%d")
     plan = plan_symbol_price_fetch(
@@ -56,6 +59,24 @@ def test_skip_when_local_complete_and_fresh():
     assert "fresh" in plan.reason
 
 
+def test_partial_window_tail_must_fetch():
+    """350+ bars starting mid-window must NOT skip — missing early window coverage."""
+    asof = "2026-07-10"
+    # Window start ≈ 2024-07-10; start history much later
+    df = _ohlcv_frame("AAPL", "2025-01-02", 400)
+    plan = plan_symbol_price_fetch(
+        "AAPL",
+        df,
+        mode="forecast",
+        asof=asof,
+        min_bars=350,
+        freshness_days=400,  # freshness alone would pass
+    )
+    assert plan.action == "fetch", plan
+    assert plan.reason.startswith("window_starts_late"), plan
+    assert plan.fetch_start == forecast_window_start(asof=asof).strftime("%Y-%m-%d")
+
+
 def test_fetch_when_missing_symbol():
     df = _ohlcv_frame("MSFT", "2024-01-02", 600)
     plan = plan_symbol_price_fetch(
@@ -63,14 +84,13 @@ def test_fetch_when_missing_symbol():
     )
     assert plan.action == "fetch"
     assert plan.fetch_start is not None
-    # Window start ~2y before asof
     assert plan.fetch_start.startswith("2024-")
     assert plan.reason == "missing_local_symbol"
+    assert plan.is_incomplete is True
 
 
 def test_fetch_stale_uses_tail_start():
-    # Complete window relative to last bar, but asof is much later → stale tail fetch
-    df = _ohlcv_frame("AAPL", "2024-01-02", 500)
+    df = _ohlcv_frame("AAPL", "2024-01-02", 550)
     last = pd.Timestamp(df.index.get_level_values("Date").max())
     asof = last + pd.Timedelta(days=30)
     plan = plan_symbol_price_fetch(
@@ -83,6 +103,7 @@ def test_fetch_stale_uses_tail_start():
     )
     assert plan.action == "fetch", plan
     assert plan.reason == "local_complete_but_stale", plan
+    assert plan.is_incomplete is False
     assert plan.fetch_start is not None
     assert pd.Timestamp(plan.fetch_start) >= last - pd.Timedelta(days=2)
 
@@ -95,10 +116,31 @@ def test_short_history_fetches_from_window():
     )
     assert plan.action == "fetch"
     assert plan.fetch_start == forecast_window_start(asof=asof).strftime("%Y-%m-%d")
-    assert "incomplete" in plan.reason or "no_bars" in plan.reason
+    assert plan.is_incomplete is True
 
 
-def test_train_mode_uses_long_start():
+def test_train_mode_partial_history_must_fetch():
+    """~2y of data is not enough to skip under train mode (long window)."""
+    # Plenty of bars for forecast, but first bar far after train_min_start
+    df = _ohlcv_frame("AAPL", "2024-01-02", 600)
+    last = df.index.get_level_values("Date").max()
+    plan = plan_symbol_price_fetch(
+        "AAPL",
+        df,
+        mode="train",
+        asof=pd.Timestamp(last),
+        train_min_start="1991-01-01",
+        freshness_days=5,
+    )
+    assert plan.action == "fetch", plan
+    assert plan.fetch_start == "1991-01-01"
+    assert (
+        plan.reason.startswith("window_starts_late")
+        or plan.reason.startswith("local_incomplete")
+    ), plan
+
+
+def test_train_mode_uses_long_start_when_missing():
     plan = plan_symbol_price_fetch(
         "ZZZZ",
         None,
@@ -110,12 +152,23 @@ def test_train_mode_uses_long_start():
     assert plan.fetch_start == "1991-01-01"
 
 
+def test_incomplete_symbols_helper():
+    plans = plan_stock_price_fetches(
+        ["AAPL", "MSFT"],
+        _ohlcv_frame("AAPL", "2025-01-02", 400),
+        mode="forecast",
+        asof="2026-07-10",
+    )
+    bad = incomplete_symbols(plans)
+    assert "AAPL" in bad  # late window start
+    assert "MSFT" in bad  # missing
+
+
 def test_gather_stock_price_skips_remote_when_all_skip():
-    """Shipped gather_stock_price_data must not call FMP/yf when plans are all skip."""
     from canswim.gather_data import MarketDataGatherer
     from canswim.gather_policy import SymbolFetchPlan
 
-    df = _ohlcv_frame("AAPL", "2024-01-02", 600)
+    df = _ohlcv_frame("AAPL", "2024-01-02", 650)
     g = MarketDataGatherer()
     g.gather_mode = "forecast"
     g.stocks_ticker_set = ["AAPL"]
@@ -128,6 +181,8 @@ def test_gather_stock_price_skips_remote_when_all_skip():
             reason="local_complete_and_fresh",
         )
     ]
+    # Post-eval uses real plan on full df — ensure coverage ok
+    last = df.index.get_level_values("Date").max()
 
     with patch.object(g, "_data_file", return_value="/tmp/fake_prices.parquet"):
         with patch("pandas.read_parquet", return_value=df):
@@ -137,6 +192,73 @@ def test_gather_stock_price_skips_remote_when_all_skip():
                         "canswim.gather_policy.plan_stock_price_fetches",
                         return_value=skip_plan,
                     ):
-                        g.gather_stock_price_data()
+                        with patch(
+                            "canswim.gather_policy.evaluate_symbol_coverage",
+                            return_value={
+                                "plans": skip_plan,
+                                "incomplete": [],
+                                "skipped": ["AAPL"],
+                                "stale_only": [],
+                                "ok": True,
+                            },
+                        ):
+                            g.gather_stock_price_data()
                     fmp.assert_not_called()
                     yf.assert_not_called()
+
+
+def test_gather_raises_when_remote_empty_for_missing_symbol():
+    """Shipped gather_stock_price_data must not succeed with empty remote for missing sym."""
+    from canswim.gather_data import MarketDataGatherer
+
+    # Local only has AAPL; request MSFT
+    df = _ohlcv_frame("AAPL", "2024-01-02", 650)
+    g = MarketDataGatherer()
+    g.gather_mode = "forecast"
+    g.stocks_ticker_set = ["MSFT"]
+    g.FMP_API_KEY = "fake"
+
+    with patch.object(g, "_data_file", return_value="/tmp/fake_prices2.parquet"):
+        with patch("pandas.read_parquet", return_value=df):
+            with patch.object(
+                g, "_fetch_stock_prices_fmp", return_value=pd.DataFrame()
+            ):
+                with patch.object(
+                    g, "_fetch_stock_prices_yfinance", return_value=pd.DataFrame()
+                ):
+                    with pytest.raises(RuntimeError, match="MSFT|complete|usable"):
+                        g.gather_stock_price_data()
+
+
+def test_gather_for_tickers_reports_ok_false_when_incomplete(monkeypatch):
+    monkeypatch.setenv("MCP_ALLOW_RUNS", "1")
+    from canswim.run_triggers import gather_for_tickers
+
+    g = type("G", (), {})()
+    g.stocks_ticker_set = []
+    g.gather_mode = "forecast"
+    g.last_price_fetch_plans = []
+    g.last_post_fetch_plans = []
+    g.last_remote_symbols_written = []
+
+    def _boom():
+        from canswim.gather_policy import SymbolFetchPlan
+
+        g.last_price_fetch_plans = [
+            SymbolFetchPlan("MSFT", "fetch", "2024-07-10", "missing_local_symbol")
+        ]
+        g.last_post_fetch_plans = g.last_price_fetch_plans
+        g.last_remote_symbols_written = []
+        raise RuntimeError(
+            "Could not obtain complete market history for: MSFT. "
+            "Remote download returned no usable bars for those symbols."
+        )
+
+    g.gather_broad_market_data = lambda: None
+    g.gather_sectors_data = lambda: None
+    g.gather_stock_price_data = _boom
+
+    with patch("canswim.gather_data.MarketDataGatherer", return_value=g):
+        r = gather_for_tickers("MSFT", include_covariates=False, force_allow=True)
+    assert r["ok"] is False
+    assert "MSFT" in (r.get("error") or "")

--- a/tests/canswim/test_mcp_tools.py
+++ b/tests/canswim/test_mcp_tools.py
@@ -9,7 +9,8 @@ import duckdb
 import pytest
 
 from canswim.mcp.tools import forecasts, meta, prices, query, tickers
-from canswim.mcp.tools.meta import TOOL_NAMES
+from canswim.mcp.tools import runs as run_tools
+from canswim.mcp.tools.meta import READ_TOOL_NAMES, TOOL_NAMES, WRITE_TOOL_NAMES
 
 
 def _build_mini_db(path: Path) -> str:
@@ -72,17 +73,56 @@ def test_tool_names_cover_surface():
         "get_close_price",
         "get_backtest_error",
         "run_select",
+        "resolve_forecast_start",
+        "gather_tickers",
+        "forecast_tickers",
     }
     assert set(TOOL_NAMES) == expected
+    assert set(WRITE_TOOL_NAMES) == {"gather_tickers", "forecast_tickers"}
+    assert "resolve_forecast_start" in READ_TOOL_NAMES
 
 
-def test_health_and_info(mcp_env):
+def test_health_and_info(mcp_env, monkeypatch):
+    monkeypatch.delenv("MCP_ALLOW_RUNS", raising=False)
+    monkeypatch.delenv("CANSWIM_ALLOW_RUNS", raising=False)
     h = meta.health_check_impl()
     assert h["ok"] is True
+    assert h["data"]["is_read_only"] is True
     info = meta.get_server_info_impl()
     assert info["ok"] is True
     assert info["data"]["is_read_only"] is True
+    assert info["data"]["runs_allowed"] is False
     assert "list_tickers" in info["data"]["tools"]
+    assert "gather_tickers" in info["data"]["tools"]
+    assert "forecast_tickers" in info["data"]["write_tools"]
+
+
+def test_write_tools_blocked_without_opt_in(mcp_env, monkeypatch):
+    monkeypatch.delenv("MCP_ALLOW_RUNS", raising=False)
+    monkeypatch.delenv("CANSWIM_ALLOW_RUNS", raising=False)
+    g = run_tools.gather_tickers_impl("AAPL")
+    assert g["ok"] is False
+    assert "MCP_ALLOW_RUNS" in g["error"]
+    f = run_tools.forecast_tickers_impl("AAPL", dry_run=True)
+    assert f["ok"] is False
+
+
+def test_resolve_forecast_start_always_available(mcp_env, monkeypatch):
+    monkeypatch.delenv("MCP_ALLOW_RUNS", raising=False)
+    r = run_tools.resolve_forecast_start_impl(start_date="2026-03-05")
+    assert r["ok"] is True
+    assert r["data"]["start"] == "2026-03-02"
+
+
+def test_server_module_registers_run_tools():
+    """Structural: real server module exposes write tool callables."""
+    from canswim.mcp import server as srv
+
+    assert hasattr(srv, "gather_tickers")
+    assert hasattr(srv, "forecast_tickers")
+    assert hasattr(srv, "resolve_forecast_start")
+    assert callable(srv.gather_tickers)
+    assert callable(srv.forecast_tickers)
 
 
 def test_list_tickers(mcp_env):

--- a/tests/canswim/test_run_triggers.py
+++ b/tests/canswim/test_run_triggers.py
@@ -1,0 +1,181 @@
+"""Tests for ticker parse + run orchestration entry points (hermetic)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from canswim.run_triggers import (
+    forecast_for_tickers,
+    gather_for_tickers,
+    parse_ticker_list,
+    require_runs_allowed,
+    resolve_start_for_run,
+    runs_allowed,
+)
+
+
+def test_parse_comma_and_newline():
+    r = parse_ticker_list("aapl, msft\nGOOGL,  nvda")
+    assert r["ok"] is True
+    assert r["tickers"] == ["AAPL", "MSFT", "GOOGL", "NVDA"]
+    assert r["rejected"] == []
+
+
+def test_parse_mixed_whitespace_semicolon():
+    r = parse_ticker_list("aapl;msft  googl")
+    assert r["tickers"] == ["AAPL", "MSFT", "GOOGL"]
+
+
+def test_parse_empty():
+    r = parse_ticker_list("  \n  ")
+    assert r["ok"] is False
+    assert r["tickers"] == []
+
+
+def test_parse_invalid_and_duplicate():
+    r = parse_ticker_list("AAPL, 12.5, AAPL, ???, MSFT")
+    assert r["ok"] is True
+    assert r["tickers"] == ["AAPL", "MSFT"]
+    reasons = {x["reason"] for x in r["rejected"]}
+    assert "invalid_symbol" in reasons
+    assert "duplicate" in reasons
+
+
+def test_parse_max_truncation():
+    text = ",".join(f"T{i:03d}" for i in range(60))
+    # T000 style may fail ticker regex (digit after letter ok) — use AAA, AAB...
+    syms = []
+    for i in range(60):
+        syms.append(f"A{i:03d}")  # A000 invalid? letter then digits ok up to 10
+    r = parse_ticker_list(",".join(syms), max_tickers=10)
+    assert r["ok"] is True
+    assert len(r["tickers"]) == 10
+    assert r["truncated"] is True
+
+
+def test_runs_allowed_env(monkeypatch):
+    monkeypatch.delenv("MCP_ALLOW_RUNS", raising=False)
+    monkeypatch.delenv("CANSWIM_ALLOW_RUNS", raising=False)
+    assert runs_allowed() is False
+    monkeypatch.setenv("MCP_ALLOW_RUNS", "1")
+    assert runs_allowed() is True
+
+
+def test_require_runs_blocked(monkeypatch):
+    monkeypatch.delenv("MCP_ALLOW_RUNS", raising=False)
+    monkeypatch.delenv("CANSWIM_ALLOW_RUNS", raising=False)
+    err = require_runs_allowed()
+    assert err is not None
+    assert err["ok"] is False
+
+
+def test_gather_blocked_without_flag(monkeypatch):
+    monkeypatch.delenv("MCP_ALLOW_RUNS", raising=False)
+    monkeypatch.delenv("CANSWIM_ALLOW_RUNS", raising=False)
+    r = gather_for_tickers("AAPL")
+    assert r["ok"] is False
+    assert "disabled" in r["error"].lower() or "MCP_ALLOW_RUNS" in r["error"]
+
+
+def test_gather_calls_scoped_tickers(monkeypatch):
+    monkeypatch.setenv("MCP_ALLOW_RUNS", "1")
+    g = MagicMock()
+    with patch("canswim.gather_data.MarketDataGatherer", return_value=g):
+        with patch("canswim.run_triggers._ensure_symbols_on_list"):
+            r = gather_for_tickers("aapl, msft\nnvda", include_covariates=False)
+    assert r["ok"] is True
+    assert r["tickers"] == ["AAPL", "MSFT", "NVDA"]
+    assert g.stocks_ticker_set == ["AAPL", "MSFT", "NVDA"]
+    g.gather_stock_price_data.assert_called_once()
+    g.gather_broad_market_data.assert_called_once()
+
+
+def test_gather_force_allow_skips_gate(monkeypatch):
+    monkeypatch.delenv("MCP_ALLOW_RUNS", raising=False)
+    monkeypatch.delenv("CANSWIM_ALLOW_RUNS", raising=False)
+    g = MagicMock()
+    with patch("canswim.gather_data.MarketDataGatherer", return_value=g):
+        with patch("canswim.run_triggers._ensure_symbols_on_list"):
+            r = gather_for_tickers("AAPL", include_covariates=False, force_allow=True)
+    assert r["ok"] is True
+    assert r["tickers"] == ["AAPL"]
+
+
+def test_forecast_dry_run_resolves_start(monkeypatch):
+    monkeypatch.setenv("MCP_ALLOW_RUNS", "1")
+    with patch(
+        "canswim.run_triggers.resolve_start_for_run",
+        return_value={
+            "ok": True,
+            "start": "2026-03-02",
+            "reason": "snapped_week_start",
+            "live_default": "2026-07-13",
+            "input": "2026-03-05",
+            "error": None,
+            "latest_close_used": "2026-07-10",
+        },
+    ):
+        r = forecast_for_tickers(
+            "AAPL,MSFT",
+            forecast_start_date="2026-03-05",
+            dry_run=True,
+        )
+    assert r["ok"] is True
+    assert r["dry_run"] is True
+    assert r["tickers"] == ["AAPL", "MSFT"]
+    assert r["resolved_start"]["start"] == "2026-03-02"
+
+
+def test_forecast_passes_resolved_start_to_forecaster(monkeypatch):
+    monkeypatch.setenv("MCP_ALLOW_RUNS", "1")
+    monkeypatch.setenv("data_dir", "/tmp/canswim_test_data_unused")
+    monkeypatch.setenv("data-3rd-party", "data-3rd-party")
+
+    cf = MagicMock()
+    cf.all_already_saved = False
+    cf.prep_next_stock_group.return_value = iter([0])
+    mock_ts = MagicMock()
+    mock_ts.quantile_df.return_value = MagicMock(
+        **{"isna.return_value.all.return_value.all.return_value": False}
+    )
+    # make isna().all().all() False
+    qdf = MagicMock()
+    qdf.isna.return_value.all.return_value.all.return_value = False
+    mock_ts.quantile_df.return_value = qdf
+    cf.get_forecast.return_value = {"AAPL": mock_ts}
+
+    with patch(
+        "canswim.run_triggers.resolve_start_for_run",
+        return_value={
+            "ok": True,
+            "start": "2026-03-02",
+            "reason": "snapped_week_start",
+            "live_default": "2026-07-13",
+            "input": "2026-03-05",
+            "error": None,
+            "latest_close_used": None,
+        },
+    ):
+        with patch("canswim.forecast.CanswimForecaster", return_value=cf):
+            with patch("canswim.forecast.get_next_open_market_day"):
+                r = forecast_for_tickers(
+                    "AAPL",
+                    forecast_start_date="2026-03-05",
+                    dry_run=False,
+                )
+
+    assert r["ok"] is True
+    assert r["forecasted"] == ["AAPL"]
+    # Forecast start passed to get_forecast / prep is snapped week start
+    call_kw = cf.get_forecast.call_args
+    fsd = call_kw.kwargs.get("forecast_start_date") or call_kw[1].get(
+        "forecast_start_date"
+    )
+    if fsd is None and call_kw[0]:
+        fsd = call_kw[0][0]
+    import pandas as pd
+
+    assert pd.Timestamp(fsd).strftime("%Y-%m-%d") == "2026-03-02"
+    cf.save_forecast.assert_called_once()

--- a/tests/canswim/test_ux_split_labels.py
+++ b/tests/canswim/test_ux_split_labels.py
@@ -52,6 +52,38 @@ def test_run_tab_has_separate_gather_and_forecast_controls():
     # Two separate status outputs
     assert "gatherStatus" in src
     assert "forecastStatus" in src
+    # JSON is advanced/collapsed, not primary body
+    assert "Advanced details" in src
+    assert "gatherDetails" in src
+    assert "forecastDetails" in src
+    assert "open=False" in src
+
+
+def test_summary_helpers_are_plain():
+    from canswim.dashboard.run_tab import _forecast_summary, _gather_summary
+
+    g = _gather_summary(
+        {
+            "ok": True,
+            "tickers": ["AAPL"],
+            "skipped_remote": ["AAPL"],
+            "fetched": [],
+            "db_sync": {"added": []},
+        }
+    )
+    assert "AAPL" in g
+    assert "```" not in g
+    f = _forecast_summary(
+        {
+            "ok": True,
+            "already_saved": True,
+            "forecasted": [],
+            "already_have_forecast": ["QLYS"],
+            "resolved_start": {"start": "2026-07-06"},
+        }
+    )
+    assert "Already done" in f or "already" in f.lower()
+    assert "```json" not in f
 
 
 def test_cli_help_separates_gather_and_forecast():

--- a/tests/canswim/test_ux_split_labels.py
+++ b/tests/canswim/test_ux_split_labels.py
@@ -1,0 +1,96 @@
+"""UX split + consumer-friendly labels (structural + string checks)."""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+
+from canswim.dashboard import run_tab as run_tab_mod
+from canswim.run_triggers import (
+    DATE_POLICY_SUMMARY,
+    FORECAST_BUTTON,
+    FORECAST_SECTION_TITLE,
+    FORECAST_START_HELP,
+    GATHER_BUTTON,
+    GATHER_SECTION_TITLE,
+    TICKERS_HELP,
+)
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_consumer_copy_avoids_dev_jargon():
+    for s in (
+        TICKERS_HELP,
+        FORECAST_START_HELP,
+        GATHER_SECTION_TITLE,
+        FORECAST_SECTION_TITLE,
+        GATHER_BUTTON,
+        FORECAST_BUTTON,
+    ):
+        assert "ISO week" not in s
+        assert "TiDE" not in s
+        assert "week-aligned starts:" not in s.lower()
+        assert "CLI equivalent" not in s
+
+
+def test_date_policy_summary_not_technical_dump():
+    # Primary UI must not use the old multi-clause technical blurb
+    assert "backtest picks" not in DATE_POLICY_SUMMARY
+    assert "ISO week" not in DATE_POLICY_SUMMARY
+
+
+def test_run_tab_has_separate_gather_and_forecast_controls():
+    src = inspect.getsource(run_tab_mod.RunTab.__init__)
+    assert "gatherTickers" in src
+    assert "forecastTickers" in src
+    assert "gatherBtn" in src
+    assert "forecastBtn" in src
+    assert GATHER_SECTION_TITLE in src or "GATHER_SECTION_TITLE" in src
+    assert FORECAST_SECTION_TITLE in src or "FORECAST_SECTION_TITLE" in src
+    # Two separate status outputs
+    assert "gatherStatus" in src
+    assert "forecastStatus" in src
+
+
+def test_cli_help_separates_gather_and_forecast():
+    import subprocess
+    import sys
+
+    proc = subprocess.run(
+        [sys.executable, "-m", "canswim", "-h"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert proc.returncode == 0
+    out = proc.stdout + proc.stderr
+    assert "gatherdata" in out
+    assert "forecast" in out
+    assert "--tickers" in out
+    assert "ISO week" not in out
+
+
+def test_mcp_tool_descriptions_are_plain():
+    from canswim.mcp import server as srv
+
+    # FastMCP stores tools; at least callables exist with docstrings / descriptions
+    assert callable(srv.gather_tickers)
+    assert callable(srv.forecast_tickers)
+    assert callable(srv.resolve_forecast_start)
+    # Descriptions live on decorated tools — check module source for plain language
+    src = Path(srv.__file__).read_text()
+    assert "market data" in src.lower()
+    assert "ISO week" not in src
+    assert 'name="gather_tickers"' in src
+    assert 'name="forecast_tickers"' in src
+    assert "Requires MCP_ALLOW_RUNS=1" in src
+    # Tool description block for forecast should be plain language
+    assert "Run a forecast for listed stock symbols" in src
+
+
+def test_docs_exist_for_operators():
+    doc = ROOT / "docs" / "run_triggers.md"
+    assert doc.is_file()


### PR DESCRIPTION
## Summary
- Shared pure helpers: ticker list parse + NYSE week-start snap / live default
- Orchestration: `gather_for_tickers` / `forecast_for_tickers` (structured results)
- Dashboard **Run** tab: paste tickers → Gather / Forecast / preview start
- MCP: `resolve_forecast_start` (read-only); `gather_tickers` / `forecast_tickers` require `MCP_ALLOW_RUNS=1`

## Test plan
- [x] Unit tests for parse + calendar fixtures
- [x] Hermetic orchestration mocks (ticker list + snapped start passed through)
- [x] MCP surface / opt-in gate tests
- [x] Local CI (`./scripts/ci-local.sh`)
- [x] Optional live gather smoke for AAPL when FMP key present