### PR TITLE
fix: include dashboard tests in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,4 +34,4 @@ jobs:
     
     - name: Run tests
       run: |
-        python -m pytest tests/canswim/test_*.py -v
+        python -m pytest tests/canswim/ -v

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -39,7 +39,7 @@ fi
 mkdir -p data/data-3rd-party data/forecast
 
 echo "==> pytest tests/canswim/"
-# Same module set as CI: tests/canswim/test_*.py
-"${PY[@]}" -m pytest tests/canswim/test_*.py -q --tb=short
+# Recurse package (includes tests/canswim/dashboard/, etc.)
+"${PY[@]}" -m pytest tests/canswim/ -q --tb=short
 
 echo "==> local CI OK"


### PR DESCRIPTION
## Summary
- `pytest tests/canswim/test_*.py` only matched top-level files.
- Nested `tests/canswim/dashboard/` (e.g. backtest_error formatting) was never executed.
- Local + GHA now use `pytest tests/canswim/` (131 tests locally).

## Test plan
- [x] `./scripts/ci-local.sh` → 131 passed