### PR TITLE
feat: search DB status banner + refresh from parquet

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ python -m canswim dashboard --same_data True
 |-----|---------|
 | **Charts** | Price history + forecast bands for a symbol |
 | **Scans** | Filter forecasts by as-of date, reward, risk, confidence |
-| **Run** | **Update market data** / **Run forecast** / **Check start date** |
+| **Run** | **Update market data** / **Run forecast** / **Check start date** / **Refresh search DB from parquet** |
 | **Advanced Queries** | Read-only SQL against the search DB |
 
 ### Sample screenshots

--- a/docs/data_store.md
+++ b/docs/data_store.md
@@ -36,8 +36,17 @@ python -m canswim dashboard --same_data True
 python -m canswim dashboard --same_data False
 ```
 
+- The dashboard shows a **search DB status** banner (path, reuse vs rebuild, row counts, whether parquet sources exist).
+- On the **Run** tab, **Refresh search DB from parquet** rebuilds DuckDB without restarting (same as `--same_data False`).
+- With `--same_data True`, optional tables such as `company_profile` are **repaired lazily** if missing (no full wipe).
 - Prefer **`hfhub_sync=False`** for local work so gather does not pull the full HF dataset snapshot.
 - Do not commit gitignored `data/` artifacts or slimmed local-only symbol lists used for experiments (see `AGENTS.md`).
+
+### If Charts look empty but parquet has data
+
+1. Confirm the status banner DB path matches the data you expect.
+2. Click **Refresh search DB from parquet** on the Run tab (or restart with `--same_data False`).
+3. Charts still read **DuckDB only** — editing parquet alone does not update the UI until sync/rebuild.
 
 ## Related docs
 

--- a/docs/run_triggers.md
+++ b/docs/run_triggers.md
@@ -12,6 +12,7 @@ User-facing actions for a **short list of symbols**. Implementation: `canswim.ru
 | **Get market data** | Update local prices **and** model fundamentals for listed symbols | `gatherdata --tickers "AAPL,MSFT"` | **Update market data** | `gather_tickers` |
 | **Run a forecast** | Forecast those symbols | `forecast --tickers "AAPL" …` | **Run forecast** | `forecast_tickers` |
 | **Check start date** | Show which start date will be used | `resolve_start` | **Check start date** | `resolve_forecast_start` |
+| **Refresh search DB** | Rebuild DuckDB Charts/Scans cache from parquet | `dashboard --same_data False` | **Refresh search DB from parquet** | (rebuild via dashboard / `MCP_INIT_DB`) |
 
 MCP write tools need `MCP_ALLOW_RUNS=1`. CLI and dashboard do not.
 

--- a/src/canswim/dashboard/__init__.py
+++ b/src/canswim/dashboard/__init__.py
@@ -8,7 +8,12 @@ from canswim.dashboard.charts import ChartTab
 from canswim.dashboard.scans import ScanTab
 from canswim.dashboard.advanced import AdvancedTab
 from canswim.dashboard.run_tab import RunTab
-from canswim.db import DataPaths, init_search_db
+from canswim.db import (
+    DataPaths,
+    format_search_db_status_markdown,
+    init_search_db,
+    search_db_status,
+)
 
 # Note: It appears that gradio Plot ignores the backend plot lib setting
 # pd.options.plotting.backend = "plotly"
@@ -29,6 +34,8 @@ class CanswimPlayground:
         self.forecast_path = paths.forecast_path
         self.stocks_price_path = paths.stocks_price_path
         self.stock_tickers_path = paths.stock_tickers_path
+        self.init_db_result = None  # set by initdb()
+        self.db_status_md = ""
 
     def download_model(self):
         """Load model from HF Hub"""
@@ -47,7 +54,7 @@ class CanswimPlayground:
         self.hfhub.download_data(repo_id=repo_id)
 
     def initdb(self):
-        init_search_db(
+        self.init_db_result = init_search_db(
             self.db_path,
             same_data=self.same_data,
             target_column=self.canswim_model.target_column,
@@ -55,6 +62,17 @@ class CanswimPlayground:
             forecast_path=self.forecast_path,
             stocks_price_path=self.stocks_price_path,
         )
+        mode = "reused" if self.init_db_result.get("reused") else "rebuilt"
+        repaired = (self.init_db_result.get("repair") or {}).get("repaired") or []
+        status = self.init_db_result.get("status") or search_db_status(self.db_path)
+        self.db_status_md = format_search_db_status_markdown(
+            status, mode=mode, repaired=repaired
+        )
+        logger.info(
+            f"Search DB {mode}: path={self.db_path} "
+            f"ok={status.get('ok')} repaired={repaired}"
+        )
+        return self.init_db_result
 
     def launch(self):
         self.download_model()
@@ -68,6 +86,7 @@ class CanswimPlayground:
             * Model trainer source repo [here](https://github.com/ivelin/canswim). Feedback welcome via github issues.
             """
             )
+            self.dbStatusBanner = gr.Markdown(value=self.db_status_md)
             with gr.Tab("Charts"):
                 charts_tab = ChartTab(
                     canswim_model=self.canswim_model,
@@ -83,6 +102,7 @@ class CanswimPlayground:
                     self.canswim_model,
                     db_path=self.db_path,
                     charts_ticker_dropdown=charts_tab.tickerDropdown,
+                    db_status_banner=self.dbStatusBanner,
                 )
             with gr.Tab("Advanced Queries"):
                 AdvancedTab(

--- a/src/canswim/dashboard/run_tab.py
+++ b/src/canswim/dashboard/run_tab.py
@@ -11,7 +11,12 @@ import json
 import gradio as gr
 from loguru import logger
 
-from canswim.db import list_tickers
+from canswim.db import (
+    format_search_db_status_markdown,
+    init_search_db,
+    list_tickers,
+    search_db_status,
+)
 from canswim.run_triggers import (
     FORECAST_BUTTON,
     FORECAST_SECTION_HELP,
@@ -21,6 +26,9 @@ from canswim.run_triggers import (
     GATHER_SECTION_HELP,
     GATHER_SECTION_TITLE,
     PREVIEW_START_BUTTON,
+    REFRESH_SEARCH_BUTTON,
+    REFRESH_SEARCH_SECTION_HELP,
+    REFRESH_SEARCH_SECTION_TITLE,
     TICKERS_HELP,
     forecast_for_tickers,
     gather_for_tickers,
@@ -134,10 +142,12 @@ class RunTab:
         canswim_model=None,
         db_path=None,
         charts_ticker_dropdown=None,
+        db_status_banner=None,
     ):
         self.canswim_model = canswim_model
         self.db_path = db_path
         self.charts_ticker_dropdown = charts_ticker_dropdown
+        self.db_status_banner = db_status_banner
 
         gr.Markdown(
             """
@@ -200,6 +210,33 @@ Two separate steps: **get market data**, then **run a forecast**.
                     value="",
                 )
 
+        gr.Markdown("---")
+
+        # ---- Search DB refresh (parquet → DuckDB) ----
+        with gr.Group():
+            gr.Markdown(
+                f"### {REFRESH_SEARCH_SECTION_TITLE}\n{REFRESH_SEARCH_SECTION_HELP}"
+            )
+            self.refreshDbBtn = gr.Button(REFRESH_SEARCH_BUTTON, variant="secondary")
+            initial_status = ""
+            if self.db_path:
+                try:
+                    initial_status = format_search_db_status_markdown(
+                        search_db_status(self.db_path)
+                    )
+                except Exception as e:
+                    logger.debug(f"initial search db status: {e}")
+                    initial_status = "_Search DB status unavailable._"
+            self.refreshDbStatus = gr.Markdown(value=initial_status)
+            with gr.Accordion("Advanced details", open=False):
+                self.refreshDbDetails = gr.Code(
+                    label="Technical log",
+                    language="json",
+                    lines=8,
+                    interactive=False,
+                    value="",
+                )
+
         gather_outputs = [self.gatherStatus, self.gatherDetails]
         if self.charts_ticker_dropdown is not None:
             gather_outputs.append(self.charts_ticker_dropdown)
@@ -218,6 +255,17 @@ Two separate steps: **get market data**, then **run a forecast**.
             fn=self.do_forecast,
             inputs=[self.forecastTickers, self.forecastDate],
             outputs=[self.forecastStatus, self.forecastDetails],
+        )
+
+        refresh_outputs = [self.refreshDbStatus, self.refreshDbDetails]
+        if self.db_status_banner is not None:
+            refresh_outputs.append(self.db_status_banner)
+        if self.charts_ticker_dropdown is not None:
+            refresh_outputs.append(self.charts_ticker_dropdown)
+        self.refreshDbBtn.click(
+            fn=self.do_refresh_search_db,
+            inputs=[],
+            outputs=refresh_outputs,
         )
 
     def _charts_dropdown_update(self):
@@ -278,3 +326,56 @@ Two separate steps: **get market data**, then **run a forecast**.
             force_allow=True,
         )
         return _forecast_summary(result), _json_details(result)
+
+    def do_refresh_search_db(self):
+        """Rebuild DuckDB search cache from local parquet (full refresh)."""
+        banner = "_Search DB status unavailable._"
+        if not self.db_path:
+            status = "❌ **No database path configured.**"
+            details = _json_details({"ok": False, "error": "db_path missing"})
+            return self._refresh_outputs(status, details, banner, dropdown=False)
+
+        target_col = "Close"
+        if self.canswim_model is not None:
+            target_col = getattr(self.canswim_model, "target_column", None) or "Close"
+
+        logger.info(f"Refreshing search DB from parquet → {self.db_path}")
+        try:
+            result = init_search_db(
+                self.db_path,
+                same_data=False,
+                target_column=target_col,
+            )
+            st = result.get("status") or search_db_status(self.db_path)
+            banner = format_search_db_status_markdown(st, mode="rebuilt")
+            if st.get("ok"):
+                head = f"✅ **Search DB rebuilt** from parquet → `{self.db_path}`."
+            else:
+                head = (
+                    f"⚠️ **Rebuild finished but search DB looks incomplete.**  \n"
+                    f"Path: `{self.db_path}`"
+                )
+            status = head + "  \n\n" + banner
+            details = _json_details(result)
+        except Exception as e:
+            logger.exception("Search DB refresh failed")
+            result = {"ok": False, "error": str(e)}
+            try:
+                st = search_db_status(self.db_path)
+                banner = format_search_db_status_markdown(st)
+            except Exception:
+                banner = f"_Could not read status: {e}_"
+            status = f"❌ **Could not rebuild search DB.**  \n{e}  \n\n{banner}"
+            details = _json_details(result)
+
+        return self._refresh_outputs(status, details, banner, dropdown=True)
+
+    def _refresh_outputs(self, status, details, banner, *, dropdown: bool):
+        outs = [status, details]
+        if self.db_status_banner is not None:
+            outs.append(banner)
+        if self.charts_ticker_dropdown is not None:
+            outs.append(
+                self._charts_dropdown_update() if dropdown else gr.update()
+            )
+        return tuple(outs)

--- a/src/canswim/db.py
+++ b/src/canswim/db.py
@@ -109,6 +109,193 @@ def tables_present(db_path: str, tables: Sequence[str] = CORE_SEARCH_TABLES) -> 
         return False
 
 
+def _list_main_tables(db_con) -> set[str]:
+    return {
+        row[0]
+        for row in db_con.execute(
+            "SELECT table_name FROM information_schema.tables "
+            "WHERE table_schema = 'main'"
+        ).fetchall()
+    }
+
+
+def search_db_status(db_path: Optional[str] = None) -> dict[str, Any]:
+    """Inspect DuckDB search cache + whether source parquet files exist.
+
+    Charts/Scans/MCP read DuckDB only. Parquet is the system of record used
+    to (re)build or sync the search DB.
+    """
+    paths = DataPaths.from_env()
+    path = db_path or paths.db_path
+    profile_pq = company_profile_parquet_path(paths)
+    forecast_root = Path(paths.forecast_path)
+    forecast_files = 0
+    if forecast_root.is_dir():
+        try:
+            forecast_files = sum(1 for _ in forecast_root.glob("**/*.parquet"))
+        except Exception:
+            forecast_files = 0
+
+    out: dict[str, Any] = {
+        "db_path": path,
+        "db_exists": Path(path).is_file(),
+        "tables": {},
+        "counts": {},
+        "missing_core": list(CORE_SEARCH_TABLES),
+        "missing_optional": ["company_profile"],
+        "parquet": {
+            "prices": Path(paths.stocks_price_path).is_file(),
+            "prices_path": paths.stocks_price_path,
+            "forecast_dir": paths.forecast_path,
+            "forecast_parquet_files": forecast_files,
+            "company_profile": Path(profile_pq).is_file(),
+            "company_profile_path": profile_pq,
+            "stock_tickers_csv": Path(paths.stock_tickers_path).is_file(),
+            "stock_tickers_path": paths.stock_tickers_path,
+        },
+        "ok": False,
+    }
+    if not out["db_exists"]:
+        return out
+    try:
+        with connect_readonly(path) as con:
+            existing = _list_main_tables(con)
+            for t in SEARCH_TABLES:
+                present = t in existing
+                out["tables"][t] = present
+                if present:
+                    try:
+                        n = con.execute(f'SELECT count(*) FROM "{t}"').fetchone()[0]
+                        out["counts"][t] = int(n)
+                    except Exception:
+                        out["counts"][t] = None
+            out["missing_core"] = [t for t in CORE_SEARCH_TABLES if t not in existing]
+            out["missing_optional"] = [
+                t for t in ("company_profile",) if t not in existing
+            ]
+            out["ok"] = len(out["missing_core"]) == 0
+    except Exception as e:
+        logger.warning(f"search_db_status({path}): {e}")
+        out["error"] = str(e)
+        out["ok"] = False
+    return out
+
+
+def format_search_db_status_markdown(
+    status: Optional[dict[str, Any]],
+    *,
+    mode: Optional[str] = None,
+    repaired: Optional[Sequence[str]] = None,
+) -> str:
+    """Operator-facing Markdown: which DB, reuse vs rebuild, row counts."""
+    if not status:
+        return "_Search database status unavailable._"
+    path = status.get("db_path") or "—"
+    lines: list[str] = ["### Search database (Charts / Scans / MCP)"]
+    if mode == "reused":
+        lines.append(f"**Mode:** reusing existing DuckDB at `{path}`")
+    elif mode == "rebuilt":
+        lines.append(f"**Mode:** rebuilt from parquet → `{path}`")
+    else:
+        lines.append(f"**Path:** `{path}`")
+
+    if not status.get("db_exists"):
+        lines.append(
+            "❌ **No DuckDB file yet.** Open with rebuild, or use "
+            "**Refresh search DB from parquet** on the Run tab."
+        )
+        return "  \n".join(lines)
+
+    if status.get("ok"):
+        lines.append("✅ Core search tables present.")
+    else:
+        missing = status.get("missing_core") or []
+        lines.append(
+            "⚠️ **Incomplete search DB** — missing: "
+            + (", ".join(missing) if missing else "unknown")
+            + ". Use **Refresh search DB from parquet**."
+        )
+
+    counts = status.get("counts") or {}
+    if counts:
+        bits = []
+        for key, label in (
+            ("stock_tickers", "symbols"),
+            ("forecast", "forecast rows"),
+            ("close_price", "closes"),
+            ("company_profile", "profiles"),
+        ):
+            if key in counts and counts[key] is not None:
+                bits.append(f"{label}: **{counts[key]:,}**")
+        if bits:
+            lines.append(" · ".join(bits))
+
+    if repaired:
+        lines.append("Repaired optional tables: " + ", ".join(repaired))
+
+    pq = status.get("parquet") or {}
+    pq_bits = []
+    if pq.get("prices"):
+        pq_bits.append("prices ✓")
+    else:
+        pq_bits.append("prices ✗")
+    n_fc = pq.get("forecast_parquet_files") or 0
+    pq_bits.append(f"forecast files: {n_fc}")
+    if pq.get("company_profile"):
+        pq_bits.append("profiles ✓")
+    else:
+        pq_bits.append("profiles ✗")
+    lines.append("Parquet (system of record): " + " · ".join(pq_bits))
+    lines.append(
+        "_Charts read DuckDB only. After bulk parquet changes, refresh the search DB._"
+    )
+    return "  \n".join(lines)
+
+
+def ensure_optional_search_tables(
+    db_path: str,
+    *,
+    paths: Optional[DataPaths] = None,
+) -> dict[str, Any]:
+    """Lazy-create optional tables (e.g. company_profile) without a full rebuild.
+
+    Safe for ``--same_data True``: does not drop core tables.
+    """
+    paths = paths or DataPaths.from_env()
+    if not db_file_exists(db_path):
+        return {
+            "ok": False,
+            "repaired": [],
+            "error": f"No database file at {db_path}",
+        }
+    repaired: list[str] = []
+    notes: list[str] = []
+    try:
+        with connect_readwrite(db_path) as db_con:
+            existing = _list_main_tables(db_con)
+            need_profile = "company_profile" not in existing
+            if not need_profile:
+                try:
+                    n = db_con.execute(
+                        "SELECT count(*) FROM company_profile"
+                    ).fetchone()[0]
+                    pq = company_profile_parquet_path(paths)
+                    if int(n) == 0 and Path(pq).is_file():
+                        need_profile = True
+                        notes.append(
+                            "company_profile was empty; reloading from parquet"
+                        )
+                except Exception:
+                    need_profile = True
+            if need_profile:
+                _create_or_load_company_profile_table(db_con, paths)
+                repaired.append("company_profile")
+        return {"ok": True, "repaired": repaired, "notes": notes}
+    except Exception as e:
+        logger.warning(f"ensure_optional_search_tables: {e}")
+        return {"ok": False, "repaired": repaired, "notes": notes, "error": str(e)}
+
+
 def _should_reuse_db(db_path: str, same_data: bool) -> bool:
     if not same_data or not db_file_exists(db_path):
         return False
@@ -128,10 +315,12 @@ def init_search_db(
     stock_tickers_path: Optional[str] = None,
     forecast_path: Optional[str] = None,
     stocks_price_path: Optional[str] = None,
-) -> bool:
+) -> dict[str, Any]:
     """Build or reuse the search-optimized DuckDB (dashboard initdb semantics).
 
-    Returns True if the database was (re)created, False if reused.
+    Returns a dict with ``rebuilt``, ``reused``, ``repair``, and ``status``
+    (see :func:`search_db_status`). On reuse, optionally repairs missing
+    optional tables (e.g. ``company_profile``) without wiping core data.
     """
     paths = DataPaths.from_env()
     stock_tickers_path = stock_tickers_path or paths.stock_tickers_path
@@ -140,7 +329,14 @@ def init_search_db(
 
     if _should_reuse_db(db_path, same_data):
         logger.info("Reusing search database")
-        return False
+        repair = ensure_optional_search_tables(db_path, paths=paths)
+        status = search_db_status(db_path)
+        return {
+            "rebuilt": False,
+            "reused": True,
+            "repair": repair,
+            "status": status,
+        }
 
     logger.info("Creating search optimized database")
     Path(db_path).parent.mkdir(parents=True, exist_ok=True)
@@ -257,7 +453,13 @@ def init_search_db(
             """
         )
         _create_or_load_company_profile_table(db_con, paths)
-    return True
+    status = search_db_status(db_path)
+    return {
+        "rebuilt": True,
+        "reused": False,
+        "repair": {"ok": True, "repaired": [], "notes": []},
+        "status": status,
+    }
 
 
 def company_profile_parquet_path(paths: Optional[DataPaths] = None) -> str:

--- a/src/canswim/run_triggers.py
+++ b/src/canswim/run_triggers.py
@@ -70,6 +70,15 @@ FORECAST_SECTION_HELP = (
 FORECAST_BUTTON = "Run forecast"
 PREVIEW_START_BUTTON = "Check start date"
 
+REFRESH_SEARCH_SECTION_TITLE = "Search database (Charts / Scans)"
+REFRESH_SEARCH_SECTION_HELP = (
+    "Charts and Scans read the local DuckDB search cache, not parquet files directly. "
+    "Parquet under data/ is the system of record. "
+    "After bulk data changes—or if Charts look empty while parquet exists—"
+    "use **Refresh search DB from parquet** to rebuild the cache."
+)
+REFRESH_SEARCH_BUTTON = "Refresh search DB from parquet"
+
 INCOMPLETE_DATA_MSG = (
     "Market history is incomplete or not ready for: {symbols}. "
     "Use Update market data for these symbols, then run the forecast again. "

--- a/tests/canswim/test_db.py
+++ b/tests/canswim/test_db.py
@@ -11,7 +11,9 @@ import pytest
 from canswim.db import (
     SelectOnlyError,
     dataframe_to_records,
+    ensure_optional_search_tables,
     format_company_profile_markdown,
+    format_search_db_status_markdown,
     get_backtest_error,
     get_close_prices,
     get_company_profile,
@@ -23,6 +25,7 @@ from canswim.db import (
     list_tickers,
     run_select,
     scan_forecasts,
+    search_db_status,
     sync_gathered_symbols,
     sync_forecasts_to_search_db,
     tables_present,
@@ -302,6 +305,59 @@ def test_get_company_profile(mini_db):
     assert p["industry"] == "Software"
     assert get_company_profile(mini_db, "ZZZ") is None
     assert get_company_profile(mini_db, "") is None
+
+
+def test_search_db_status(mini_db):
+    st = search_db_status(mini_db)
+    assert st["db_exists"] is True
+    assert st["ok"] is True
+    assert st["counts"].get("stock_tickers") == 2
+    assert st["tables"].get("company_profile") is True
+    assert "missing_core" in st and st["missing_core"] == []
+    md = format_search_db_status_markdown(st, mode="reused")
+    assert "reusing" in md.lower() or "Reusing" in md or "reusing existing" in md.lower()
+    assert "symbols" in md.lower() or "2" in md
+
+
+def test_ensure_optional_search_tables_creates_missing_profile(tmp_path: Path):
+    """--same_data reuse path: add company_profile without wiping core tables."""
+    import duckdb
+
+    db = str(tmp_path / "core_only.duckdb")
+    with duckdb.connect(db) as con:
+        con.execute(
+            "CREATE TABLE stock_tickers AS SELECT 'AAA' AS symbol"
+        )
+        con.execute(
+            """
+            CREATE TABLE forecast AS
+            SELECT CAST('2025-01-06' AS DATE) AS date, 'AAA' AS symbol,
+                   CAST('2025-01-06' AS DATE) AS start_date,
+                   100.0 AS "close_quantile_0.5"
+            """
+        )
+        con.execute(
+            "CREATE TABLE latest_forecast AS SELECT 'AAA' AS symbol, "
+            "CAST('2025-01-06' AS DATE) AS date"
+        )
+        con.execute(
+            "CREATE TABLE close_price AS SELECT CAST('2025-01-03' AS DATE) AS Date, "
+            "'AAA' AS Symbol, 100.0 AS Close"
+        )
+        con.execute(
+            "CREATE TABLE backtest_error AS SELECT 'AAA' AS symbol, "
+            "CAST('2025-01-06' AS DATE) AS start_date, 0.01 AS mal_error"
+        )
+    assert tables_present(db) is True
+    st0 = search_db_status(db)
+    assert st0["tables"].get("company_profile") is not True
+    res = ensure_optional_search_tables(db)
+    assert res["ok"] is True
+    assert "company_profile" in res["repaired"]
+    st1 = search_db_status(db)
+    assert st1["tables"].get("company_profile") is True
+    # Core table still present (not wiped)
+    assert list_tickers(db) == ["AAA"]
 
 
 def test_format_company_profile_markdown():

--- a/tests/canswim/test_docs_sync.py
+++ b/tests/canswim/test_docs_sync.py
@@ -16,11 +16,17 @@ def _read(rel: str) -> str:
 
 def test_run_tab_button_labels_in_docs():
     """README + run_triggers must use product button names from run_triggers.py."""
-    labels = {rt.GATHER_BUTTON, rt.FORECAST_BUTTON, rt.PREVIEW_START_BUTTON}
+    labels = {
+        rt.GATHER_BUTTON,
+        rt.FORECAST_BUTTON,
+        rt.PREVIEW_START_BUTTON,
+        rt.REFRESH_SEARCH_BUTTON,
+    }
     for path in ("README.md", "docs/run_triggers.md"):
         text = _read(path)
         for lab in labels:
             assert lab in text, f"{path} missing button label {lab!r}"
+    assert rt.REFRESH_SEARCH_BUTTON in _read("docs/data_store.md")
     readme = _read("README.md")
     # Stale pre-split UX strings should not reappear as the primary CTA
     assert "Preview start date" not in readme

--- a/tests/canswim/test_ux_split_labels.py
+++ b/tests/canswim/test_ux_split_labels.py
@@ -52,6 +52,10 @@ def test_run_tab_has_separate_gather_and_forecast_controls():
     # Two separate status outputs
     assert "gatherStatus" in src
     assert "forecastStatus" in src
+    # Search DB refresh (parquet → DuckDB)
+    assert "refreshDbBtn" in src
+    assert "do_refresh_search_db" in inspect.getsource(run_tab_mod.RunTab)
+    assert "REFRESH_SEARCH_BUTTON" in src or "Refresh search DB" in src
     # JSON is advanced/collapsed, not primary body
     assert "Advanced details" in src
     assert "gatherDetails" in src


### PR DESCRIPTION
## Summary
- **Status banner** on dashboard: DuckDB path, reuse vs rebuild, row counts, parquet presence
- **Lazy repair** of optional tables (e.g. `company_profile`) when reusing `--same_data True`
- **Run tab**: **Refresh search DB from parquet** (full rebuild without CLI restart)
- Docs: `data_store.md`, `run_triggers.md`, README

## Why
Charts/Scans/MCP read DuckDB only; parquet is SoT. Operators sometimes saw “empty Charts” while parquet was full — this makes the handshake explicit and one-click fixable.

## Test plan
- [x] `./scripts/ci-local.sh` (160 passed)
- [x] Unit: `search_db_status`, `ensure_optional_search_tables`, docs/UX labels
- [ ] Manual: open dashboard, confirm banner; click refresh on Run tab