### PR TITLE
fix: train loop key-metrics duplicate index (#75)

### DIFF
--- a/src/canswim/covariates.py
+++ b/src/canswim/covariates.py
@@ -389,6 +389,9 @@ class Covariates:
 
         price_idx = price_series.pd_dataframe().index
         cov_df = cov_series.pd_dataframe()
+        cov_df.index = pd.DatetimeIndex(pd.to_datetime(cov_df.index)).normalize()
+        # Biz-day mapping can collapse multiple report dates onto one session
+        cov_df = cov_df[~cov_df.index.duplicated(keep="last")].sort_index()
         # ffill known values onto price calendar; remaining holes → fillna_value
         aligned = cov_df.reindex(price_idx, method="ffill")
         aligned = aligned.fillna(fillna_value)
@@ -409,9 +412,10 @@ class Covariates:
         assert not kms_unique.index.has_duplicates
         kms_loaded_df = kms_unique.copy()
         # convert earnings reporting time - Before Market Open / After Market Close - categories to numerical representation
-        kms_loaded_df["period"] = pd.Categorical(
-            kms_loaded_df["period"], categories=["_", "Q1", "Q2", "Q3", "Q4"]
-        ).codes
+        if "period" in kms_loaded_df.columns:
+            kms_loaded_df["period"] = pd.Categorical(
+                kms_loaded_df["period"], categories=["_", "Q1", "Q2", "Q3", "Q4"]
+            ).codes
         # kms_loaded_df["period"] = (
         #     kms_loaded_df["period"]
         #     .replace(["Q1", "Q2", "Q3", "Q4"], [1, 2, 3, 4], inplace=False)
@@ -428,6 +432,7 @@ class Covariates:
                 kms_df = kms_df.droplevel("Symbol")
                 kms_df.index = pd.to_datetime(kms_df.index)
                 # logger.info(f'index type for {t}: {type(t_kms.index)}')
+                kms_df = kms_df[~kms_df.index.duplicated(keep="last")]
                 assert kms_df.index.is_unique
                 kms_df = kms_df.dropna()
                 # logger.info("kms_df\n", kms_df[kms_df.isnull()])
@@ -435,20 +440,29 @@ class Covariates:
                 assert len(kms_df) > 0, f"No key metrics available for {t}"
                 # logger.info(f'{t} earnings: \n{t_kms.columns}')
                 kms_df = self.df_index_to_biz_days(kms_df)
+                # Weekend/holiday mapping can create duplicate biz-day labels
+                # (issue #75: pandas reindex raises ValueError).
+                kms_df = kms_df[~kms_df.index.duplicated(keep="last")].sort_index()
+                assert kms_df.index.is_unique, (
+                    f"duplicate key-metrics dates for {t} after biz-day align"
+                )
                 tkms_series_tmp = TimeSeries.from_dataframe(
                     kms_df, freq="B", fill_missing_dates=True
                 )
                 # logger.info(f'kms_series_tmp start time, end time: {tkms_series_tmp.start_time()}, {tkms_series_tmp.end_time()}')
                 kms_df_ext = tkms_series_tmp.pd_dataframe()
                 kms_df_ext.ffill(inplace=True)
-                kms_ser = TimeSeries.from_dataframe(kms_df, freq="B", fillna_value=-1)
+                kms_ser = TimeSeries.from_dataframe(
+                    kms_df_ext, freq="B", fillna_value=-1
+                )
                 kms_ser_padded = self.pad_covs(cov_series=kms_ser, price_series=prices)
                 # logger.info(f'kms_ser_padded start time, end time: {kms_ser_padded.start_time()}, {kms_ser_padded.end_time()}')
                 assert (
                     len(kms_ser_padded.gaps()) == 0
                 ), f"found gaps in tmks series: \n{kms_ser_padded.gaps()}"
                 t_kms_series[t] = kms_ser_padded
-            except (KeyError, AssertionError) as e:
+            except (KeyError, AssertionError, ValueError) as e:
+                # ValueError: duplicate-index reindex (dirty fund data) — skip ticker
                 logger.warning(f"Skipping {t} due to error: {type(e)}: {e}")
         # logger.info("t_kms_series:", t_kms_series)
         return t_kms_series

--- a/tests/canswim/test_key_metrics_dedupe.py
+++ b/tests/canswim/test_key_metrics_dedupe.py
@@ -24,18 +24,13 @@ def _price_ts(n: int = 40, start: str = "2024-01-02") -> TimeSeries:
     return timeseries_from_observed_df(df)
 
 
-def test_prepare_key_metrics_collapses_biz_day_duplicates():
-    """Two calendar dates that map to the same business day must not raise."""
+def test_prepare_key_metrics_collapses_exact_duplicate_dates():
+    """Exact duplicate (Symbol, Date) rows must not raise."""
     c = Covariates()
-    # Sat + Mon can both land on the same Monday via to_biz_day depending on path;
-    # force duplicate after normalize by using two identical dates first, then
-    # one weekend + one weekday pair that is known to collide.
-    # Explicit duplicate index (as if already collapsed) + a unique row.
     idx = pd.MultiIndex.from_tuples(
         [
-            ("BAD", pd.Timestamp("2024-01-05")),  # Friday
-            ("BAD", pd.Timestamp("2024-01-06")),  # Saturday → may map near Fri/Mon
-            ("BAD", pd.Timestamp("2024-01-06")),  # exact duplicate calendar date
+            ("BAD", pd.Timestamp("2024-01-05")),
+            ("BAD", pd.Timestamp("2024-01-05")),  # exact duplicate
             ("GOOD", pd.Timestamp("2024-01-05")),
             ("GOOD", pd.Timestamp("2024-04-05")),
         ],
@@ -43,23 +38,61 @@ def test_prepare_key_metrics_collapses_biz_day_duplicates():
     )
     c.kms_loaded_df = pd.DataFrame(
         {
-            "period": ["Q1", "Q1", "Q1", "Q1", "Q2"],
-            "revenuePerShare": [1.0, 1.1, 1.2, 2.0, 2.1],
-            "netIncomePerShare": [0.1, 0.11, 0.12, 0.2, 0.21],
+            "period": ["Q1", "Q1", "Q1", "Q2"],
+            "revenuePerShare": [1.0, 1.1, 2.0, 2.1],
+            "netIncomePerShare": [0.1, 0.11, 0.2, 0.21],
         },
         index=idx,
     )
-
     prices = {"BAD": _price_ts(), "GOOD": _price_ts()}
-    # Must not raise ValueError (issue #75)
     out = c.prepare_key_metrics(stock_price_series=prices)
-    # GOOD always builds; BAD may build after dedupe or be skipped if empty/invalid
     assert "GOOD" in out
     assert isinstance(out["GOOD"], TimeSeries)
+    # BAD should succeed after dedupe (not abort the whole call)
+    assert "BAD" in out
 
 
-def test_prepare_key_metrics_skips_value_error_without_aborting():
-    """Per-ticker ValueError is skipped; other symbols still prepared."""
+def test_prepare_key_metrics_collapses_biz_day_collision():
+    """Sat + Sun both map to Monday via to_biz_day → must not raise (issue #75)."""
+    from canswim.covariates import to_biz_day
+
+    sat = pd.Timestamp("2024-01-06")  # Saturday
+    sun = pd.Timestamp("2024-01-07")  # Sunday
+    mon = pd.Timestamp("2024-01-08")  # Monday
+    assert to_biz_day(date=sat) == mon
+    assert to_biz_day(date=sun) == mon
+
+    c = Covariates()
+    idx = pd.MultiIndex.from_tuples(
+        [
+            ("COLLIDE", sat),
+            ("COLLIDE", sun),  # both → Monday after df_index_to_biz_days
+            ("COLLIDE", pd.Timestamp("2024-04-01")),  # unique later report
+            ("OK", pd.Timestamp("2024-01-05")),
+            ("OK", pd.Timestamp("2024-04-05")),
+        ],
+        names=["Symbol", "Date"],
+    )
+    c.kms_loaded_df = pd.DataFrame(
+        {
+            "period": ["Q1", "Q1", "Q2", "Q1", "Q2"],
+            "revenuePerShare": [1.0, 1.5, 2.0, 3.0, 3.1],
+            "netIncomePerShare": [0.1, 0.15, 0.2, 0.3, 0.31],
+        },
+        index=idx,
+    )
+    prices = {
+        "COLLIDE": _price_ts(n=80, start="2023-12-01"),
+        "OK": _price_ts(n=80, start="2023-12-01"),
+    }
+    # Pre-fix this raised ValueError on reindex and aborted the whole method
+    out = c.prepare_key_metrics(stock_price_series=prices)
+    assert "OK" in out
+    assert "COLLIDE" in out  # dedupe keeps last Mon row + April report
+
+
+def test_prepare_key_metrics_skips_missing_symbol_without_aborting():
+    """Missing KMS for one ticker must not prevent others from preparing."""
     c = Covariates()
     idx = pd.MultiIndex.from_tuples(
         [
@@ -77,7 +110,6 @@ def test_prepare_key_metrics_skips_value_error_without_aborting():
         },
         index=idx,
     )
-    # MISSING has no rows → KeyError skip
     prices = {"OK": _price_ts(n=80, start="2023-01-03"), "MISSING": _price_ts()}
     out = c.prepare_key_metrics(stock_price_series=prices)
     assert "OK" in out

--- a/tests/canswim/test_key_metrics_dedupe.py
+++ b/tests/canswim/test_key_metrics_dedupe.py
@@ -1,0 +1,99 @@
+"""Issue #75: key metrics with duplicate biz-day labels must not abort train prep."""
+
+from __future__ import annotations
+
+import pandas as pd
+from darts import TimeSeries
+
+from canswim.covariates import Covariates
+from canswim.eligibility import timeseries_from_observed_df
+
+
+def _price_ts(n: int = 40, start: str = "2024-01-02") -> TimeSeries:
+    idx = pd.bdate_range(start, periods=n)
+    df = pd.DataFrame(
+        {
+            "Open": range(n),
+            "High": range(1, n + 1),
+            "Low": range(n),
+            "Close": range(n),
+            "Volume": [1_000_000.0] * n,
+        },
+        index=idx,
+    )
+    return timeseries_from_observed_df(df)
+
+
+def test_prepare_key_metrics_collapses_biz_day_duplicates():
+    """Two calendar dates that map to the same business day must not raise."""
+    c = Covariates()
+    # Sat + Mon can both land on the same Monday via to_biz_day depending on path;
+    # force duplicate after normalize by using two identical dates first, then
+    # one weekend + one weekday pair that is known to collide.
+    # Explicit duplicate index (as if already collapsed) + a unique row.
+    idx = pd.MultiIndex.from_tuples(
+        [
+            ("BAD", pd.Timestamp("2024-01-05")),  # Friday
+            ("BAD", pd.Timestamp("2024-01-06")),  # Saturday → may map near Fri/Mon
+            ("BAD", pd.Timestamp("2024-01-06")),  # exact duplicate calendar date
+            ("GOOD", pd.Timestamp("2024-01-05")),
+            ("GOOD", pd.Timestamp("2024-04-05")),
+        ],
+        names=["Symbol", "Date"],
+    )
+    c.kms_loaded_df = pd.DataFrame(
+        {
+            "period": ["Q1", "Q1", "Q1", "Q1", "Q2"],
+            "revenuePerShare": [1.0, 1.1, 1.2, 2.0, 2.1],
+            "netIncomePerShare": [0.1, 0.11, 0.12, 0.2, 0.21],
+        },
+        index=idx,
+    )
+
+    prices = {"BAD": _price_ts(), "GOOD": _price_ts()}
+    # Must not raise ValueError (issue #75)
+    out = c.prepare_key_metrics(stock_price_series=prices)
+    # GOOD always builds; BAD may build after dedupe or be skipped if empty/invalid
+    assert "GOOD" in out
+    assert isinstance(out["GOOD"], TimeSeries)
+
+
+def test_prepare_key_metrics_skips_value_error_without_aborting():
+    """Per-ticker ValueError is skipped; other symbols still prepared."""
+    c = Covariates()
+    idx = pd.MultiIndex.from_tuples(
+        [
+            ("OK", pd.Timestamp("2023-06-30")),
+            ("OK", pd.Timestamp("2023-09-30")),
+            ("OK", pd.Timestamp("2023-12-31")),
+        ],
+        names=["Symbol", "Date"],
+    )
+    c.kms_loaded_df = pd.DataFrame(
+        {
+            "period": ["Q2", "Q3", "Q4"],
+            "revenuePerShare": [1.0, 1.1, 1.2],
+            "netIncomePerShare": [0.1, 0.11, 0.12],
+        },
+        index=idx,
+    )
+    # MISSING has no rows → KeyError skip
+    prices = {"OK": _price_ts(n=80, start="2023-01-03"), "MISSING": _price_ts()}
+    out = c.prepare_key_metrics(stock_price_series=prices)
+    assert "OK" in out
+    assert "MISSING" not in out
+
+
+def test_pad_covs_handles_duplicate_cov_index():
+    c = Covariates()
+    prices = _price_ts(n=20)
+    # Duplicate timestamps in covariate series
+    idx = list(pd.DatetimeIndex(prices.time_index)[:5]) + [
+        pd.Timestamp(prices.time_index[2])
+    ]
+    cov = timeseries_from_observed_df(
+        pd.DataFrame({"feat": range(len(idx))}, index=pd.DatetimeIndex(idx))
+    )
+    padded = c.pad_covs(cov_series=cov, price_series=prices, fillna_value=0)
+    assert len(padded) == len(prices)
+    assert padded.pd_dataframe().index.is_unique


### PR DESCRIPTION
## Summary
Fixes [#75](https://github.com/ivelin/canswim/issues/75): train prep could abort with
\`cannot reindex on an axis with duplicate labels\` when key metrics mapped two
report dates onto the same business day.

- Dedupe after \`df_index_to_biz_days\`
- Catch \`ValueError\` per symbol (skip + warn)
- Harder \`pad_covs\` against duplicate cov index
- Unit tests

## Test plan
- [x] \`./scripts/ci-local.sh\` (140)
- [x] \`tests/canswim/test_key_metrics_dedupe.py\`