### PR TITLE
release: canswim 0.0.20260711

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,8 +24,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pytest
-        pip install -e .
+        pip install -e ".[dev]"
     
     - name: Create data directories
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,41 @@
+# Changelog
+
+All notable releases are documented here. Versioning follows date-style `0.0.YYYYMMDD` unless noted.
+
+## 0.0.20260711
+
+Operator-focused release: install locally, use Gradio GUI or MCP with a public TiDE checkpoint and your own market-data API keys (e.g. FMP).
+
+### Highlights
+
+- **Dashboard Run tab** — **Update market data** / **Run forecast** / **Check start date** (same backend as CLI and MCP)
+- **Scoped CLI** — `gatherdata --tickers`, `forecast --tickers`, `resolve_start`, `--dry_run`, `--no_covariates`
+- **MCP server** — read-only by default; `gather_tickers` / `forecast_tickers` with `MCP_ALLOW_RUNS=1`
+- **Lean gather** — ~2y missing-only history for scoped runs; train path keeps long history
+- **Hard-fail forecast** — no invented prices; clear messages for incomplete OHLCV vs missing covariates
+- **Skip re-forecast** when a partition already exists for the start date
+- **DuckDB sync** after gather/forecast so Charts/Scans see new symbols
+- **Docs site** — https://ivelin.github.io/canswim/ (from `main` / MkDocs)
+- Operator guides: CLI, MCP, data store (parquet vs DuckDB), run triggers
+
+### Requirements for end users
+
+- Python ≥ 3.10
+- Optional but typical: **FMP API key** (and related env) for full fundamentals/covariates
+- Default model checkpoint on **Hugging Face** (public; swappable)
+- Local disk for parquet + DuckDB under `data/`
+
+**NOT FINANCIAL OR INVESTMENT ADVICE. USE AT YOUR OWN RISK.**
+
+### Install
+
+```bash
+pip install canswim==0.0.20260711
+python -m canswim -h
+python -m canswim dashboard --same_data True
+python -m canswim mcp
+```
+
+## 0.0.20250107
+
+Previous PyPI release (baseline prior to 2026 operator tooling wave).

--- a/README.md
+++ b/README.md
@@ -26,13 +26,16 @@ Flags: `python -m canswim -h` is the source of truth. Local site preview: `pip i
 
 ```bash
 pip install canswim
+# pin a release: pip install canswim==0.0.20260711
 
 # dev checkout
-pip install -e ./
+pip install -e ".[dev]"
 
 # recommended for this repo
 conda activate canswim
 ```
+
+See [CHANGELOG.md](CHANGELOG.md) for release notes. Docs: [https://ivelin.github.io/canswim/](https://ivelin.github.io/canswim/).
 
 ## Local-first market data
 

--- a/publish.sh
+++ b/publish.sh
@@ -1,18 +1,36 @@
-#!/usr/bin/bash
-echo "Packaging canswim and publishing to PyPI repo"
-set -exv
+#!/usr/bin/env bash
+# Build and publish canswim to TestPyPI and/or PyPI.
+# Usage:
+#   ./publish.sh test     # TestPyPI only
+#   ./publish.sh prod     # PyPI (after version bump on main)
+#   ./publish.sh both     # TestPyPI then PyPI
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$ROOT"
+MODE="${1:-test}"
 
-rm -r dist/
-
-# install build deps
-python3 -m pip install build
-python3 -m pip install twine
-
-
-# test repo publish
+python3 -m pip install -q build twine
+rm -rf dist/ build/ *.egg-info src/*.egg-info
 python3 -m build
-python3 -m twine upload --verbose --repository testpypi dist/*
-python3 -m pip install --index-url https://test.pypi.org/simple/ --no-deps canswim
 
-# proper repo publish
-python3 -m twine upload --verbose dist/*
+version="$(python3 -c "import configparser; c=configparser.ConfigParser(); c.read('setup.cfg'); print(c['metadata']['version'])")"
+echo "Built canswim==${version}"
+
+case "$MODE" in
+  test)
+    python3 -m twine upload --verbose --repository testpypi dist/*
+    echo "Install: pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ canswim==${version}"
+    ;;
+  prod)
+    python3 -m twine upload --verbose dist/*
+    echo "Install: pip install canswim==${version}"
+    ;;
+  both)
+    python3 -m twine upload --verbose --repository testpypi dist/*
+    python3 -m twine upload --verbose dist/*
+    ;;
+  *)
+    echo "Usage: $0 test|prod|both" >&2
+    exit 1
+    ;;
+esac

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -38,6 +38,12 @@ fi
 
 mkdir -p data/data-3rd-party data/forecast
 
+# Ensure editable install has test deps (pytest moved to extras_require[dev])
+if ! "${PY[@]}" -c "import pytest" 2>/dev/null; then
+  echo "==> installing package with [dev] extras for pytest"
+  "${PY[@]}" -m pip install -q -e ".[dev]"
+fi
+
 echo "==> pytest tests/canswim/"
 # Recurse package (includes tests/canswim/dashboard/, etc.)
 "${PY[@]}" -m pytest tests/canswim/ -q --tb=short

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,18 +1,28 @@
 [metadata]
 name = canswim
-version = 0.0.20250107
+version = 0.0.20260711
 author = Ivelin Ivanov
 author_email = ivelin117@gmail.com
-description = "Developer toolkit for CANSLIM investment style practitioners"
+description = Developer toolkit for CANSLIM-style investors (CLI, Gradio GUI, MCP)
 long_description = file: README.md
-keywords = stock market, analytics
+long_description_content_type = text/markdown
+keywords = stock market, analytics, CANSLIM, forecast, MCP
 license = Apache-2.0
 classifiers =
-    # Framework :: Django
+    Development Status :: 4 - Beta
+    Intended Audience :: Developers
+    Intended Audience :: Financial and Insurance Industry
+    License :: OSI Approved :: Apache Software License
     Programming Language :: Python :: 3
+    Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Topic :: Office/Business :: Financial :: Investment
 project_urls =
-	# Documentation = https://setuptools.pypa.io/
-	# Changelog = https://setuptools.pypa.io/en/stable/history.html
+    Homepage = https://github.com/ivelin/canswim
+    Documentation = https://ivelin.github.io/canswim/
+    Changelog = https://github.com/ivelin/canswim/blob/main/CHANGELOG.md
+    Issues = https://github.com/ivelin/canswim/issues
 
 [options]
 zip_safe = False
@@ -35,24 +45,21 @@ install_requires =
     mcp>=1.2,<2
     python-dotenv
     requests-ratelimiter>=0.6,<1
-    # hvplot
-    # requests
-    # importlib-metadata; python_version<"3.8"
-    pytest
-    pytest-cov
-
 
 [options.package_data]
 * = *.txt, *.rst, *.md
-# hello = *.msg
 
 [options.entry_points]
 console_scripts =
     canswim-mcp = canswim.mcp.server:main
 
 [options.extras_require]
-# pdf = ReportLab>=1.2; RXP
-# rest = docutils>=0.3; pack ==1.1, ==1.3
+dev =
+    pytest
+    pytest-cov
+    mkdocs-material
+    build
+    twine
 
 [options.packages.find]
 where=src


### PR DESCRIPTION
## Summary
Cut **0.0.20260711** for PyPI / GitHub after operator tooling (GUI Run, MCP, scoped gather/forecast, docs site).

- Users: `pip install canswim` → CLI / dashboard / MCP; public HF TiDE checkpoint; FMP for covariates
- Packaging: cleaner metadata; test deps in `[dev]`
- After merge: tag `v0.0.20260711`, GitHub Release, `./publish.sh prod`

## Test plan
- [x] `./scripts/ci-local.sh` (135)
- [x] `importlib.metadata.version('canswim') == 0.0.20260711`
- [ ] PyPI upload after merge