### PR TITLE
release: 0.0.20260713 quality + company profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 All notable releases are documented here. Versioning follows date-style `0.0.YYYYMMDD` unless noted.
 
+## 0.0.20260713
+
+Stability and quality release on top of the 0.0.20260711 operator toolkit (GUI / MCP / scoped gather·forecast).
+
+### Highlights
+
+- **Company profiles (#50)** — FMP profile → parquet / DuckDB; Charts name·sector·industry blurb; Scans columns for company name, sector, industry
+- **Train key-metrics hard fails (#75)** — collapse dirty weekend / duplicate index paths before train; skip bad symbols instead of aborting the whole loop
+- **Forecast parquet sanity (#32)** — validate forecast frames before save (no empty / all-null quantile dumps)
+- **Fund covariate imputation (#33)** — zero-fill missing fundamentals for IPO / short-history symbols so train·forecast dimensions match
+- **Held-out test metrics (#31)** — report test MAE/MAPE after train fit
+- **IPO / short-history UX** — consumer-friendly gather messages (not raw rate-limit noise)
+- **Gradio dashboard launch** — works on restricted / non-localhost hosts
+- **Publish tooling** — twine≥6 for Metadata-Version 2.4 PyPI uploads
+
+### Requirements for end users
+
+- Python ≥ 3.10
+- Optional but typical: **FMP API key** for fundamentals, ownership, estimates, **and company profiles**
+- Default model checkpoint on **Hugging Face** (public; swappable)
+- Local disk for parquet + DuckDB under `data/`
+
+**NOT FINANCIAL OR INVESTMENT ADVICE. USE AT YOUR OWN RISK.**
+
+### Install
+
+```bash
+pip install canswim==0.0.20260713
+python -m canswim -h
+python -m canswim dashboard --same_data True
+python -m canswim mcp
+```
+
 ## 0.0.20260711
 
 Operator-focused release: install locally, use Gradio GUI or MCP with a public TiDE checkpoint and your own market-data API keys (e.g. FMP).

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Flags: `python -m canswim -h` is the source of truth. Local site preview: `pip i
 
 ```bash
 pip install canswim
-# pin a release: pip install canswim==0.0.20260711
+# pin a release: pip install canswim==0.0.20260713
 
 # dev checkout
 pip install -e ".[dev]"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = canswim
-version = 0.0.20260711
+version = 0.0.20260713
 author = Ivelin Ivanov
 author_email = ivelin117@gmail.com
 description = Developer toolkit for CANSLIM-style investors (CLI, Gradio GUI, MCP)


### PR DESCRIPTION
## Summary
- Bump package version to **0.0.20260713**
- CHANGELOG highlights since 0.0.20260711 (#50, #75, #32, #33, #31, IPO UX, Gradio launch, publish fix)
- README install pin

## Audit (pre-release)
- [x] `./scripts/ci-local.sh` — 158 passed
- [x] `main` GitHub Tests + Docs green after #101
- [x] `python -m build` + `twine check` PASSED
- [x] `python -m canswim -h` OK
- Open issues: only #36 (parked research)

## After merge
- Tag `v0.0.20260713`
- `./publish.sh prod`
- `gh release create` from CHANGELOG