### PR TITLE
feat: impute missing covariates for IPO train/forecast (#33)

### DIFF
--- a/docs/run_triggers.md
+++ b/docs/run_triggers.md
@@ -74,6 +74,18 @@ python -m canswim forecast --tickers "AAPL,MSFT" --forecast_start_date 2026-03-0
 
 More CLI recipes: [cli.md](cli.md). MCP: [mcp.md](mcp.md).
 
+## Missing fundamentals (IPO / thin coverage)
+
+The model stack uses **zero-fill / sentinel fill** when a symbol has prices but no
+earnings, key metrics, institutional ownership, or analyst estimates (common for
+recent IPOs and small caps). That keeps feature dimensionality fixed for train
+and forecast so those names are not dropped solely for missing fundamentals.
+
+- Prices remain ground-truth (no invented OHLCV). Short price history still fails
+  readiness checks (~2y for forecast-scoped runs).
+- Ownership fill: `0`. Earnings / estimates: same padding style as sparse known
+  series (`-1` / zero columns aligned to the price calendar when a template exists).
+
 ## Design rules
 
 1. One orchestration for CLI / GUI / MCP.
@@ -81,3 +93,4 @@ More CLI recipes: [cli.md](cli.md). MCP: [mcp.md](mcp.md).
 3. Fail closed on incomplete forecast data (prices or covariates).
 4. Consumer copy in the product; policy detail in this doc.
 5. Parquet is the system of record; DuckDB is the search/UI cache ([data_store.md](data_store.md)).
+6. Impute missing optional fundamentals rather than excluding symbols (train + forecast).

--- a/src/canswim/covariates.py
+++ b/src/canswim/covariates.py
@@ -75,7 +75,7 @@ class Covariates:
             assert is_business_day(i)
         return t_earn
 
-    def prepare_earn_series(self, tickers=None):
+    def prepare_earn_series(self, tickers=None, stock_price_series: dict = None):
         logger.info("preparing past covariates: earnings estimates ")
         # convert date strings to numerical representation
         earn_df = self.earnings_loaded_df.copy()
@@ -116,7 +116,10 @@ class Covariates:
         # )
         # convert earnings dataframe to series
         t_earn_series = {}
-        for t in list(tickers):
+        # Prefer full price dict when provided so missing symbols can be zero-filled
+        price_map = stock_price_series if isinstance(stock_price_series, dict) else {}
+        ticker_list = list(price_map.keys()) if price_map else list(tickers or [])
+        for t in ticker_list:
             try:
                 # logger.info(f'ticker: {t}')
                 t_earn = earn_df.loc[[t]].copy()
@@ -128,12 +131,6 @@ class Covariates:
                 t_earn = self.align_earn_to_business_days(t_earn)
                 # drop rows with duplicate datetime index values
                 t_earn = t_earn[~t_earn.index.duplicated(keep="last")]
-                # t_earn = (
-                #     t_earn.reset_index()
-                #     .drop_duplicates(subset="Date", keep="last")
-                #     .set_index("Date")
-                # )
-                # logger.info(f't_earn freq: {t_earn.index}')
                 tes_tmp = TimeSeries.from_dataframe(
                     t_earn, freq="B", fill_missing_dates=True
                 )
@@ -141,8 +138,21 @@ class Covariates:
                 tes = TimeSeries.from_dataframe(t_earn, fillna_value=-1)
                 assert len(tes.gaps()) == 0
                 t_earn_series[t] = tes
-            except KeyError as e:
-                logger.warning(f"Skipping {t} due to error: {type(e)}: {e}")
+            except (KeyError, AssertionError, ValueError) as e:
+                logger.warning(
+                    f"No earnings series for {t} ({type(e)}: {e}); will zero-fill if template exists"
+                )
+
+        # Issue #33: keep IPOs / thin coverage in train by imputing missing earn covs
+        if t_earn_series and price_map:
+            template = next(iter(t_earn_series.values()))
+            for t, prices in price_map.items():
+                if t not in t_earn_series:
+                    logger.info(
+                        f"Zero-filling earnings covariates for {t} "
+                        f"({len(template.components)} columns)"
+                    )
+                    t_earn_series[t] = self._zero_cov_like(template, prices)
 
         return t_earn_series
 
@@ -464,6 +474,16 @@ class Covariates:
             except (KeyError, AssertionError, ValueError) as e:
                 # ValueError: duplicate-index reindex (dirty fund data) — skip ticker
                 logger.warning(f"Skipping {t} due to error: {type(e)}: {e}")
+        # Issue #33: impute missing key metrics so symbols without coverage stay in train
+        if t_kms_series and stock_price_series:
+            template = next(iter(t_kms_series.values()))
+            for t, prices in stock_price_series.items():
+                if t not in t_kms_series:
+                    logger.info(
+                        f"Zero-filling key metrics for {t} "
+                        f"({len(template.components)} columns)"
+                    )
+                    t_kms_series[t] = self._zero_cov_like(template, prices)
         # logger.info("t_kms_series:", t_kms_series)
         return t_kms_series
 
@@ -748,11 +768,21 @@ class Covariates:
                 ), f"found gaps in series: \n{est_padded.gaps()}"
                 t_est_series[t] = est_padded
 
-            except KeyError as e:
+            except (KeyError, AssertionError, ValueError) as e:
                 logger.info(
-                    f"""Skipping {t} from covariates series. 
-                        No analyst estimates available for {t}, error: {type(e)}, {e}"""
+                    f"No analyst estimates[{period}] for {t} ({type(e)}: {e}); "
+                    "will zero-fill if template exists"
                 )
+        # Issue #33: impute missing analyst estimates so IPOs stay in train/forecast
+        if t_est_series and stock_price_series:
+            template = next(iter(t_est_series.values()))
+            for t, prices in stock_price_series.items():
+                if t not in t_est_series:
+                    logger.info(
+                        f"Zero-filling analyst estimates[{period}] for {t} "
+                        f"({len(template.components)} columns)"
+                    )
+                    t_est_series[t] = self._zero_cov_like(template, prices)
         return t_est_series
 
     def prepare_analyst_estimates(self, stock_price_series=None):
@@ -782,12 +812,15 @@ class Covariates:
         past_covariates = self.get_price_covariates(
             stock_price_series=stock_price_series, target_columns=target_columns
         )
-        # add revenue and earnings covariates
-        earn_covariates = self.prepare_earn_series(tickers=stock_price_series.keys())
+        # add revenue and earnings covariates (missing → zero-fill for train IPOs #33)
+        earn_covariates = self.prepare_earn_series(
+            tickers=stock_price_series.keys(),
+            stock_price_series=stock_price_series,
+        )
         past_covariates = self.stack_covariates(
             old_covs=past_covariates, new_covs=earn_covariates
         )
-        # add key metrics covariates
+        # add key metrics covariates (missing → zero-fill inside prepare_key_metrics)
         kms_series = self.prepare_key_metrics(stock_price_series=stock_price_series)
         past_covariates = self.stack_covariates(
             old_covs=past_covariates, new_covs=kms_series
@@ -1087,17 +1120,20 @@ class Covariates:
         quarter_est_series, annual_est_series = self.prepare_analyst_estimates(
             stock_price_series=stock_price_series
         )
+        # min_samples=1 on optional estimate stacks so short/IPO series are not
+        # dropped solely for lacking analyst coverage (issue #33). Length vs
+        # train min_samples is enforced later on targets.
         if quarter_est_series:
             future_covariates = self.stack_covariates(
                 old_covs=future_covariates,
                 new_covs=quarter_est_series,
-                min_samples=min_samples,
+                min_samples=1,
             )
         if annual_est_series:
             future_covariates = self.stack_covariates(
                 old_covs=future_covariates,
                 new_covs=annual_est_series,
-                min_samples=min_samples,
+                min_samples=1,
             )
         # extend covars into forecast horizon future dates
         future_covariates = self.__extend_series(

--- a/tests/canswim/test_cov_imputation.py
+++ b/tests/canswim/test_cov_imputation.py
@@ -1,0 +1,127 @@
+"""Issue #33: impute missing fund covariates so IPOs stay in the train stack."""
+
+from __future__ import annotations
+
+import pandas as pd
+from darts import TimeSeries
+
+from canswim.covariates import Covariates
+from canswim.eligibility import timeseries_from_observed_df
+
+
+def _price_ts(n: int = 30, start: str = "2024-01-02") -> TimeSeries:
+    idx = pd.bdate_range(start, periods=n)
+    df = pd.DataFrame(
+        {
+            "Open": range(n),
+            "High": range(1, n + 1),
+            "Low": range(n),
+            "Close": range(n),
+            "Volume": [1e6] * n,
+        },
+        index=idx,
+    )
+    return timeseries_from_observed_df(df)
+
+
+def test_prepare_earn_zero_fills_missing_ticker():
+    c = Covariates()
+    # Only COVERED has earnings rows
+    idx = pd.MultiIndex.from_tuples(
+        [
+            ("COVERED", pd.Timestamp("2024-01-15")),
+            ("COVERED", pd.Timestamp("2024-04-15")),
+        ],
+        names=["Symbol", "Date"],
+    )
+    c.earnings_loaded_df = pd.DataFrame(
+        {
+            "eps": [1.0, 1.1],
+            "epsEstimated": [0.9, 1.0],
+            "time": ["amc", "amc"],
+            "revenue": [1e6, 1.1e6],
+            "revenueEstimated": [9e5, 1e6],
+            "updatedFromDate": pd.to_datetime(["2024-01-10", "2024-04-10"]),
+            "fiscalDateEnding": pd.to_datetime(["2023-12-31", "2024-03-31"]),
+        },
+        index=idx,
+    )
+    prices = {"COVERED": _price_ts(), "IPO": _price_ts()}
+    out = c.prepare_earn_series(
+        tickers=prices.keys(), stock_price_series=prices
+    )
+    assert "COVERED" in out and "IPO" in out
+    assert len(out["IPO"].components) == len(out["COVERED"].components)
+    # Imputed IPO series is finite (zero-filled template)
+    assert out["IPO"].pd_dataframe().notna().all().all()
+
+
+def test_prepare_est_zero_fills_missing_ticker():
+    c = Covariates()
+    # Minimal annual estimates for one symbol only
+    idx = pd.MultiIndex.from_tuples(
+        [
+            ("BIG", pd.Timestamp("2023-12-31")),
+            ("BIG", pd.Timestamp("2024-12-31")),
+        ],
+        names=["Symbol", "Date"],
+    )
+    # Columns used after est_add_future_periods — provide core numeric fields
+    est = pd.DataFrame(
+        {
+            "estimatedRevenueAvg": [1e9, 1.1e9],
+            "estimatedEpsAvg": [2.0, 2.2],
+            "numberAnalystEstimatedRevenue": [10, 11],
+            "numberAnalystsEstimatedEps": [10, 11],
+            "estimatedRevenueLow": [0.9e9, 1.0e9],
+            "estimatedRevenueHigh": [1.1e9, 1.2e9],
+            "estimatedEpsLow": [1.8, 2.0],
+            "estimatedEpsHigh": [2.2, 2.4],
+            "estimatedEbitdaAvg": [1e8, 1.1e8],
+            "estimatedEbitAvg": [1e8, 1.1e8],
+            "estimatedNetIncomeAvg": [5e7, 5.5e7],
+            "estimatedSgaExpenseAvg": [1e7, 1.1e7],
+            "estimatedEbitdaHigh": [1.1e8, 1.2e8],
+            "estimatedEbitdaLow": [0.9e8, 1.0e8],
+            "estimatedEbitHigh": [1.1e8, 1.2e8],
+            "estimatedEbitLow": [0.9e8, 1.0e8],
+            "estimatedNetIncomeHigh": [5.5e7, 6e7],
+            "estimatedNetIncomeLow": [4.5e7, 5e7],
+            "estimatedSgaExpenseHigh": [1.1e7, 1.2e7],
+            "estimatedSgaExpenseLow": [0.9e7, 1.0e7],
+        },
+        index=idx,
+    )
+    prices = {"BIG": _price_ts(n=60, start="2023-06-01"), "IPO": _price_ts(n=60, start="2023-06-01")}
+    out = c.prepare_est_series(
+        all_est_df=est,
+        n_future_periods=2,
+        period="annual",
+        stock_price_series=prices,
+    )
+    assert "BIG" in out
+    assert "IPO" in out
+    assert list(out["IPO"].components) == list(out["BIG"].components)
+
+
+def test_prepare_key_metrics_zero_fills_missing():
+    c = Covariates()
+    idx = pd.MultiIndex.from_tuples(
+        [
+            ("HAS", pd.Timestamp("2024-03-31")),
+            ("HAS", pd.Timestamp("2024-06-30")),
+        ],
+        names=["Symbol", "Date"],
+    )
+    c.kms_loaded_df = pd.DataFrame(
+        {
+            "period": ["Q1", "Q2"],
+            "revenuePerShare": [1.0, 1.1],
+            "netIncomePerShare": [0.1, 0.11],
+        },
+        index=idx,
+    )
+    prices = {"HAS": _price_ts(), "IPO": _price_ts()}
+    out = c.prepare_key_metrics(stock_price_series=prices)
+    assert "HAS" in out and "IPO" in out
+    assert len(out["IPO"].components) == len(out["HAS"].components)

--- a/tests/canswim/test_key_metrics_dedupe.py
+++ b/tests/canswim/test_key_metrics_dedupe.py
@@ -91,8 +91,8 @@ def test_prepare_key_metrics_collapses_biz_day_collision():
     assert "COLLIDE" in out  # dedupe keeps last Mon row + April report
 
 
-def test_prepare_key_metrics_skips_missing_symbol_without_aborting():
-    """Missing KMS for one ticker must not prevent others from preparing."""
+def test_prepare_key_metrics_imputes_missing_symbol_without_aborting():
+    """Missing KMS for one ticker is zero-filled (#33); others still prepare."""
     c = Covariates()
     idx = pd.MultiIndex.from_tuples(
         [
@@ -113,7 +113,9 @@ def test_prepare_key_metrics_skips_missing_symbol_without_aborting():
     prices = {"OK": _price_ts(n=80, start="2023-01-03"), "MISSING": _price_ts()}
     out = c.prepare_key_metrics(stock_price_series=prices)
     assert "OK" in out
-    assert "MISSING" not in out
+    # Issue #33: impute rather than drop
+    assert "MISSING" in out
+    assert len(out["MISSING"].components) == len(out["OK"].components)
 
 
 def test_pad_covs_handles_duplicate_cov_index():


### PR DESCRIPTION
## Summary
Closes [#33](https://github.com/ivelin/canswim/issues/33): symbols without analyst estimates / earnings / key metrics (typical IPOs, small caps) are **zero-filled** from a peer template instead of being excluded from the covariate stack.

- Earnings, key metrics, analyst estimates imputation
- Ownership already zero-filled (prior work)
- Future estimate stacks use \`min_samples=1\` so length floors do not drop IPOs for missing estimates alone
- Docs: \`docs/run_triggers.md\`
- Tests: \`test_cov_imputation.py\`

## Test plan
- [x] \`./scripts/ci-local.sh\` (151)