### PR TITLE
chore: GitHub Pages from main docs (MkDocs)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,47 @@
+# Deploy operator docs (docs/) to GitHub Pages from main.
+# Source of truth: main branch — do not maintain a parallel website branch.
+name: Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install MkDocs
+        run: pip install mkdocs-material
+      - name: Build site
+        run: mkdocs build --strict
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ dist/**
 data/
 forecast/
 yfinance.cache
+site/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,3 +49,11 @@ User-facing docs live under `docs/` and the root `README.md`. **Update them in t
 | Data paths / DuckDB vs parquet semantics | `docs/data_store.md` |
 
 Do **not** maintain a separate design-doc tree that diverges from `docs/run_triggers.md`. Prefer tests that lock consumer strings (`tests/canswim/test_ux_split_labels.py`) and MCP tool registration checks (`tests/canswim/test_docs_sync.py`) over stale prose.
+
+## GitHub Pages (https://ivelin.github.io/canswim/)
+
+- The public docs site is **generated from `main`** (`docs/` + `mkdocs.yml`) via `.github/workflows/docs.yml`.
+- **Do not** maintain operator docs on a parallel `website` branch (legacy Pages source). That branch is frozen; new content goes on `main` only.
+- Merging docs to `main` (paths under `docs/` or `mkdocs.yml`) triggers a Pages redeploy. Use **Actions → Docs → Run workflow** if a manual rebuild is needed.
+- After changing operator docs, `./scripts/ci-local.sh` (includes `test_docs_sync`) must pass before push/merge, same as code.
+- Local preview: `pip install mkdocs-material && mkdocs serve` (from repo root).

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ For a brief introduction read [this blog post](https://medium.com/@ivelin.atanas
 
 ## Documentation
 
+**Published site:** [https://ivelin.github.io/canswim/](https://ivelin.github.io/canswim/) (built from `main` / `docs/` via GitHub Actions — not the legacy `website` branch).
+
 | Doc | Contents |
 |-----|----------|
 | **[docs/cli.md](docs/cli.md)** | CLI tasks, recipes, env vars |
@@ -18,7 +20,7 @@ For a brief introduction read [this blog post](https://medium.com/@ivelin.atanas
 | **[docs/data_store.md](docs/data_store.md)** | Parquet (SoT) vs DuckDB (search/UI) |
 | **[AGENTS.md](AGENTS.md)** | CI, merge rules, docs DoD for agents |
 
-Flags: `python -m canswim -h` is the source of truth.
+Flags: `python -m canswim -h` is the source of truth. Local site preview: `pip install mkdocs-material && mkdocs serve`.
 
 ## Setup
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -110,4 +110,4 @@ Exact copy and policy: [run_triggers.md](run_triggers.md).
 - [run_triggers.md](run_triggers.md) — gather/forecast contract (CLI · GUI · MCP)
 - [mcp.md](mcp.md) — MCP server
 - [data_store.md](data_store.md) — parquet vs DuckDB
-- [../README.md](../README.md) — landing page
+- [Home](index.md) — landing page

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,77 @@
+# canswim
+
+Developer toolkit for CANSLIM-style investors: **CLI**, Gradio **GUI**, and **MCP** over a local search database.
+
+**NOT FINANCIAL OR INVESTMENT ADVICE. USE AT YOUR OWN RISK.**
+
+Intro: [blog post](https://medium.com/@ivelin.atanasoff.ivanov/canswim-a-deep-learning-tool-for-canslim-practitioners-2c9740bb0d3d) ·
+[Austin Python Meetup video](https://www.youtube.com/watch?v=GfC-H0uxXvk&ab_channel=AustinPythonMeetup) ·
+[GitHub repo](https://github.com/ivelin/canswim)
+
+## Documentation
+
+| Page | Contents |
+|------|----------|
+| [CLI](cli.md) | Tasks, recipes, env vars (`python -m canswim -h` is flag SoT) |
+| [Gather & forecast](run_triggers.md) | CLI · GUI · MCP shared contract |
+| [MCP](mcp.md) | Tools, read-only default, `MCP_ALLOW_RUNS` |
+| [Data store](data_store.md) | Parquet (system of record) vs DuckDB (search/UI) |
+
+This site is built from the `main` branch `docs/` folder. Edit docs on `main`; Pages redeploys automatically.
+
+## Setup
+
+```bash
+pip install canswim
+# or from a checkout
+pip install -e ./
+conda activate canswim   # recommended for this repo
+```
+
+Local work: keep **`hfhub_sync=False`** (default) unless you intentionally sync Hugging Face data. Full forecast path needs market data APIs (e.g. FMP). Default TiDE checkpoint is public on Hugging Face and can be swapped.
+
+## Get market data & run forecasts
+
+| | Get market data | Run a forecast | Check start date |
+|--|-----------------|----------------|------------------|
+| **CLI** | `gatherdata --tickers "…"` | `forecast --tickers "…" …` | `resolve_start` |
+| **GUI** | **Update market data** | **Run forecast** | **Check start date** |
+| **MCP** | `gather_tickers`* | `forecast_tickers`* | `resolve_forecast_start` |
+
+\*MCP write tools need `MCP_ALLOW_RUNS=1`.
+
+```bash
+hfhub_sync=False python -m canswim gatherdata --tickers "AAPL, MSFT"
+python -m canswim forecast --tickers AAPL --dry_run
+python -m canswim dashboard --same_data True
+```
+
+Details: [run_triggers.md](run_triggers.md) · [cli.md](cli.md)
+
+## Dashboard
+
+```bash
+python -m canswim dashboard --same_data True
+```
+
+| Tab | Purpose |
+|-----|---------|
+| **Charts** | Price + forecast bands |
+| **Scans** | Filter by as-of, reward, risk, confidence |
+| **Run** | Update market data / Run forecast / Check start date |
+| **Advanced** | Read-only SQL |
+
+![Charts](images/charts.png)
+
+![Scans](images/scans.png)
+
+![Run](images/run.png)
+
+## MCP (quick)
+
+```bash
+python -m canswim mcp
+MCP_ALLOW_RUNS=1 python -m canswim mcp
+```
+
+Full guide: [mcp.md](mcp.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,49 @@
+# Site is generated from main-branch docs/ (see .github/workflows/docs.yml).
+# Do not maintain a parallel website branch for operator docs.
+site_name: canswim
+site_description: Developer toolkit for CANSLIM-style investors (CLI, GUI, MCP)
+site_url: https://ivelin.github.io/canswim/
+repo_url: https://github.com/ivelin/canswim
+repo_name: ivelin/canswim
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+  palette:
+    - scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Light mode
+    - scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Dark mode
+  features:
+    - navigation.instant
+    - navigation.tracking
+    - content.code.copy
+    - toc.follow
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
+  - tables
+  - toc:
+      permalink: true
+
+nav:
+  - Home: index.md
+  - CLI: cli.md
+  - Gather & forecast: run_triggers.md
+  - MCP: mcp.md
+  - Data store: data_store.md
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/ivelin/canswim

--- a/tests/canswim/test_docs_sync.py
+++ b/tests/canswim/test_docs_sync.py
@@ -52,9 +52,12 @@ def test_cli_tasks_mentioned_in_cli_doc():
 
 def test_docs_index_links_exist():
     for rel in (
+        "docs/index.md",
         "docs/cli.md",
         "docs/mcp.md",
         "docs/run_triggers.md",
         "docs/data_store.md",
+        "mkdocs.yml",
+        ".github/workflows/docs.yml",
     ):
         assert (ROOT / rel).is_file(), rel


### PR DESCRIPTION
## Summary
Replace stale legacy Pages source (`website` branch) with **auto-deploy from `main`**:

- `mkdocs.yml` + `docs/index.md` (Material theme)
- `.github/workflows/docs.yml` — build + `actions/deploy-pages`
- AGENTS.md / README rules: do not maintain parallel `website` docs

After merge: switch repo Pages settings to **GitHub Actions** (script will attempt via API).

## Test plan
- [x] `mkdocs build --strict` locally
- [x] `./scripts/ci-local.sh`
- [ ] After merge: site at https://ivelin.github.io/canswim/ shows new docs