### PR TITLE
fix: clearer multi-bucket gather status on Run tab

### DIFF
--- a/src/canswim/dashboard/run_tab.py
+++ b/src/canswim/dashboard/run_tab.py
@@ -41,90 +41,263 @@ def _json_details(payload: dict) -> str:
     return json.dumps(payload, indent=2, default=str)
 
 
+def _norm_syms(symbols) -> list[str]:
+    out: list[str] = []
+    seen: set[str] = set()
+    for s in symbols or []:
+        u = str(s).strip().upper()
+        if u and u not in seen:
+            seen.add(u)
+            out.append(u)
+    return out
+
+
+def _fmt_syms(symbols, *, limit: int = 10) -> str:
+    """Compact ticker list for primary UI (full list lives in Advanced details)."""
+    syms = _norm_syms(symbols)
+    if not syms:
+        return "—"
+    if len(syms) <= limit:
+        return ", ".join(syms)
+    head = ", ".join(syms[:limit])
+    return f"{head} … +{len(syms) - limit} more"
+
+
+def _copy_line(symbols) -> str:
+    """Single pasteable line for the forecast box."""
+    syms = _norm_syms(symbols)
+    return ", ".join(syms) if syms else ""
+
+
 def _gather_summary(result: dict) -> str:
+    """Consumer-facing gather status: buckets, counts, clear next steps."""
+    tickers = _norm_syms(result.get("tickers") or [])
+    ready = _norm_syms(result.get("ready") or [])
+    incomplete = _norm_syms(result.get("incomplete") or [])
+    short = _norm_syms(result.get("short_history") or [])
+    no_hist = _norm_syms(result.get("no_history") or [])
+    skipped = _norm_syms(result.get("skipped_remote") or [])
+    fetched = _norm_syms(result.get("fetched") or [])
+    added = _norm_syms((result.get("db_sync") or {}).get("added") or [])
+    n_req = len(tickers) or (len(ready) + len(incomplete))
+    n_ready = len(ready)
+    n_not = len(incomplete) if incomplete else len(short) + len(no_hist)
+
+    # ---- hard failure (nothing forecast-ready) ----
     if not result.get("ok"):
-        err = result.get("error") or "Unknown error."
-        short = result.get("short_history") or []
-        none = result.get("no_history") or []
-        if short or none or "IPO" in err or "trading history" in err:
-            return f"❌ **Could not finish for every symbol.**  \n{err}"
-        return f"❌ **Could not update market data.**  \n{err}"
-    tickers = result.get("tickers") or []
-    ready = result.get("ready") or []
-    incomplete = result.get("incomplete") or []
-    skipped = result.get("skipped_remote") or []
-    fetched = result.get("fetched") or []
-    added = (result.get("db_sync") or {}).get("added") or []
-    short = result.get("short_history") or []
-    if result.get("partial") and incomplete:
-        show = ", ".join(ready) if ready else "—"
-        lines = [
-            f"⚠️ **Partial success** — ready: {show}.",
-            result.get("error")
-            or (
-                f"Not ready (often recent IPOs / short history): "
-                f"{', '.join(incomplete)}."
-            ),
-        ]
-        # Prefer full friendly text from messages if present
-        for m in result.get("messages") or []:
-            if "trading history" in m or "No usable price" in m:
-                lines = [
-                    f"⚠️ **Partial success** — ready: {show}.",
-                    m,
-                ]
-                break
-        if short:
+        err = (result.get("error") or "").strip()
+        is_hist = bool(
+            short
+            or no_hist
+            or "IPO" in err
+            or "trading history" in err.lower()
+            or "not enough" in err.lower()
+        )
+        lines: list[str] = []
+        if is_hist:
             lines.append(
-                "Tip: drop recent IPOs from the list, then run **Update market data** again."
+                f"❌ **None of these symbols are ready for forecasts yet** "
+                f"({n_not or n_req} checked)."
             )
+            if short:
+                lines.append(
+                    f"**Short history / recent listings ({len(short)}):** "
+                    f"{_fmt_syms(short)}"
+                )
+            if no_hist:
+                lines.append(
+                    f"**No usable price history ({len(no_hist)}):** "
+                    f"{_fmt_syms(no_hist)}"
+                )
+            if not short and not no_hist and incomplete:
+                lines.append(
+                    f"**Not ready ({len(incomplete)}):** {_fmt_syms(incomplete)}"
+                )
+            lines.append("")
+            lines.append("**What this means**")
+            lines.append(
+                "Forecasts need about **two years** of trading sessions. "
+                "Recent IPOs and new listings usually cannot be forecasted yet—"
+                "even if some prices were saved."
+            )
+            lines.append("")
+            lines.append("**What you can do next**")
+            lines.append(
+                "1. **Recommended:** Remove those names from the list and "
+                "**Update market data** only for symbols with longer history, "
+                "then **Run forecast**."
+            )
+            lines.append(
+                "2. Keep watching the short-history names in Charts later—"
+                "they become usable as more sessions accumulate."
+            )
+            lines.append(
+                "3. Full lists and technical notes are under **Advanced details**."
+            )
+        else:
+            lines.append("❌ **Could not update market data.**")
+            if err:
+                # Keep error short in primary UI
+                short_err = err if len(err) <= 220 else err[:217] + "…"
+                lines.append(short_err)
+            lines.append("")
+            lines.append("**What you can do next**")
+            lines.append(
+                "1. **Recommended:** Retry **Update market data** with a shorter list."
+            )
+            lines.append(
+                "2. Check API keys / network, then open **Advanced details** for the log."
+            )
+        return "\n\n".join(lines)
+
+    # ---- success (all or partial) ----
+    partial = bool(result.get("partial") and incomplete)
+    lines = []
+    if partial:
+        lines.append(
+            f"⚠️ **Partial update** — **{n_ready} of {n_req or (n_ready + n_not)}** "
+            f"symbols are ready for forecasts."
+        )
     else:
-        show = ", ".join(ready or tickers) or "—"
-        lines = [f"✅ **Market data ready** for {show}."]
+        show_n = n_ready or len(tickers)
+        lines.append(
+            f"✅ **Market data ready** — **{show_n}** symbol"
+            f"{'s' if show_n != 1 else ''} can be forecasted."
+        )
+
+    # Buckets (counts first; compact symbol lists)
+    if ready:
+        lines.append(
+            f"**Ready for forecasts ({n_ready}):** {_fmt_syms(ready)}"
+        )
+        if n_ready > 1:
+            lines.append(f"Paste into forecast box: `{_copy_line(ready)}`")
+
+    if incomplete:
+        why = "often recent IPOs or short listings"
+        if short and not no_hist:
+            why = "short trading history / recent listings"
+        elif no_hist and not short:
+            why = "no usable price history"
+        lines.append(
+            f"**Not ready for forecasts yet ({len(incomplete)}):** "
+            f"{_fmt_syms(incomplete)}  \n"
+            f"_Why: {why}. Prices may still be on file; forecasts need ~2 years of sessions._"
+        )
+
+    # Download activity as counts (avoid repeating every ticker twice)
+    dl_bits = []
     if skipped and not fetched:
-        lines.append("Already up to date locally — no download needed.")
-    elif skipped:
-        lines.append(f"Already local: {', '.join(skipped)}.")
-    if fetched:
-        lines.append(f"Downloaded or refreshed: {', '.join(fetched)}.")
+        dl_bits.append(f"already up to date locally ({len(skipped)})")
+    else:
+        if skipped:
+            dl_bits.append(f"already local, no download ({len(skipped)})")
+        if fetched:
+            dl_bits.append(f"downloaded or refreshed ({len(fetched)})")
     if added:
-        lines.append(f"Added to Charts list: {', '.join(added)}.")
-    return "  \n".join(lines)
+        dl_bits.append(f"new on Charts list: {_fmt_syms(added, limit=8)}")
+    if dl_bits:
+        lines.append("**Downloads:** " + " · ".join(dl_bits))
+
+    lines.append("**What you can do next**")
+    if ready and incomplete:
+        lines.append(
+            "1. **Recommended:** Copy the ready line above into "
+            "**Symbols to forecast** and click **Run forecast**."
+        )
+        lines.append(
+            "2. Leave the not-ready names off the forecast list for now "
+            "(try again in months as history grows)."
+        )
+        lines.append(
+            "3. Optional: trim them from **Symbols to update** before the next gather "
+            "to keep the status quieter."
+        )
+    elif ready:
+        lines.append(
+            "1. **Recommended:** Enter the same symbols under **Run a forecast** "
+            "and click **Run forecast**."
+        )
+        lines.append(
+            "2. Or open **Charts** to review a symbol visually first."
+        )
+    else:
+        lines.append(
+            "1. **Recommended:** Narrow the list to longer-history names and "
+            "run **Update market data** again."
+        )
+    lines.append(
+        "Full symbol lists and the technical log are under **Advanced details**."
+    )
+    return "\n\n".join(lines)
 
 
 def _forecast_summary(result: dict) -> str:
     start = (result.get("resolved_start") or {}).get("start") or "—"
     if result.get("dry_run"):
-        already = result.get("already_have_forecast") or []
+        already = _norm_syms(result.get("already_have_forecast") or [])
         if already:
             return (
-                f"ℹ️ **Check only** — start date `{start}`.  \n"
-                f"Already on file (would skip): {', '.join(already)}."
+                f"ℹ️ **Check only** — start date `{start}`.\n\n"
+                f"**Would skip (already on file, {len(already)}):** "
+                f"{_fmt_syms(already)}\n\n"
+                "No model run. Click **Run forecast** when ready."
             )
-        return f"ℹ️ **Check only** — start date `{start}`. No model run."
-    if result.get("already_saved") and not result.get("forecasted"):
-        already = result.get("already_have_forecast") or result.get("tickers") or []
         return (
-            f"✅ **Already done** for {', '.join(already)} "
-            f"(start `{start}`).  \n"
-            "Skipped re-run — no new forecast files written."
+            f"ℹ️ **Check only** — start date `{start}`.\n\n"
+            "No model run. Click **Run forecast** when ready."
+        )
+    if result.get("already_saved") and not result.get("forecasted"):
+        already = _norm_syms(
+            result.get("already_have_forecast") or result.get("tickers") or []
+        )
+        return (
+            f"✅ **Already done** for **{len(already)}** symbol"
+            f"{'s' if len(already) != 1 else ''} (start `{start}`).\n\n"
+            f"{_fmt_syms(already)}\n\n"
+            "Skipped re-run — no new forecast files written.\n\n"
+            "**Next:** open **Charts** or **Scans** to review results."
         )
     if not result.get("ok"):
         if result.get("need_covariates"):
             head = "❌ **Forecast inputs incomplete.**"
+            nexts = (
+                "1. **Recommended:** **Update market data** for these symbols "
+                "(includes fundamentals), then **Run forecast** again.\n\n"
+                "2. See **Advanced details** for which inputs failed."
+            )
         elif result.get("need_gather"):
             head = "❌ **Need more market data first.**"
+            nexts = (
+                "1. **Recommended:** **Update market data** for these symbols, "
+                "then **Run forecast**.\n\n"
+                "2. Recent IPOs may never be ready until enough history exists."
+            )
         else:
             head = "❌ **Forecast failed.**"
-        return f"{head}  \n{result.get('error') or 'Unknown error.'}"
-    forecasted = result.get("forecasted") or []
-    already = result.get("already_have_forecast") or []
+            nexts = (
+                "1. **Recommended:** Retry with a shorter list.\n\n"
+                "2. Open **Advanced details** for the error log."
+            )
+        err = (result.get("error") or "Unknown error.").strip()
+        short_err = err if len(err) <= 280 else err[:277] + "…"
+        return f"{head}\n\n{short_err}\n\n**What you can do next**\n\n{nexts}"
+
+    forecasted = _norm_syms(result.get("forecasted") or [])
+    already = _norm_syms(result.get("already_have_forecast") or [])
     lines = [f"✅ **Forecast complete** (start `{start}`)."]
     if forecasted:
-        lines.append(f"New: {', '.join(forecasted)}.")
+        lines.append(
+            f"**New forecasts ({len(forecasted)}):** {_fmt_syms(forecasted)}"
+        )
     if already:
-        lines.append(f"Already on file (skipped): {', '.join(already)}.")
-    return "  \n".join(lines)
+        lines.append(
+            f"**Already on file, skipped ({len(already)}):** {_fmt_syms(already)}"
+        )
+    lines.append(
+        "**Next:** open **Charts** for a symbol or **Scans** for the whole set."
+    )
+    return "\n\n".join(lines)
 
 
 def _start_summary(info: dict) -> str:

--- a/tests/canswim/test_ux_split_labels.py
+++ b/tests/canswim/test_ux_split_labels.py
@@ -64,7 +64,11 @@ def test_run_tab_has_separate_gather_and_forecast_controls():
 
 
 def test_summary_helpers_are_plain():
-    from canswim.dashboard.run_tab import _forecast_summary, _gather_summary
+    from canswim.dashboard.run_tab import (
+        _fmt_syms,
+        _forecast_summary,
+        _gather_summary,
+    )
 
     g = _gather_summary(
         {
@@ -77,27 +81,45 @@ def test_summary_helpers_are_plain():
         }
     )
     assert "AAPL" in g
-    assert "```" not in g
+    assert "ready" in g.lower()
+    assert "What you can do next" in g
+    assert "Recommended" in g
+    assert "```json" not in g
 
+    # Portfolio-style partial: many ready + many short-history — no spaghetti wall
+    many_ready = [f"R{i:02d}" for i in range(20)]
+    many_short = [f"S{i:02d}" for i in range(15)]
     partial = _gather_summary(
         {
             "ok": True,
             "partial": True,
-            "tickers": ["AAPL", "STRC"],
-            "ready": ["AAPL"],
-            "incomplete": ["STRC"],
-            "short_history": ["STRC"],
+            "tickers": many_ready + many_short,
+            "ready": many_ready,
+            "incomplete": many_short,
+            "short_history": many_short,
             "messages": [
-                "Not enough trading history yet for: STRC. Recent IPOs usually cannot."
+                "Not enough trading history yet for: "
+                + ", ".join(many_short)
+                + ". Recent IPOs usually cannot."
             ],
-            "skipped_remote": ["AAPL"],
-            "fetched": [],
-            "db_sync": {"added": []},
+            "skipped_remote": many_ready[:10],
+            "fetched": many_short,
+            "db_sync": {"added": ["DASH", "ZYXI"]},
         }
     )
-    assert "Partial" in partial
-    assert "STRC" in partial or "IPO" in partial
+    assert "Partial update" in partial
+    assert "20 of 35" in partial or "20 of" in partial
+    assert "Ready for forecasts (20)" in partial
+    assert "Not ready for forecasts yet (15)" in partial
+    assert "What you can do next" in partial
+    assert "Recommended" in partial
+    assert "Run forecast" in partial
+    # Compact lists — not full 20+15 dumped three times
+    assert "+10 more" in partial or "…" in partial
+    assert partial.count("S00") <= 2  # shown in not-ready once, not thrice
     assert "rate limit" not in partial.lower()
+    # long IPO essay should not be the primary body
+    assert "drop those symbols from the list (or use train-mode" not in partial
 
     fail_ipo = _gather_summary(
         {
@@ -107,10 +129,16 @@ def test_summary_helpers_are_plain():
                 "Recent IPOs and newly listed names usually cannot be used."
             ),
             "short_history": ["BOT"],
+            "incomplete": ["BOT"],
         }
     )
-    assert "Could not finish" in fail_ipo
+    assert "None of these symbols are ready" in fail_ipo or "not ready" in fail_ipo.lower()
     assert "BOT" in fail_ipo
+    assert "What you can do next" in fail_ipo
+    assert "Recommended" in fail_ipo
+
+    assert _fmt_syms(["A", "B", "C"], limit=2) == "A, B … +1 more"
+
     f = _forecast_summary(
         {
             "ok": True,
@@ -122,6 +150,7 @@ def test_summary_helpers_are_plain():
     )
     assert "Already done" in f or "already" in f.lower()
     assert "```json" not in f
+    assert "Charts" in f or "Scans" in f
 
 
 def test_cli_help_separates_gather_and_forecast():


### PR DESCRIPTION
## Summary
Portfolio gathers often produce mixed outcomes (ready / short history / already local / fetched). The primary status was one long wall of repeated tickers.

New layout:
- **Headline with counts** (e.g. 36 of 51 ready)
- **Buckets**: Ready · Not ready (why) · Downloads (counts, not lists thrice)
- **Paste line** for ready symbols → forecast box
- **What you can do next** with **Recommended** first
- Full JSON stays under Advanced details

## Test plan
- [x] `./scripts/ci-local.sh` (160 passed)
- [x] UX unit tests for partial portfolio-sized result
- [ ] Restart dashboard and re-run gather on holdings list