### PR TITLE
feat: company profiles in Charts and Scans (#50)

### DIFF
--- a/docs/data_store.md
+++ b/docs/data_store.md
@@ -13,12 +13,18 @@ If the UI or MCP looks stale or missing a symbol, the usual fix is: ensure parqu
 
 ## What each is used for
 
-- **Gather** writes/merges parquet (prices, earnings, ownership, estimates, …).
+- **Gather** writes/merges parquet (prices, earnings, ownership, estimates, company profiles, …).
 - **Forecast** writes forecast partitions under `data/forecast/` (and may sync rows into DuckDB).
 - **Dashboard** builds or reuses DuckDB (`--same_data True` reuses; first open / rebuild loads from parquet).
 - **MCP** reads DuckDB; optional `MCP_INIT_DB=1` can build it on start.
 
-Scoped gather/forecast also **sync** symbols and forecast rows into DuckDB so Charts/Scans pick up new tickers without a full rebuild.
+Scoped gather/forecast also **sync** symbols, forecast rows, and **company profiles** into DuckDB so Charts/Scans pick up new tickers and name/sector/industry without a full rebuild.
+
+| Parquet file | DuckDB table | Used by |
+|--------------|--------------|---------|
+| `data-3rd-party/company_profile.parquet` | `company_profile` | Charts company blurb; Scans `company_name` / `sector` / `industry` columns |
+
+`company_profile` is optional for `--same_data True` reuse (core scan tables can exist without it); gather/sync or a full rebuild populates it when the parquet is present.
 
 ## Operator tips
 

--- a/src/canswim/dashboard/__init__.py
+++ b/src/canswim/dashboard/__init__.py
@@ -91,7 +91,7 @@ class CanswimPlayground:
                 )
 
             def _on_load(ticker, lowq):
-                """Page load: chart + scan dates + auto-scan with defaults."""
+                """Page load: chart + company blurb + scan dates + auto-scan."""
                 chart_out = charts_tab.plot_forecast(ticker, lowq)
                 start_dd, start_iso, scan_status, scan_table = (
                     scans_tab.initial_scan()
@@ -99,9 +99,11 @@ class CanswimPlayground:
                 if isinstance(chart_out, dict):
                     plot_val = chart_out.get(charts_tab.plotComponent)
                     rr_val = chart_out.get(charts_tab.rrTable)
+                    company_val = chart_out.get(charts_tab.companyInfo)
                     return (
                         plot_val,
                         rr_val,
+                        company_val,
                         start_dd,
                         start_iso,
                         scan_status,
@@ -110,6 +112,7 @@ class CanswimPlayground:
                 return (
                     chart_out[0],
                     chart_out[1],
+                    charts_tab._company_md(ticker),
                     start_dd,
                     start_iso,
                     scan_status,
@@ -122,6 +125,7 @@ class CanswimPlayground:
                 outputs=[
                     charts_tab.plotComponent,
                     charts_tab.rrTable,
+                    charts_tab.companyInfo,
                     scans_tab.forecastStart,
                     scans_tab.selectedStart,
                     scans_tab.scanStatus,

--- a/src/canswim/dashboard/charts.py
+++ b/src/canswim/dashboard/charts.py
@@ -8,7 +8,13 @@ import matplotlib.dates as mdates
 import random
 import pandas as pd
 from pandas.tseries.offsets import BDay
-from canswim.db import list_tickers, get_reward_risk, get_saved_forecasts_as_series
+from canswim.db import (
+    list_tickers,
+    get_reward_risk,
+    get_saved_forecasts_as_series,
+    get_company_profile,
+    format_company_profile_markdown,
+)
 
 # Note: It appears that gradio Plot ignores the backend plot lib setting
 # pd.options.plotting.backend = 'hvplot'
@@ -25,10 +31,13 @@ class ChartTab:
         with gr.Row():
             sorted_tickers = sorted(self.get_tickers())
             logger.info(f"Sorted selection tickers: {sorted_tickers}")
+            default_ticker = (
+                random.sample(sorted_tickers, 1)[0] if sorted_tickers else None
+            )
             self.tickerDropdown = gr.Dropdown(
                 choices=sorted_tickers,
                 label="Stock Symbol",
-                value=random.sample(sorted_tickers, 1)[0],
+                value=default_ticker,
             )
             self.lowq = gr.Radio(
                 choices=[80, 95, 99],
@@ -36,6 +45,10 @@ class ChartTab:
                 label="Confidence level for lowest close price",
                 info="Choose low price confidence percentage",
             )
+        self.companyInfo = gr.Markdown(
+            value=self._company_md(default_ticker),
+            label="Company",
+        )
         with gr.Row():
             self.rrTable = gr.Dataframe(
                 label="Reward / Risk metrics (only for uptrending forecasts)"
@@ -43,13 +56,24 @@ class ChartTab:
         self.tickerDropdown.change(
             fn=self.plot_forecast,
             inputs=[self.tickerDropdown, self.lowq],
-            outputs=[self.plotComponent, self.rrTable],
+            outputs=[self.plotComponent, self.rrTable, self.companyInfo],
         )
         self.lowq.change(
             fn=self.plot_forecast,
             inputs=[self.tickerDropdown, self.lowq],
-            outputs=[self.plotComponent, self.rrTable],
+            outputs=[self.plotComponent, self.rrTable, self.companyInfo],
         )
+
+    def _company_md(self, ticker: str | None) -> str:
+        if not ticker:
+            return ""
+        try:
+            return format_company_profile_markdown(
+                get_company_profile(self.db_path, ticker)
+            )
+        except Exception as e:
+            logger.debug(f"company profile blurb: {e}")
+            return "_Company profile unavailable._"
 
     def get_tickers(self):
         return list_tickers(self.db_path)
@@ -348,7 +372,12 @@ class ChartTab:
         if target is None:
             axes.legend()
             axes.grid(True, which="major", linestyle="-", alpha=0.3)
-        return {self.plotComponent: fig, self.rrTable: rr_df}
+        company_md = self._company_md(ticker)
+        return {
+            self.plotComponent: fig,
+            self.rrTable: rr_df,
+            self.companyInfo: company_md,
+        }
 
     def get_saved_forecasts(self, ticker: str = None, start_date=None):
         """Load forecasts from storage to a list of individual forecast series with quantile sampling"""

--- a/src/canswim/db.py
+++ b/src/canswim/db.py
@@ -1,7 +1,8 @@
 """Shared DuckDB access for dashboard and MCP (read path + search-DB init).
 
 Uses the same tables and schema as the Gradio dashboard:
-stock_tickers, forecast, latest_forecast, close_price, backtest_error.
+stock_tickers, forecast, latest_forecast, close_price, backtest_error,
+company_profile.
 """
 
 from __future__ import annotations
@@ -16,12 +17,29 @@ import duckdb
 import pandas as pd
 from loguru import logger
 
-SEARCH_TABLES = (
+# Required for --same_data reuse (company_profile is optional / added lazily)
+CORE_SEARCH_TABLES = (
     "stock_tickers",
     "forecast",
     "latest_forecast",
     "close_price",
     "backtest_error",
+)
+SEARCH_TABLES = CORE_SEARCH_TABLES + ("company_profile",)
+
+COMPANY_PROFILE_PARQUET = "company_profile.parquet"
+COMPANY_PROFILE_COLS = (
+    "symbol",
+    "company_name",
+    "sector",
+    "industry",
+    "country",
+    "exchange",
+    "mkt_cap",
+    "currency",
+    "ipo_date",
+    "website",
+    "description",
 )
 
 DEFAULT_ROW_LIMIT = 5000
@@ -73,7 +91,7 @@ def db_file_exists(db_path: Optional[str] = None) -> bool:
     return Path(path).is_file()
 
 
-def tables_present(db_path: str, tables: Sequence[str] = SEARCH_TABLES) -> bool:
+def tables_present(db_path: str, tables: Sequence[str] = CORE_SEARCH_TABLES) -> bool:
     if not db_file_exists(db_path):
         return False
     try:
@@ -238,7 +256,202 @@ def init_search_db(
             ON backtest_error (symbol, start_date)
             """
         )
+        _create_or_load_company_profile_table(db_con, paths)
     return True
+
+
+def company_profile_parquet_path(paths: Optional[DataPaths] = None) -> str:
+    paths = paths or DataPaths.from_env()
+    data_3rd = os.getenv("data-3rd-party", "data-3rd-party")
+    return str(Path(paths.data_dir) / data_3rd / COMPANY_PROFILE_PARQUET)
+
+
+def _create_or_load_company_profile_table(db_con, paths: Optional[DataPaths] = None) -> None:
+    """Create company_profile from parquet or empty schema."""
+    logger.info("Creating company_profile table")
+    pq = company_profile_parquet_path(paths)
+    if Path(pq).is_file():
+        db_con.sql(
+            f"""--sql
+            CREATE OR REPLACE TABLE company_profile AS
+            SELECT
+                upper(CAST(symbol AS VARCHAR)) AS symbol,
+                CAST(company_name AS VARCHAR) AS company_name,
+                CAST(sector AS VARCHAR) AS sector,
+                CAST(industry AS VARCHAR) AS industry,
+                CAST(country AS VARCHAR) AS country,
+                CAST(exchange AS VARCHAR) AS exchange,
+                TRY_CAST(mkt_cap AS DOUBLE) AS mkt_cap,
+                CAST(currency AS VARCHAR) AS currency,
+                CAST(ipo_date AS VARCHAR) AS ipo_date,
+                CAST(website AS VARCHAR) AS website,
+                CAST(description AS VARCHAR) AS description
+            FROM read_parquet('{pq}')
+            """
+        )
+    else:
+        db_con.sql(
+            """--sql
+            CREATE OR REPLACE TABLE company_profile (
+                symbol VARCHAR,
+                company_name VARCHAR,
+                sector VARCHAR,
+                industry VARCHAR,
+                country VARCHAR,
+                exchange VARCHAR,
+                mkt_cap DOUBLE,
+                currency VARCHAR,
+                ipo_date VARCHAR,
+                website VARCHAR,
+                description VARCHAR
+            )
+            """
+        )
+    try:
+        db_con.sql(
+            """--sql
+            CREATE UNIQUE INDEX company_profile_sym_idx ON company_profile (symbol)
+            """
+        )
+    except Exception as e:
+        logger.debug(f"company_profile index: {e}")
+    try:
+        db_con.table("company_profile").show()
+    except Exception:
+        pass
+
+
+def sync_company_profiles_to_search_db(
+    db_path: str,
+    *,
+    profile_path: Optional[str] = None,
+) -> dict[str, Any]:
+    """Reload company_profile table from local parquet into DuckDB."""
+    pq = profile_path or company_profile_parquet_path()
+    if not Path(pq).is_file():
+        return {"ok": True, "rows": 0, "message": f"No profile parquet at {pq}"}
+    try:
+        with connect_readwrite(db_path) as db_con:
+            # Ensure table exists even if DB was created before this feature
+            try:
+                db_con.execute("SELECT 1 FROM company_profile LIMIT 0")
+            except Exception:
+                _create_or_load_company_profile_table(db_con)
+            db_con.sql(
+                f"""--sql
+                CREATE OR REPLACE TABLE company_profile AS
+                SELECT
+                    upper(CAST(symbol AS VARCHAR)) AS symbol,
+                    CAST(company_name AS VARCHAR) AS company_name,
+                    CAST(sector AS VARCHAR) AS sector,
+                    CAST(industry AS VARCHAR) AS industry,
+                    CAST(country AS VARCHAR) AS country,
+                    CAST(exchange AS VARCHAR) AS exchange,
+                    TRY_CAST(mkt_cap AS DOUBLE) AS mkt_cap,
+                    CAST(currency AS VARCHAR) AS currency,
+                    CAST(ipo_date AS VARCHAR) AS ipo_date,
+                    CAST(website AS VARCHAR) AS website,
+                    CAST(description AS VARCHAR) AS description
+                FROM read_parquet('{pq}')
+                """
+            )
+            try:
+                db_con.sql(
+                    "CREATE UNIQUE INDEX company_profile_sym_idx ON company_profile (symbol)"
+                )
+            except Exception:
+                pass
+            n = db_con.execute("SELECT count(*) FROM company_profile").fetchone()[0]
+        return {"ok": True, "rows": int(n)}
+    except Exception as e:
+        logger.warning(f"sync_company_profiles_to_search_db failed: {e}")
+        return {"ok": False, "error": str(e), "rows": 0}
+
+
+def get_company_profile(db_path: str, symbol: str) -> Optional[dict[str, Any]]:
+    """Return one company profile row as a dict, or None."""
+    sym = str(symbol or "").strip().upper()
+    if not sym:
+        return None
+    try:
+        with connect_readonly(db_path) as db_con:
+            try:
+                row = db_con.execute(
+                    """--sql
+                    SELECT symbol, company_name, sector, industry, country,
+                           exchange, mkt_cap, currency, ipo_date, website, description
+                    FROM company_profile
+                    WHERE upper(CAST(symbol AS VARCHAR)) = ?
+                    LIMIT 1
+                    """,
+                    [sym],
+                ).fetchone()
+            except Exception:
+                return None
+            if not row:
+                return None
+            cols = [
+                "symbol",
+                "company_name",
+                "sector",
+                "industry",
+                "country",
+                "exchange",
+                "mkt_cap",
+                "currency",
+                "ipo_date",
+                "website",
+                "description",
+            ]
+            return dict(zip(cols, row))
+    except Exception as e:
+        logger.debug(f"get_company_profile({sym}): {e}")
+        return None
+
+
+def format_company_profile_markdown(profile: Optional[dict[str, Any]]) -> str:
+    """Short Gradio Markdown blurb for Charts tab."""
+    if not profile:
+        return "_No company profile on file. Run **Update market data** for this symbol._"
+    name = profile.get("company_name") or profile.get("symbol") or ""
+    bits = [f"**{name}**"]
+    if profile.get("symbol"):
+        bits[0] = f"**{name}** (`{profile['symbol']}`)"
+    meta = [
+        x
+        for x in (
+            profile.get("sector"),
+            profile.get("industry"),
+            profile.get("country"),
+            profile.get("exchange"),
+        )
+        if x
+    ]
+    line = " · ".join(str(m) for m in meta)
+    lines = [bits[0]]
+    if line:
+        lines.append(line)
+    mkt = profile.get("mkt_cap")
+    if mkt is not None:
+        try:
+            mkt_f = float(mkt)
+            if mkt_f >= 1e12:
+                lines.append(f"Market cap: ${mkt_f / 1e12:.2f}T")
+            elif mkt_f >= 1e9:
+                lines.append(f"Market cap: ${mkt_f / 1e9:.2f}B")
+            elif mkt_f >= 1e6:
+                lines.append(f"Market cap: ${mkt_f / 1e6:.1f}M")
+            else:
+                lines.append(f"Market cap: ${mkt_f:,.0f}")
+        except (TypeError, ValueError):
+            pass
+    if profile.get("website"):
+        lines.append(f"[{profile['website']}]({profile['website']})")
+    desc = profile.get("description") or ""
+    if desc:
+        short = desc if len(desc) <= 280 else desc[:277] + "..."
+        lines.append(f"\n{short}")
+    return "  \n".join(lines)
 
 
 def _format_date_columns(df: pd.DataFrame, columns: Sequence[str]) -> pd.DataFrame:
@@ -704,10 +917,38 @@ def scan_forecasts(
         logger.warning("scan_forecasts: no forecast start dates in database")
         return pd.DataFrame()
     with connect_readonly(db_path) as db_con:
+        has_profile = False
+        try:
+            db_con.execute("SELECT 1 FROM company_profile LIMIT 0")
+            has_profile = True
+        except Exception:
+            has_profile = False
+        profile_select = (
+            """
+                any_value(p.company_name) as company_name,
+                any_value(p.sector) as sector,
+                any_value(p.industry) as industry,
+            """
+            if has_profile
+            else """
+                CAST(NULL AS VARCHAR) as company_name,
+                CAST(NULL AS VARCHAR) as sector,
+                CAST(NULL AS VARCHAR) as industry,
+            """
+        )
+        profile_join = (
+            """
+            LEFT JOIN company_profile p
+              ON upper(CAST(p.symbol AS VARCHAR)) = upper(CAST(f.symbol AS VARCHAR))
+            """
+            if has_profile
+            else ""
+        )
         sql_result = db_con.sql(
             f"""--sql
             SELECT
                 f.symbol,
+                {profile_select}
                 f.start_date as forecast_start_date,
                 arg_max(c.close, c.date) as prior_close_price,
                 min("{low_quantile_col}") as forecast_close_low,
@@ -722,6 +963,7 @@ def scan_forecasts(
              AND CAST(c.Date AS DATE) < f.start_date
             LEFT JOIN backtest_error e
               ON e.symbol = f.symbol AND e.start_date = f.start_date
+            {profile_join}
             WHERE f.start_date = CAST($start AS DATE)
             GROUP BY f.symbol, f.start_date
             HAVING forecast_close_high > prior_close_price AND

--- a/src/canswim/gather_data.py
+++ b/src/canswim/gather_data.py
@@ -968,6 +968,94 @@ class MarketDataGatherer:
             f"({inst_own_df.index.get_level_values(0).nunique()} symbols)"
         )
 
+    def gather_company_profiles(self):
+        """Fetch FMP company profile (name, sector, industry, …) for dashboard UI."""
+        logger.info("Gathering company profiles...")
+        if not self.FMP_API_KEY:
+            logger.warning("FMP_API_KEY missing; skip company profiles")
+            return
+        profile_file = self._data_file("company_profile.parquet")
+        old_df = None
+        try:
+            old_df = pd.read_parquet(profile_file)
+            if old_df is not None and not old_df.empty and "symbol" in old_df.columns:
+                old_df["symbol"] = old_df["symbol"].astype(str).str.upper()
+                old_df = old_df.set_index("symbol", drop=False)
+        except Exception as e:
+            logger.info(f"No existing company profile file ({e})")
+
+        rows = []
+        for ticker in self.stocks_ticker_set:
+            try:
+                raw = fmpsdk.company_profile(
+                    apikey=self.FMP_API_KEY, symbol=ticker
+                )
+            except Exception as e:
+                logger.warning(f"company_profile API error for {ticker}: {e}")
+                continue
+            if not raw:
+                logger.info(f"No company profile for {ticker}")
+                continue
+            rec = raw[0] if isinstance(raw, list) else raw
+            if not isinstance(rec, dict):
+                continue
+            sym = str(rec.get("symbol") or ticker).upper()
+            desc = rec.get("description") or ""
+            if isinstance(desc, str) and len(desc) > 500:
+                desc = desc[:497] + "..."
+            rows.append(
+                {
+                    "symbol": sym,
+                    "company_name": rec.get("companyName") or "",
+                    "sector": rec.get("sector") or "",
+                    "industry": rec.get("industry") or "",
+                    "country": rec.get("country") or "",
+                    "exchange": rec.get("exchangeShortName")
+                    or rec.get("exchange")
+                    or "",
+                    "mkt_cap": rec.get("mktCap"),
+                    "currency": rec.get("currency") or "",
+                    "ipo_date": rec.get("ipoDate") or "",
+                    "website": rec.get("website") or "",
+                    "description": desc,
+                }
+            )
+            logger.info(
+                f"Profile {sym}: {rows[-1]['company_name']} · "
+                f"{rows[-1]['sector']} / {rows[-1]['industry']}"
+            )
+
+        if not rows:
+            if old_df is not None and not old_df.empty:
+                logger.warning("No new company profiles; keeping existing file")
+                return
+            logger.warning("No company profiles gathered")
+            return
+
+        new_df = pd.DataFrame(rows)
+        new_df["symbol"] = new_df["symbol"].astype(str).str.upper()
+        if old_df is not None and not old_df.empty:
+            if "symbol" not in old_df.columns and old_df.index.name == "symbol":
+                old_df = old_df.reset_index()
+            old_df["symbol"] = old_df["symbol"].astype(str).str.upper()
+            refreshed = set(new_df["symbol"].astype(str).str.upper())
+            keep = old_df[~old_df["symbol"].isin(refreshed)].copy()
+            for c in new_df.columns:
+                if c not in keep.columns:
+                    keep[c] = None
+            if not keep.empty:
+                keep = keep.reindex(columns=list(new_df.columns))
+                new_df = pd.concat([keep, new_df], axis=0, ignore_index=True)
+        new_df = new_df.drop_duplicates(subset=["symbol"], keep="last")
+        new_df = new_df.sort_values("symbol")
+        Path(profile_file).parent.mkdir(parents=True, exist_ok=True)
+        out = new_df.reset_index(drop=True)
+        out.to_parquet(profile_file, engine="pyarrow", index=False)
+        logger.info(
+            f"Saved company profiles to {profile_file} "
+            f"({out['symbol'].nunique()} symbols)"
+        )
+
     def gather_analyst_estimates(self):
 
         def _fetch_estimates(period=None):
@@ -1069,6 +1157,7 @@ def main():
     g.gather_stock_key_metrics()
     g.gather_institutional_stock_ownership()
     g.gather_analyst_estimates()
+    g.gather_company_profiles()
 
     if hfhub is not None:
         hfhub.upload_data()

--- a/src/canswim/run_triggers.py
+++ b/src/canswim/run_triggers.py
@@ -479,6 +479,7 @@ def gather_for_tickers(
                     ("key_metrics", g.gather_stock_key_metrics),
                     ("institutional_ownership", g.gather_institutional_stock_ownership),
                     ("analyst_estimates", g.gather_analyst_estimates),
+                    ("company_profiles", g.gather_company_profiles),
                 ):
                     try:
                         fn()
@@ -491,9 +492,14 @@ def gather_for_tickers(
 
         db_sync: dict[str, Any] | None = None
         try:
-            from canswim.db import sync_gathered_symbols, get_db_path
+            from canswim.db import (
+                sync_gathered_symbols,
+                sync_company_profiles_to_search_db,
+                get_db_path,
+            )
 
-            db_sync = sync_gathered_symbols(get_db_path(), work_tickers)
+            db_path = get_db_path()
+            db_sync = sync_gathered_symbols(db_path, work_tickers)
             if db_sync.get("ok"):
                 if db_sync.get("added"):
                     messages.append(
@@ -510,6 +516,13 @@ def gather_for_tickers(
                 messages.append(
                     f"Could not update Charts list: {db_sync.get('error')}"
                 )
+            prof = sync_company_profiles_to_search_db(db_path)
+            if prof.get("ok") and prof.get("rows"):
+                messages.append(
+                    f"Company profiles in search DB: {prof.get('rows')} rows."
+                )
+            elif not prof.get("ok") and prof.get("error"):
+                messages.append(f"Company profile sync note: {prof.get('error')}")
         except Exception as e:
             messages.append(f"Charts list sync note: {e}")
 

--- a/tests/canswim/test_db.py
+++ b/tests/canswim/test_db.py
@@ -11,8 +11,10 @@ import pytest
 from canswim.db import (
     SelectOnlyError,
     dataframe_to_records,
+    format_company_profile_markdown,
     get_backtest_error,
     get_close_prices,
+    get_company_profile,
     get_forecast_rows,
     get_reward_risk,
     is_select_only,
@@ -80,6 +82,20 @@ def _build_mini_db(path: Path) -> str:
                 ('AAA', DATE '2025-01-06', 0.05),
                 ('BBB', DATE '2025-01-06', 0.08)
             ) t(symbol, start_date, mal_error)
+            """
+        )
+        con.execute(
+            """
+            CREATE TABLE company_profile AS
+            SELECT * FROM (VALUES
+                ('AAA', 'Aaa Corp', 'Technology', 'Software', 'US',
+                 'NASDAQ', 1e9, 'USD', '2010-01-01', 'https://aaa.example',
+                 'Makes software.'),
+                ('BBB', 'Bbb Inc', 'Healthcare', 'Biotech', 'US',
+                 'NYSE', 5e8, 'USD', '2015-06-01', 'https://bbb.example',
+                 'Biotech firm.')
+            ) t(symbol, company_name, sector, industry, country,
+                exchange, mkt_cap, currency, ipo_date, website, description)
             """
         )
     return db_path
@@ -252,6 +268,14 @@ def test_scan_forecasts(mini_db):
     df = scan_forecasts(mini_db, lowq=80, reward=5, rr=1.0)
     assert "AAA" in set(df["symbol"]) if not df.empty else True
     # AAA: high 112 vs prior 102 → ~9.8% reward, low 100 → should pass loose rr
+    if not df.empty and "AAA" in set(df["symbol"]):
+        row = df[df["symbol"] == "AAA"].iloc[0]
+        assert "company_name" in df.columns
+        assert "sector" in df.columns
+        assert "industry" in df.columns
+        assert row["company_name"] == "Aaa Corp"
+        assert row["sector"] == "Technology"
+        assert row["industry"] == "Software"
 
 
 def test_scan_forecasts_historic_start(mini_db):
@@ -265,6 +289,72 @@ def test_scan_forecasts_historic_start(mini_db):
     # prior for 2025-01-03 is close on 2025-01-02 = 100; mid = 108
     assert float(df.iloc[0]["prior_close_price"]) == pytest.approx(100.0)
     assert float(df.iloc[0]["forecast_close_high"]) == pytest.approx(108.0)
+    assert df.iloc[0]["company_name"] == "Aaa Corp"
+    assert df.iloc[0]["sector"] == "Technology"
+
+
+def test_get_company_profile(mini_db):
+    p = get_company_profile(mini_db, "aaa")
+    assert p is not None
+    assert p["symbol"] == "AAA"
+    assert p["company_name"] == "Aaa Corp"
+    assert p["sector"] == "Technology"
+    assert p["industry"] == "Software"
+    assert get_company_profile(mini_db, "ZZZ") is None
+    assert get_company_profile(mini_db, "") is None
+
+
+def test_format_company_profile_markdown():
+    md = format_company_profile_markdown(
+        {
+            "symbol": "AAA",
+            "company_name": "Aaa Corp",
+            "sector": "Technology",
+            "industry": "Software",
+            "country": "US",
+            "exchange": "NASDAQ",
+            "mkt_cap": 1.5e9,
+            "website": "https://aaa.example",
+            "description": "Makes software.",
+        }
+    )
+    assert "Aaa Corp" in md
+    assert "Technology" in md
+    assert "Software" in md
+    assert "1.50B" in md
+    assert "aaa.example" in md
+    empty = format_company_profile_markdown(None)
+    assert "No company profile" in empty
+
+
+def test_sync_company_profiles_to_search_db(mini_db, tmp_path: Path):
+    from canswim.db import sync_company_profiles_to_search_db
+
+    pq = tmp_path / "company_profile.parquet"
+    pd.DataFrame(
+        [
+            {
+                "symbol": "CCC",
+                "company_name": "Ccc Ltd",
+                "sector": "Energy",
+                "industry": "Oil",
+                "country": "US",
+                "exchange": "NYSE",
+                "mkt_cap": 2e9,
+                "currency": "USD",
+                "ipo_date": "2000-01-01",
+                "website": "https://ccc.example",
+                "description": "Energy co.",
+            }
+        ]
+    ).to_parquet(pq, index=False)
+    res = sync_company_profiles_to_search_db(mini_db, profile_path=str(pq))
+    assert res["ok"] is True
+    assert res["rows"] == 1
+    p = get_company_profile(mini_db, "CCC")
+    assert p is not None
+    assert p["company_name"] == "Ccc Ltd"
+    assert p["sector"] == "Energy"
 
 
 def test_is_select_only():

--- a/tests/canswim/test_market_data_io.py
+++ b/tests/canswim/test_market_data_io.py
@@ -173,6 +173,9 @@ def test_gather_main_skips_hf_when_local(monkeypatch):
         def gather_analyst_estimates(self):
             pass
 
+        def gather_company_profiles(self):
+            pass
+
     monkeypatch.setenv("hfhub_sync", "False")
     monkeypatch.setenv("SYNC_SYMBOL_LISTS", "0")
     monkeypatch.setattr(gd, "HFHub", FakeHub)


### PR DESCRIPTION
## Summary
- Fetch FMP `company_profile` into `data-3rd-party/company_profile.parquet` (full CLI gather + scoped covariates)
- Sync into DuckDB `company_profile` (optional for `--same_data`; rebuild/sync when parquet present)
- Charts tab: markdown blurb (name, sector/industry, mkt cap, website, short description)
- Scans: `company_name`, `sector`, `industry` columns via LEFT JOIN

Closes #50

## Test plan
- [x] `./scripts/ci-local.sh` (158 passed)
- [x] Unit tests: get/format profile, sync parquet→DuckDB, scan columns
- [ ] After merge: gather a few symbols with FMP key, open dashboard Charts + Scans