### PR TITLE
fix: IPO-friendly market data gather UX

### DIFF
--- a/src/canswim/dashboard/run_tab.py
+++ b/src/canswim/dashboard/run_tab.py
@@ -35,12 +35,44 @@ def _json_details(payload: dict) -> str:
 
 def _gather_summary(result: dict) -> str:
     if not result.get("ok"):
-        return f"❌ **Could not update market data.**  \n{result.get('error') or 'Unknown error.'}"
+        err = result.get("error") or "Unknown error."
+        short = result.get("short_history") or []
+        none = result.get("no_history") or []
+        if short or none or "IPO" in err or "trading history" in err:
+            return f"❌ **Could not finish for every symbol.**  \n{err}"
+        return f"❌ **Could not update market data.**  \n{err}"
     tickers = result.get("tickers") or []
+    ready = result.get("ready") or []
+    incomplete = result.get("incomplete") or []
     skipped = result.get("skipped_remote") or []
     fetched = result.get("fetched") or []
     added = (result.get("db_sync") or {}).get("added") or []
-    lines = [f"✅ **Market data ready** for {', '.join(tickers) or '—' }."]
+    short = result.get("short_history") or []
+    if result.get("partial") and incomplete:
+        show = ", ".join(ready) if ready else "—"
+        lines = [
+            f"⚠️ **Partial success** — ready: {show}.",
+            result.get("error")
+            or (
+                f"Not ready (often recent IPOs / short history): "
+                f"{', '.join(incomplete)}."
+            ),
+        ]
+        # Prefer full friendly text from messages if present
+        for m in result.get("messages") or []:
+            if "trading history" in m or "No usable price" in m:
+                lines = [
+                    f"⚠️ **Partial success** — ready: {show}.",
+                    m,
+                ]
+                break
+        if short:
+            lines.append(
+                "Tip: drop recent IPOs from the list, then run **Update market data** again."
+            )
+    else:
+        show = ", ".join(ready or tickers) or "—"
+        lines = [f"✅ **Market data ready** for {show}."]
     if skipped and not fetched:
         lines.append("Already up to date locally — no download needed.")
     elif skipped:

--- a/src/canswim/gather_data.py
+++ b/src/canswim/gather_data.py
@@ -538,11 +538,19 @@ class MarketDataGatherer:
             )
             self.last_post_fetch_plans = cov["plans"]
             if not cov["ok"]:
-                raise RuntimeError(
-                    "Market history is incomplete for: "
-                    f"{', '.join(cov['incomplete'])}. "
-                    "Could not skip remote fetch and local data is insufficient."
+                self.last_incomplete_coverage = cov
+                # Partial: some ready is OK for scoped runs; fail only if none ready
+                if mode == "forecast" and not cov.get("skipped"):
+                    from canswim.gather_policy import format_incomplete_gather_message
+
+                    raise RuntimeError(
+                        format_incomplete_gather_message(cov["plans"])
+                    )
+                logger.warning(
+                    f"Local coverage incomplete (continuing with ready symbols): "
+                    f"{cov['incomplete']}"
                 )
+                return
             logger.info("All requested symbols already covered locally; no remote call")
             return
 
@@ -626,7 +634,7 @@ class MarketDataGatherer:
                 f"history for: {', '.join(fetch_syms)}"
             )
 
-        # Scoped forecast gather: fail if any planned fetch symbol is still incomplete
+        # Coverage after merge: save whatever we have; fail only if nothing ready
         cov = evaluate_symbol_coverage(
             tickers,
             merged_df,
@@ -634,22 +642,13 @@ class MarketDataGatherer:
             train_min_start=self.min_start_date,
         )
         self.last_post_fetch_plans = cov["plans"]
+        self.last_incomplete_coverage = cov
         still_bad = cov["incomplete"]
-        if still_bad:
-            # Do not silently keep old_df as success when requested symbols failed
-            if mode == "forecast":
-                raise RuntimeError(
-                    "Could not obtain complete market history for: "
-                    f"{', '.join(still_bad)}. "
-                    "Remote download returned no usable bars for those symbols. "
-                    "Check the symbol and try again later (rate limits / API keys)."
-                )
-            logger.warning(
-                f"Train gather: still incomplete after fetch: {still_bad}"
-            )
+        ready = list(cov.get("skipped") or [])
 
         assert merged_df.index.is_unique
         Path(data_file).parent.mkdir(parents=True, exist_ok=True)
+        # Always persist bars we have so partial lists don't lose good symbols
         merged_df.to_parquet(data_file)
         logger.info(
             f"Saved stock prices to {data_file} "
@@ -657,6 +656,16 @@ class MarketDataGatherer:
             f"{merged_df.index.get_level_values('Symbol').nunique()} symbols, "
             f"latest={merged_df.index.get_level_values('Date').max()})"
         )
+
+        if still_bad:
+            if mode == "forecast" and not ready:
+                from canswim.gather_policy import format_incomplete_gather_message
+
+                raise RuntimeError(format_incomplete_gather_message(cov["plans"]))
+            logger.warning(
+                f"{'Forecast' if mode == 'forecast' else 'Train'} gather: "
+                f"still incomplete after fetch (ready={ready}): {still_bad}"
+            )
 
     def _merge_symbol_date_parquet(
         self, path: str, new_df: pd.DataFrame

--- a/src/canswim/gather_policy.py
+++ b/src/canswim/gather_policy.py
@@ -277,6 +277,103 @@ def incomplete_symbols(plans: Sequence[SymbolFetchPlan]) -> list[str]:
     return [p.symbol for p in plans if p.is_incomplete]
 
 
+def complete_symbols(plans: Sequence[SymbolFetchPlan]) -> list[str]:
+    """Symbols ready for forecast (skip, or complete-but-stale after refresh path)."""
+    out: list[str] = []
+    for p in plans:
+        if p.action == "skip":
+            out.append(p.symbol)
+        elif p.reason == "local_complete_but_stale":
+            # Still needs a fetch; not complete until re-checked after download
+            continue
+    return out
+
+
+# Consumer-facing buckets for incomplete price coverage
+IncompleteKind = Literal["short_history", "no_history", "other"]
+
+
+def classify_incomplete_reason(reason: str) -> IncompleteKind:
+    """Map planner reason → plain-language category for UI / gather errors."""
+    r = (reason or "").strip().lower()
+    if not r:
+        return "other"
+    # Listed after window start, or too few sessions for model lookback
+    if "window_starts_late" in r:
+        return "short_history"
+    if "only " in r and "bars" in r and "need" in r:
+        return "short_history"
+    if "local_incomplete:" in r and "bars" in r:
+        return "short_history"
+    if r in ("missing_local_symbol", "no_bars_in_window"):
+        return "no_history"
+    if r.startswith("missing_local") or "no_bars" in r:
+        return "no_history"
+    return "other"
+
+
+def classify_incomplete_plans(
+    plans: Sequence[SymbolFetchPlan],
+) -> dict[str, list[str]]:
+    """Bucket incomplete symbols by consumer-facing cause."""
+    buckets: dict[str, list[str]] = {
+        "short_history": [],
+        "no_history": [],
+        "other": [],
+    }
+    for p in plans:
+        if not p.is_incomplete:
+            continue
+        buckets[classify_incomplete_reason(p.reason)].append(p.symbol)
+    return buckets
+
+
+def format_incomplete_gather_message(
+    plans: Sequence[SymbolFetchPlan],
+    *,
+    min_bars: int = DEFAULT_FORECAST_MIN_BARS,
+    lookback_years: int = FORECAST_LOOKBACK_YEARS,
+) -> str:
+    """Human-readable gather/forecast readiness failure (no rate-limit scolding)."""
+    buckets = classify_incomplete_plans(plans)
+    # After coverage check, action=skip means ready for forecast lookback
+    ready = [p.symbol for p in plans if p.action == "skip"]
+    lines: list[str] = []
+
+    short = buckets["short_history"]
+    none = buckets["no_history"]
+    other = buckets["other"]
+
+    if short:
+        lines.append(
+            f"Not enough trading history yet for: {', '.join(short)}. "
+            f"Forecasts need about {lookback_years} years of daily sessions "
+            f"(~{min_bars} trading days). Recent IPOs and newly listed names "
+            "usually cannot be used until they age — remove them and try again "
+            "with the rest of your list."
+        )
+    if none:
+        lines.append(
+            f"No usable price history found for: {', '.join(none)}. "
+            "Check the ticker spelling, or that the symbol trades on a supported "
+            "exchange. If the name is correct, try again later."
+        )
+    if other:
+        lines.append(
+            f"Market history is still incomplete for: {', '.join(other)}. "
+            "Update market data again after checking symbols, or remove them from "
+            "the list."
+        )
+    if ready and (short or none or other):
+        lines.append(f"Ready for the next step: {', '.join(ready)}.")
+    if not lines:
+        return (
+            "Market history is incomplete for some symbols. "
+            "Forecasts never invent missing prices."
+        )
+    return " ".join(lines)
+
+
 def evaluate_symbol_coverage(
     tickers: Sequence[str],
     price_df: Optional[pd.DataFrame],
@@ -298,10 +395,17 @@ def evaluate_symbol_coverage(
     stale_only = [
         p.symbol for p in plans if p.reason == "local_complete_but_stale"
     ]
+    buckets = classify_incomplete_plans(plans)
     return {
         "plans": plans,
         "incomplete": incomplete,
         "skipped": skipped,
         "stale_only": stale_only,
+        "short_history": buckets["short_history"],
+        "no_history": buckets["no_history"],
         "ok": len(incomplete) == 0,
+        "partial_ok": len(skipped) > 0 and len(incomplete) > 0,
+        "message": format_incomplete_gather_message(plans)
+        if incomplete
+        else "",
     }

--- a/src/canswim/run_triggers.py
+++ b/src/canswim/run_triggers.py
@@ -72,8 +72,9 @@ PREVIEW_START_BUTTON = "Check start date"
 
 INCOMPLETE_DATA_MSG = (
     "Market history is incomplete or not ready for: {symbols}. "
-    "Use Get market data / gather for these symbols, then run the forecast again. "
-    "Forecasts never invent missing prices."
+    "Use Update market data for these symbols, then run the forecast again. "
+    "Forecasts never invent missing prices. "
+    "Recent IPOs often lack enough history (~2 years of sessions)."
 )
 
 COVARIATE_FAIL_MSG = (
@@ -397,14 +398,27 @@ def gather_for_tickers(
         pre_plans = getattr(g, "last_price_fetch_plans", []) or []
         post_plans = getattr(g, "last_post_fetch_plans", None) or pre_plans
         written = list(getattr(g, "last_remote_symbols_written", None) or [])
+        cov = getattr(g, "last_incomplete_coverage", None) or {}
 
-        from canswim.gather_policy import incomplete_symbols
+        from canswim.gather_policy import (
+            format_incomplete_gather_message,
+            incomplete_symbols,
+        )
 
         skipped = [p.symbol for p in pre_plans if p.action == "skip"]
         # Only count as downloaded when remote actually returned bars for the symbol
         planned_fetch = {p.symbol for p in pre_plans if p.action == "fetch"}
         fetched = sorted(planned_fetch & set(written))
         still_incomplete = incomplete_symbols(post_plans)
+        ready = [p.symbol for p in post_plans if p.action == "skip"]
+        short_hist = list(cov.get("short_history") or [])
+        no_hist = list(cov.get("no_history") or [])
+        if not short_hist and not no_hist and still_incomplete:
+            from canswim.gather_policy import classify_incomplete_plans
+
+            buckets = classify_incomplete_plans(post_plans)
+            short_hist = buckets["short_history"]
+            no_hist = buckets["no_history"]
 
         if skipped:
             messages.append(
@@ -421,11 +435,17 @@ def gather_for_tickers(
             messages.append("No remote price download needed.")
 
         if still_incomplete:
+            friendly = cov.get("message") or format_incomplete_gather_message(
+                post_plans
+            )
+        else:
+            friendly = ""
+
+        if still_incomplete and not ready:
             return {
                 "ok": False,
-                "error": INCOMPLETE_DATA_MSG.format(
-                    symbols=", ".join(still_incomplete)
-                ),
+                "error": friendly
+                or INCOMPLETE_DATA_MSG.format(symbols=", ".join(still_incomplete)),
                 "tickers": tickers,
                 "rejected": parsed.get("rejected", []),
                 "messages": messages,
@@ -433,34 +453,47 @@ def gather_for_tickers(
                 "fetched": fetched,
                 "skipped_remote": skipped,
                 "incomplete": still_incomplete,
+                "short_history": short_hist,
+                "no_history": no_hist,
+                "ready": [],
                 "need_gather": True,
             }
 
-        if include_covariates:
-            # Fundamentals required by the model stack (not just OHLCV)
-            for name, fn in (
-                ("dividends", g.gather_stock_dividends),
-                ("splits", g.gather_stock_splits),
-                ("earnings", g.gather_earnings_data),
-                ("key_metrics", g.gather_stock_key_metrics),
-                ("institutional_ownership", g.gather_institutional_stock_ownership),
-                ("analyst_estimates", g.gather_analyst_estimates),
-            ):
-                try:
-                    fn()
-                except Exception as e:
-                    messages.append(f"{name} note: {e}")
+        if still_incomplete and ready:
+            messages.append(friendly)
+            messages.append(
+                "Saved data for symbols that are ready; skipped forecasting "
+                "for names that need more history."
+            )
 
-        # Ensure symbols appear on a stock list CSV for forecast path
-        _ensure_symbols_on_list(tickers)
+        # Covariates + DB sync only for forecast-ready symbols
+        work_tickers = ready if ready else tickers
+        if include_covariates and work_tickers:
+            prev_set = g.stocks_ticker_set
+            g.stocks_ticker_set = list(work_tickers)
+            try:
+                for name, fn in (
+                    ("dividends", g.gather_stock_dividends),
+                    ("splits", g.gather_stock_splits),
+                    ("earnings", g.gather_earnings_data),
+                    ("key_metrics", g.gather_stock_key_metrics),
+                    ("institutional_ownership", g.gather_institutional_stock_ownership),
+                    ("analyst_estimates", g.gather_analyst_estimates),
+                ):
+                    try:
+                        fn()
+                    except Exception as e:
+                        messages.append(f"{name} note: {e}")
+            finally:
+                g.stocks_ticker_set = prev_set
 
-        # Sync DuckDB search tables so Charts/Scans dropdown includes new symbols
-        # (dashboard --same_data reuses DB and would otherwise stay on old list)
+        _ensure_symbols_on_list(work_tickers)
+
         db_sync: dict[str, Any] | None = None
         try:
             from canswim.db import sync_gathered_symbols, get_db_path
 
-            db_sync = sync_gathered_symbols(get_db_path(), tickers)
+            db_sync = sync_gathered_symbols(get_db_path(), work_tickers)
             if db_sync.get("ok"):
                 if db_sync.get("added"):
                     messages.append(
@@ -482,21 +515,26 @@ def gather_for_tickers(
 
         return {
             "ok": True,
+            "partial": bool(still_incomplete),
             "tickers": tickers,
             "rejected": parsed.get("rejected", []),
             "messages": messages,
-            "processed": tickers,
+            "processed": work_tickers,
             "price_plans": [p.as_dict() for p in post_plans],
             "fetched": fetched,
             "skipped_remote": skipped,
-            "incomplete": [],
+            "incomplete": still_incomplete,
+            "short_history": short_hist,
+            "no_history": no_hist,
+            "ready": ready,
             "db_sync": db_sync,
         }
     except Exception as e:
         logger.exception("gather_for_tickers failed")
+        err = str(e)
         return {
             "ok": False,
-            "error": str(e),
+            "error": err,
             "tickers": tickers,
             "rejected": parsed.get("rejected", []),
             "messages": messages,

--- a/tests/canswim/test_gather_policy.py
+++ b/tests/canswim/test_gather_policy.py
@@ -11,8 +11,11 @@ import pytest
 from canswim.gather_policy import (
     DEFAULT_FORECAST_MIN_BARS,
     DEFAULT_TRAIN_MIN_BARS,
+    SymbolFetchPlan,
+    classify_incomplete_reason,
     evaluate_symbol_coverage,
     forecast_window_start,
+    format_incomplete_gather_message,
     incomplete_symbols,
     plan_stock_price_fetches,
     plan_symbol_price_fetch,
@@ -230,6 +233,43 @@ def test_gather_raises_when_remote_empty_for_missing_symbol():
                         g.gather_stock_price_data()
 
 
+def test_classify_short_history_and_ipo_message():
+    assert (
+        classify_incomplete_reason(
+            "window_starts_late:first=2025-11-01,need_near=2024-07-10"
+        )
+        == "short_history"
+    )
+    assert (
+        classify_incomplete_reason(
+            "local_incomplete:only 40 complete OHLCV bars; need >= 350"
+        )
+        == "short_history"
+    )
+    assert classify_incomplete_reason("missing_local_symbol") == "no_history"
+    plans = [
+        SymbolFetchPlan(
+            "STRC",
+            "fetch",
+            "2024-07-10",
+            "local_incomplete:only 40 complete OHLCV bars; need >= 350",
+        ),
+        SymbolFetchPlan(
+            "BOT",
+            "fetch",
+            "2024-07-10",
+            "window_starts_late:first=2025-06-01,need_near=2024-07-10",
+        ),
+        SymbolFetchPlan("AAPL", "skip", None, "local_complete_and_fresh"),
+    ]
+    msg = format_incomplete_gather_message(plans)
+    assert "STRC" in msg and "BOT" in msg
+    assert "IPO" in msg or "Recent IPOs" in msg
+    assert "rate limit" not in msg.lower()
+    assert "AAPL" in msg  # ready called out
+    assert "API key" not in msg
+
+
 def test_gather_for_tickers_reports_ok_false_when_incomplete(monkeypatch):
     monkeypatch.setenv("MCP_ALLOW_RUNS", "1")
     from canswim.run_triggers import gather_for_tickers
@@ -240,19 +280,29 @@ def test_gather_for_tickers_reports_ok_false_when_incomplete(monkeypatch):
     g.last_price_fetch_plans = []
     g.last_post_fetch_plans = []
     g.last_remote_symbols_written = []
+    g.last_incomplete_coverage = {}
 
     def _boom():
-        from canswim.gather_policy import SymbolFetchPlan
-
-        g.last_price_fetch_plans = [
-            SymbolFetchPlan("MSFT", "fetch", "2024-07-10", "missing_local_symbol")
+        plans = [
+            SymbolFetchPlan(
+                "MSFT",
+                "fetch",
+                "2024-07-10",
+                "local_incomplete:only 10 complete OHLCV bars; need >= 350",
+            )
         ]
-        g.last_post_fetch_plans = g.last_price_fetch_plans
+        g.last_price_fetch_plans = plans
+        g.last_post_fetch_plans = plans
         g.last_remote_symbols_written = []
-        raise RuntimeError(
-            "Could not obtain complete market history for: MSFT. "
-            "Remote download returned no usable bars for those symbols."
-        )
+        g.last_incomplete_coverage = {
+            "plans": plans,
+            "incomplete": ["MSFT"],
+            "skipped": [],
+            "short_history": ["MSFT"],
+            "no_history": [],
+            "message": format_incomplete_gather_message(plans),
+        }
+        raise RuntimeError(format_incomplete_gather_message(plans))
 
     g.gather_broad_market_data = lambda: None
     g.gather_sectors_data = lambda: None
@@ -261,4 +311,55 @@ def test_gather_for_tickers_reports_ok_false_when_incomplete(monkeypatch):
     with patch("canswim.gather_data.MarketDataGatherer", return_value=g):
         r = gather_for_tickers("MSFT", include_covariates=False, force_allow=True)
     assert r["ok"] is False
-    assert "MSFT" in (r.get("error") or "")
+    err = r.get("error") or ""
+    assert "MSFT" in err
+    assert "rate limit" not in err.lower()
+    assert "trading history" in err.lower() or "IPO" in err
+
+
+def test_gather_for_tickers_partial_success(monkeypatch):
+    monkeypatch.setenv("MCP_ALLOW_RUNS", "1")
+    from canswim.run_triggers import gather_for_tickers
+
+    g = type("G", (), {})()
+    g.stocks_ticker_set = []
+    g.gather_mode = "forecast"
+    plans = [
+        SymbolFetchPlan("AAPL", "skip", None, "local_complete_and_fresh"),
+        SymbolFetchPlan(
+            "STRC",
+            "fetch",
+            "2024-07-10",
+            "window_starts_late:first=2025-11-01,need_near=2024-07-10",
+        ),
+    ]
+    g.last_price_fetch_plans = plans
+    g.last_post_fetch_plans = plans
+    g.last_remote_symbols_written = []
+    g.last_incomplete_coverage = {
+        "plans": plans,
+        "incomplete": ["STRC"],
+        "skipped": ["AAPL"],
+        "short_history": ["STRC"],
+        "no_history": [],
+        "message": format_incomplete_gather_message(plans),
+    }
+    g.gather_broad_market_data = lambda: None
+    g.gather_sectors_data = lambda: None
+    g.gather_stock_price_data = lambda: None
+
+    with patch("canswim.gather_data.MarketDataGatherer", return_value=g):
+        with patch("canswim.run_triggers._ensure_symbols_on_list"):
+            with patch(
+                "canswim.db.sync_gathered_symbols",
+                return_value={"ok": True, "added": [], "close_rows": 0},
+            ):
+                with patch("canswim.db.get_db_path", return_value=":memory:"):
+                    r = gather_for_tickers(
+                        "AAPL,STRC", include_covariates=False, force_allow=True
+                    )
+    assert r["ok"] is True
+    assert r.get("partial") is True
+    assert "AAPL" in (r.get("ready") or [])
+    assert "STRC" in (r.get("incomplete") or [])
+    assert any("IPO" in m or "trading history" in m for m in (r.get("messages") or []))

--- a/tests/canswim/test_ux_split_labels.py
+++ b/tests/canswim/test_ux_split_labels.py
@@ -66,6 +66,7 @@ def test_summary_helpers_are_plain():
         {
             "ok": True,
             "tickers": ["AAPL"],
+            "ready": ["AAPL"],
             "skipped_remote": ["AAPL"],
             "fetched": [],
             "db_sync": {"added": []},
@@ -73,6 +74,39 @@ def test_summary_helpers_are_plain():
     )
     assert "AAPL" in g
     assert "```" not in g
+
+    partial = _gather_summary(
+        {
+            "ok": True,
+            "partial": True,
+            "tickers": ["AAPL", "STRC"],
+            "ready": ["AAPL"],
+            "incomplete": ["STRC"],
+            "short_history": ["STRC"],
+            "messages": [
+                "Not enough trading history yet for: STRC. Recent IPOs usually cannot."
+            ],
+            "skipped_remote": ["AAPL"],
+            "fetched": [],
+            "db_sync": {"added": []},
+        }
+    )
+    assert "Partial" in partial
+    assert "STRC" in partial or "IPO" in partial
+    assert "rate limit" not in partial.lower()
+
+    fail_ipo = _gather_summary(
+        {
+            "ok": False,
+            "error": (
+                "Not enough trading history yet for: BOT. "
+                "Recent IPOs and newly listed names usually cannot be used."
+            ),
+            "short_history": ["BOT"],
+        }
+    )
+    assert "Could not finish" in fail_ipo
+    assert "BOT" in fail_ipo
     f = _forecast_summary(
         {
             "ok": True,


### PR DESCRIPTION
## Summary
Recent IPOs / short-history symbols were reported as \"no usable bars\" + rate limits/API keys.

- **Short history** → explain ~2y / ~350 sessions need; IPOs must age
- **No history** → check ticker spelling
- **Partial success** when some symbols in a list are ready (save those; list the rest)
- Run status copy updated

## Test plan
- [x] `./scripts/ci-local.sh` (137)
- [ ] Dashboard: list with mature names + recent IPO → partial success, no rate-limit wording