### PR TITLE
fix: backtest_error display precision on Scans/Charts

### DIFF
--- a/src/canswim/dashboard/advanced.py
+++ b/src/canswim/dashboard/advanced.py
@@ -73,7 +73,9 @@ class AdvancedTab:
         try:
             df = run_select(self.db_path, query, row_limit=50_000)
             logger.info(f"SQL Result rows: {len(df)}")
-            return df
+            from canswim.dashboard.formatting import format_forecast_metrics_table
+
+            return format_forecast_metrics_table(df)
         except SelectOnlyError as e:
             gr.Error(str(e))
             return None

--- a/src/canswim/dashboard/charts.py
+++ b/src/canswim/dashboard/charts.py
@@ -93,11 +93,9 @@ class ChartTab:
         logger.info(f"rr table df: {df}")
         if df is None or df.empty:
             return df
-        return df.style.format(
-            precision=2,
-            thousands=",",
-            decimal=".",
-        )
+        from canswim.dashboard.formatting import format_forecast_metrics_table
+
+        return format_forecast_metrics_table(df)
 
     def plot_quantiles_df(
         self,

--- a/src/canswim/dashboard/formatting.py
+++ b/src/canswim/dashboard/formatting.py
@@ -1,0 +1,33 @@
+"""Shared Gradio dataframe display formatting for dashboard tables."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+
+
+def format_forecast_metrics_table(df: pd.DataFrame | None) -> Any:
+    """Style reward/risk / scan tables for readable numeric precision.
+
+    ``backtest_error`` is a mean abs log-error typically ~0.001–0.1. Rounding
+    it to 2 decimals makes distinct symbols look identical (all 0.02/0.03).
+    Keep prices / % / R:R at 2 decimals; show backtest_error at 4.
+    """
+    if df is None or getattr(df, "empty", True):
+        return df
+
+    # Already a Styler — leave alone
+    if not isinstance(df, pd.DataFrame):
+        return df
+
+    fmt: dict[str, str] = {}
+    for col in df.columns:
+        name = str(col).lower()
+        if name in {"backtest_error", "mal_error"} or name.endswith("_mal_error"):
+            fmt[col] = "{:.4f}"
+        elif pd.api.types.is_numeric_dtype(df[col]):
+            fmt[col] = "{:.2f}"
+    if not fmt:
+        return df
+    return df.style.format(fmt, na_rep="")

--- a/src/canswim/dashboard/scans.py
+++ b/src/canswim/dashboard/scans.py
@@ -205,9 +205,6 @@ class ScanTab:
             f"**{n} symbol{'s' if n != 1 else ''}** · as-of `{asof}` · "
             f"reward ≥ {reward}% · R/R ≥ {rr} · low conf {lowq}%"
         )
-        styled = df.style.format(
-            precision=2,
-            thousands=",",
-            decimal=".",
-        )
-        return status, styled
+        from canswim.dashboard.formatting import format_forecast_metrics_table
+
+        return status, format_forecast_metrics_table(df)

--- a/tests/canswim/dashboard/test_formatting.py
+++ b/tests/canswim/dashboard/test_formatting.py
@@ -1,0 +1,34 @@
+"""Dashboard table formatting (backtest_error precision)."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from canswim.dashboard.formatting import format_forecast_metrics_table
+
+
+def test_backtest_error_uses_four_decimals():
+    df = pd.DataFrame(
+        {
+            "symbol": ["AMZN", "AAPL"],
+            "prior_close_price": [210.0, 264.18],
+            "reward_percent": [11.43, 10.16],
+            "reward_risk": [9.51, 2.65],
+            "backtest_error": [0.026425, 0.020363],
+        }
+    )
+    styled = format_forecast_metrics_table(df)
+    # Styler stores format funcs; render HTML/string and check distinction
+    html = styled.to_html()
+    assert "0.0264" in html
+    assert "0.0204" in html
+    # Must not collapse both to the same 2-dp value
+    assert "0.03" not in html or "0.0264" in html
+    assert "210.00" in html
+    assert "11.43" in html
+
+
+def test_empty_passthrough():
+    assert format_forecast_metrics_table(None) is None
+    empty = pd.DataFrame()
+    assert format_forecast_metrics_table(empty) is empty


### PR DESCRIPTION
## Summary
- Scans (and Charts RR table / Advanced query results) showed `backtest_error` rounded to 2 decimals, so distinct values like 0.020 / 0.026 / 0.028 all rendered as 0.02 or 0.03.
- Shared formatter: **4 decimals** for `backtest_error`, **2** for prices / % / R:R.

## Test plan
- [x] Unit test for HTML rendering of 4-decimal errors
- [x] `./scripts/ci-local.sh`
- [ ] Hard-refresh Scans on `2026-03-02` — errors should differ per symbol