### PR TITLE
feat: Refresh symbols + monthly forecast catch-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Two separate steps, same backend (`canswim.run_triggers`). Details: **[docs/run_
 | | Get market data | Run a forecast | Check start date |
 |--|-----------------|----------------|------------------|
 | **CLI** | `gatherdata --tickers "…"` | `forecast --tickers "…" [date] [--dry_run]` | `resolve_start` |
-| **GUI** | **Update market data** | **Run forecast** | **Check start date** |
+| **GUI** | **Refresh symbols** / **Update market data** | **Run forecast** | **Check start date** |
 | **MCP** | `gather_tickers`* | `forecast_tickers`* | `resolve_forecast_start` |
 
 \*MCP write tools need `MCP_ALLOW_RUNS=1`. Full MCP guide: **[docs/mcp.md](docs/mcp.md)**.
@@ -96,7 +96,7 @@ python -m canswim dashboard --same_data True
 |-----|---------|
 | **Charts** | Price history + forecast bands for a symbol |
 | **Scans** | Filter forecasts by as-of date, reward, risk, confidence |
-| **Run** | **Update market data** / **Run forecast** / **Check start date** / **Refresh search DB from parquet** |
+| **Run** | **Refresh symbols** / **Update market data** / **Run forecast** / **Check start date** / **Refresh search DB from parquet** |
 | **Advanced Queries** | Read-only SQL against the search DB |
 
 ### Sample screenshots

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -9,7 +9,7 @@ Expose precomputed TiDE forecasts and local market data to MCP clients (Claude D
 | Mode | How | Tools |
 |------|-----|--------|
 | **Read-only (default)** | `python -m canswim mcp` | health, list, forecast/scan/price queries, `run_select` (SELECT only) |
-| **Runs allowed** | `MCP_ALLOW_RUNS=1` (or `CANSWIM_ALLOW_RUNS=1`) | also `gather_tickers`, `forecast_tickers` |
+| **Runs allowed** | `MCP_ALLOW_RUNS=1` (or `CANSWIM_ALLOW_RUNS=1`) | also `gather_tickers`, `forecast_tickers`, `refresh_tickers` |
 
 CLI `--tickers` and the dashboard **Run** tab do **not** need `MCP_ALLOW_RUNS`. Write tools share the same backend as CLI/GUI: [run_triggers.md](run_triggers.md).
 
@@ -72,7 +72,8 @@ Canonical registration: `src/canswim/mcp/server.py`. Update this table in the **
 | `run_select` | Single `SELECT` only (≡ Advanced Queries) | — |
 | `resolve_forecast_start` | Preview week-aligned start (≡ CLI `resolve_start`) | — |
 | `gather_tickers` | Scoped gather (≡ `gatherdata --tickers`) | `MCP_ALLOW_RUNS=1` |
-| `forecast_tickers` | Scoped forecast (≡ `forecast --tickers`) | `MCP_ALLOW_RUNS=1` |
+| `forecast_tickers` | Scoped forecast; blank start = monthly catch-up + live | `MCP_ALLOW_RUNS=1` |
+| `refresh_tickers` | Gather + catch-up forecast (≡ dashboard **Refresh symbols**) | `MCP_ALLOW_RUNS=1` |
 
 ## Related docs
 

--- a/docs/run_triggers.md
+++ b/docs/run_triggers.md
@@ -9,9 +9,10 @@ User-facing actions for a **short list of symbols**. Implementation: `canswim.ru
 
 | Step | What it does | CLI | GUI | MCP |
 |------|----------------|-----|-----|-----|
+| **Refresh symbols** | Gather + catch-up forecasts (recommended default) | `forecast --tickers …` after gather, or MCP `refresh_tickers` | **Refresh symbols** | `refresh_tickers` |
 | **Get market data** | Update local prices **and** model fundamentals for listed symbols | `gatherdata --tickers "AAPL,MSFT"` | **Update market data** | `gather_tickers` |
-| **Run a forecast** | Forecast those symbols | `forecast --tickers "AAPL" …` | **Run forecast** | `forecast_tickers` |
-| **Check start date** | Show which start date will be used | `resolve_start` | **Check start date** | `resolve_forecast_start` |
+| **Run a forecast** | Forecast those symbols (blank start = monthly catch-up + live) | `forecast --tickers "AAPL" …` | **Run forecast** | `forecast_tickers` |
+| **Check start date** | Show which forecast start date will be used | `resolve_start` | **Check start date** | `resolve_forecast_start` |
 | **Refresh search DB** | Rebuild DuckDB Charts/Scans cache from parquet | `dashboard --same_data False` | **Refresh search DB from parquet** | (rebuild via dashboard / `MCP_INIT_DB`) |
 
 MCP write tools need `MCP_ALLOW_RUNS=1`. CLI and dashboard do not.
@@ -41,19 +42,41 @@ Scoped writers **merge** into existing parquet by symbol so a short ticker list 
 
 After a successful gather, symbols are **synced into the DuckDB search DB** so Charts/Scans dropdowns include them. See [data_store.md](data_store.md).
 
+## Refresh symbols (recommended)
+
+All-in-one for a short list (portfolio / new names):
+
+1. **Gather** prices + fundamentals (missing-only, ~2y).  
+2. **Catch-up forecast** for symbols that are ready (see below).  
+3. **Sync** forecasts + backtest errors into DuckDB for Charts/Scans.
+
+GUI: **Refresh symbols**. MCP: `refresh_tickers`. Agents can say “refresh AAPL, MSFT” and get one consistent pipeline.
+
 ## Run a forecast
 
-- Forecasts never invent prices. If OHLCV history is incomplete, the run **fails** and asks you to update market data first.
+- Forecasts never invent prices. If OHLCV history is incomplete, the run **fails** and asks you to update market data first (or use **Refresh symbols**).
 - If prices look fine but ownership/estimates (or alignment) fail, the run fails with a **covariates** message—run **Update market data** again (with fundamentals), then retry.
-- Symbols that **already have a saved forecast** for the resolved start are **skipped** (no re-run). Status copy explains “already on file.”
-- After a successful forecast, rows are **synced into DuckDB** for Charts/Scans.
+- Symbols that **already have a saved forecast** for a given start are **skipped** (no re-run).
+- After a successful forecast, rows are **synced into DuckDB** (including **backtest_error** refresh) for Charts/Scans.
 - Live starts may be **clamped** to the next open session after the last available local bar when broad/covariate calendars lag the requested week start.
+
+### Catch-up mode (blank start date)
+
+When **start date is blank** (GUI / MCP / CLI scoped forecast):
+
+- Origins = **first market week of each of the last ~12 calendar months** (env `CATCHUP_MONTHS`, default 12) **plus** the live week start.
+- Monthly origin = first NYSE session of that month, snapped to that week’s first session (at most **one forecast per ISO week**).
+- Already-saved symbol×start pairs are skipped.
+- Charts/Scans then have history for reward/risk and backtest quality, not only the latest live path.
+
+Explicit `YYYY-MM-DD` still means **single-origin** mode (week-aligned).
 
 ## Start date rules (enforced in code)
 
 | You enter | System uses |
 |-----------|-------------|
-| Blank / today | Next market-week start after the latest completed trading week |
+| Blank | **Catch-up**: monthly origins (~12 months) + live week start |
+| Today / default live only (via resolve) | Next market-week start after the latest completed trading week |
 | A past date | Start of that market week (first open session; if Monday is a holiday, next open day that week) |
 | A future date past the allowed default | Rejected |
 

--- a/src/canswim/calendar_weeks.py
+++ b/src/canswim/calendar_weeks.py
@@ -64,6 +64,86 @@ def first_session_of_iso_week(d: DateLike) -> pd.Timestamp:
     return pd.Timestamp(sessions[0]).normalize()
 
 
+def first_session_of_month(year: int, month: int) -> pd.Timestamp:
+    """First NYSE session in the given calendar month."""
+    start = pd.Timestamp(year=year, month=month, day=1).normalize()
+    # Search up to ~10 calendar days into the month (covers long weekends)
+    end = start + pd.Timedelta(days=14)
+    sessions = nyse_sessions(start, end)
+    if len(sessions) == 0:
+        raise ValueError(f"No NYSE session found in {year}-{month:02d}")
+    return pd.Timestamp(sessions[0]).normalize()
+
+
+def monthly_catchup_origin(year: int, month: int) -> pd.Timestamp:
+    """Default catch-up origin for a calendar month.
+
+    Uses the **first market day of the month**, then snaps to that day's
+    **market-week start** so we keep at most one forecast origin per ISO week
+    (aligned with live / single-start policy).
+    """
+    first = first_session_of_month(year, month)
+    return first_session_of_iso_week(first)
+
+
+def list_monthly_catchup_origins(
+    *,
+    asof: Optional[DateLike] = None,
+    months: int = 12,
+    latest_close: Optional[DateLike] = None,
+) -> list[str]:
+    """Monthly catch-up origins + live default (ISO week unique).
+
+    For each of the last ``months`` calendar months (including the current
+    month when its first-week start is still before live), add the monthly
+    origin. Always append the **live** week start last.
+
+    Dedupes by ISO week (one origin per week). Sorted ascending (oldest first).
+    Returns ISO date strings YYYY-MM-DD.
+    """
+    if months < 1:
+        months = 1
+    if months > 36:
+        months = 36  # hard cap — avoid accidental huge jobs
+
+    today = _ts(asof if asof is not None else pd.Timestamp.now())
+    live = default_live_forecast_start(asof=today, latest_close=latest_close)
+    calendar_live = default_live_forecast_start(asof=today, latest_close=None)
+    cap = live if live >= calendar_live else calendar_live
+
+    # Walk months: current month, previous, …
+    y, m = int(today.year), int(today.month)
+    candidates: list[pd.Timestamp] = []
+    for _ in range(months):
+        try:
+            origin = monthly_catchup_origin(y, m)
+            # Historical only; live origin is appended once below
+            if origin < live and origin <= cap:
+                candidates.append(origin)
+        except ValueError:
+            pass
+        # previous month
+        m -= 1
+        if m < 1:
+            m = 12
+            y -= 1
+
+    candidates.append(live)
+
+    # Dedupe by ISO week — keep earliest origin in that week (stable monthly)
+    by_week: dict[tuple[int, int], pd.Timestamp] = {}
+    for o in sorted(candidates):
+        key = (int(o.isocalendar()[0]), int(o.isocalendar()[1]))
+        if key not in by_week:
+            by_week[key] = o
+        # Prefer live if same week as a monthly (live is "newest" intent)
+        if o == live:
+            by_week[key] = o
+
+    ordered = sorted(by_week.values())
+    return [o.strftime("%Y-%m-%d") for o in ordered]
+
+
 def last_session_of_iso_week(d: DateLike) -> pd.Timestamp:
     """Last NYSE session in the ISO week containing ``d``."""
     day = _ts(d)

--- a/src/canswim/dashboard/run_tab.py
+++ b/src/canswim/dashboard/run_tab.py
@@ -29,10 +29,14 @@ from canswim.run_triggers import (
     REFRESH_SEARCH_BUTTON,
     REFRESH_SEARCH_SECTION_HELP,
     REFRESH_SEARCH_SECTION_TITLE,
+    REFRESH_SYMBOLS_BUTTON,
+    REFRESH_SYMBOLS_SECTION_HELP,
+    REFRESH_SYMBOLS_SECTION_TITLE,
     TICKERS_HELP,
     forecast_for_tickers,
     gather_for_tickers,
     parse_ticker_list,
+    refresh_symbols,
     resolve_start_for_run,
 )
 
@@ -202,21 +206,20 @@ def _gather_summary(result: dict) -> str:
     lines.append("**What you can do next**")
     if ready and incomplete:
         lines.append(
-            "1. **Recommended:** Copy the ready line above into "
-            "**Symbols to forecast** and click **Run forecast**."
+            "1. **Recommended:** Paste the ready line into **Refresh symbols** "
+            "(or **Run forecast** with blank start for catch-up)."
         )
         lines.append(
-            "2. Leave the not-ready names off the forecast list for now "
-            "(try again in months as history grows)."
+            "2. Leave the not-ready names off for now "
+            "(try again as history grows)."
         )
         lines.append(
-            "3. Optional: trim them from **Symbols to update** before the next gather "
-            "to keep the status quieter."
+            "3. Optional: trim them from the list next time to keep status quieter."
         )
     elif ready:
         lines.append(
-            "1. **Recommended:** Enter the same symbols under **Run a forecast** "
-            "and click **Run forecast**."
+            "1. **Recommended:** **Refresh symbols** or **Run forecast** "
+            "(blank start = monthly catch-up + live)."
         )
         lines.append(
             "2. Or open **Charts** to review a symbol visually first."
@@ -233,8 +236,21 @@ def _gather_summary(result: dict) -> str:
 
 
 def _forecast_summary(result: dict) -> str:
+    mode = result.get("mode") or "single"
+    origins = result.get("origins") or []
     start = (result.get("resolved_start") or {}).get("start") or "—"
+    n_origins = len(origins) if origins else 1
+
     if result.get("dry_run"):
+        need = 0
+        for v in (result.get("by_start") or {}).values():
+            need += len(v.get("to_run") or [])
+        if mode == "catchup":
+            return (
+                f"ℹ️ **Check only — catch-up** ({n_origins} monthly/live origins).\n\n"
+                f"**Jobs that would run:** {need} symbol×start pair(s).\n\n"
+                "No model run. Click **Run forecast** or **Refresh symbols** when ready."
+            )
         already = _norm_syms(result.get("already_have_forecast") or [])
         if already:
             return (
@@ -251,10 +267,13 @@ def _forecast_summary(result: dict) -> str:
         already = _norm_syms(
             result.get("already_have_forecast") or result.get("tickers") or []
         )
+        head = (
+            f"✅ **Already caught up** ({n_origins} origin(s))."
+            if mode == "catchup"
+            else f"✅ **Already done** (start `{start}`)."
+        )
         return (
-            f"✅ **Already done** for **{len(already)}** symbol"
-            f"{'s' if len(already) != 1 else ''} (start `{start}`).\n\n"
-            f"{_fmt_syms(already)}\n\n"
+            f"{head}\n\n{_fmt_syms(already)}\n\n"
             "Skipped re-run — no new forecast files written.\n\n"
             "**Next:** open **Charts** or **Scans** to review results."
         )
@@ -262,16 +281,16 @@ def _forecast_summary(result: dict) -> str:
         if result.get("need_covariates"):
             head = "❌ **Forecast inputs incomplete.**"
             nexts = (
-                "1. **Recommended:** **Update market data** for these symbols "
-                "(includes fundamentals), then **Run forecast** again.\n\n"
+                "1. **Recommended:** **Refresh symbols** or **Update market data**, "
+                "then try again.\n\n"
                 "2. See **Advanced details** for which inputs failed."
             )
         elif result.get("need_gather"):
             head = "❌ **Need more market data first.**"
             nexts = (
-                "1. **Recommended:** **Update market data** for these symbols, "
-                "then **Run forecast**.\n\n"
-                "2. Recent IPOs may never be ready until enough history exists."
+                "1. **Recommended:** **Refresh symbols** (gather + forecast) "
+                "or **Update market data** then **Run forecast**.\n\n"
+                "2. Recent IPOs may need more history first."
             )
         else:
             head = "❌ **Forecast failed.**"
@@ -285,18 +304,100 @@ def _forecast_summary(result: dict) -> str:
 
     forecasted = _norm_syms(result.get("forecasted") or [])
     already = _norm_syms(result.get("already_have_forecast") or [])
-    lines = [f"✅ **Forecast complete** (start `{start}`)."]
+    if mode == "catchup":
+        lines = [
+            f"✅ **Catch-up forecast complete** — "
+            f"**{n_origins}** monthly/live origin(s)."
+        ]
+    else:
+        lines = [f"✅ **Forecast complete** (start `{start}`)."]
+    if result.get("partial"):
+        lines[0] = "⚠️ " + lines[0].replace("✅ ", "")
+        lines.append("_Some symbol×start pairs still missing — see Advanced details._")
     if forecasted:
         lines.append(
-            f"**New forecasts ({len(forecasted)}):** {_fmt_syms(forecasted)}"
+            f"**New forecasts ({len(forecasted)} symbols):** {_fmt_syms(forecasted)}"
         )
-    if already:
+    if already and mode == "single":
         lines.append(
             f"**Already on file, skipped ({len(already)}):** {_fmt_syms(already)}"
         )
     lines.append(
-        "**Next:** open **Charts** for a symbol or **Scans** for the whole set."
+        "**Next:** open **Charts** (reward/risk + history) or **Scans** "
+        "to rank by RR and backtest."
     )
+    return "\n\n".join(lines)
+
+
+def _refresh_summary(result: dict) -> str:
+    """Primary status for all-in-one Refresh symbols."""
+    gather = result.get("gather") or {}
+    forecast = result.get("forecast") or {}
+    ready = _norm_syms(result.get("ready") or gather.get("ready") or [])
+    incomplete = _norm_syms(
+        result.get("incomplete") or gather.get("incomplete") or []
+    )
+    lines: list[str] = []
+
+    if result.get("dry_run"):
+        lines.append("ℹ️ **Check only — Refresh symbols** (no downloads / model).")
+        lines.append(f"**Would gather then catch-up:** {_fmt_syms(ready)}")
+        if incomplete:
+            lines.append(f"**Would skip (not ready):** {_fmt_syms(incomplete)}")
+        return "\n\n".join(lines)
+
+    if not result.get("ok") and not forecast.get("forecasted"):
+        g_part = _gather_summary(gather) if gather else ""
+        head = "❌ **Refresh could not finish.**"
+        if incomplete and not ready:
+            head = "❌ **Refresh stopped — no symbols ready for forecast yet.**"
+        return (
+            f"{head}\n\n"
+            f"{result.get('error') or ''}\n\n"
+            f"{g_part}\n\n"
+            "**What you can do next**\n\n"
+            "1. **Recommended:** Drop short-history / IPO names and "
+            "**Refresh symbols** again.\n\n"
+            "2. See **Advanced details** for the full log."
+        )
+
+    n_orig = len(forecast.get("origins") or [])
+    new_fc = _norm_syms(forecast.get("forecasted") or [])
+    if result.get("partial") or incomplete:
+        lines.append(
+            f"⚠️ **Refresh partial** — **{len(ready)}** ready, "
+            f"**{len(incomplete)}** not forecast-ready."
+        )
+    else:
+        lines.append(
+            f"✅ **Refresh complete** for **{len(ready)}** symbol"
+            f"{'s' if len(ready) != 1 else ''}."
+        )
+    if ready:
+        lines.append(f"**Forecast-ready:** {_fmt_syms(ready)}")
+    if incomplete:
+        lines.append(
+            f"**Not ready (short history etc.):** {_fmt_syms(incomplete)}"
+        )
+    if n_orig:
+        lines.append(
+            f"**Catch-up origins:** {n_orig} monthly/live starts "
+            f"(skipped ones already on file)."
+        )
+    if new_fc:
+        lines.append(f"**New forecast files:** {_fmt_syms(new_fc)}")
+    elif forecast.get("already_saved"):
+        lines.append("Forecasts were already on file for all ready origins.")
+    lines.append("**What you can do next**")
+    lines.append(
+        "1. **Recommended:** Open **Scans** or **Charts** — backtest history "
+        "and the live forecast should be available for ready names."
+    )
+    if incomplete:
+        lines.append(
+            "2. Leave not-ready names for later (need more trading history)."
+        )
+    lines.append("Full log under **Advanced details**.")
     return "\n\n".join(lines)
 
 
@@ -325,9 +426,39 @@ class RunTab:
         gr.Markdown(
             """
 ## Update data & run forecasts
-Two separate steps: **get market data**, then **run a forecast**.
+**Recommended:** **Refresh symbols** (gather + monthly catch-up forecasts + live).  
+Or use the separate steps below for finer control.
             """
         )
+
+        # ---- Primary: Refresh symbols ----
+        with gr.Group():
+            gr.Markdown(
+                f"### {REFRESH_SYMBOLS_SECTION_TITLE}\n{REFRESH_SYMBOLS_SECTION_HELP}"
+            )
+            self.refreshTickers = gr.Textbox(
+                label="Symbols to refresh",
+                lines=3,
+                placeholder="AAPL, MSFT, NVDA",
+                info=TICKERS_HELP,
+            )
+            self.refreshBtn = gr.Button(REFRESH_SYMBOLS_BUTTON, variant="primary")
+            self.refreshStatus = gr.Markdown(
+                value=(
+                    "_Enter symbols, then click **Refresh symbols**. "
+                    "Blank forecast start uses ~12 monthly backtests + live._"
+                )
+            )
+            with gr.Accordion("Advanced details", open=False):
+                self.refreshDetails = gr.Code(
+                    label="Technical log",
+                    language="json",
+                    lines=10,
+                    interactive=False,
+                    value="",
+                )
+
+        gr.Markdown("---")
 
         # ---- Gather panel ----
         with gr.Group():
@@ -410,6 +541,16 @@ Two separate steps: **get market data**, then **run a forecast**.
                     value="",
                 )
 
+        refresh_outputs = [self.refreshStatus, self.refreshDetails]
+        if self.charts_ticker_dropdown is not None:
+            refresh_outputs.append(self.charts_ticker_dropdown)
+
+        self.refreshBtn.click(
+            fn=self.do_refresh_symbols,
+            inputs=[self.refreshTickers],
+            outputs=refresh_outputs,
+        )
+
         gather_outputs = [self.gatherStatus, self.gatherDetails]
         if self.charts_ticker_dropdown is not None:
             gather_outputs.append(self.charts_ticker_dropdown)
@@ -455,6 +596,25 @@ Two separate steps: **get market data**, then **run a forecast**.
     def preview_start(self, forecast_date):
         info = resolve_start_for_run(forecast_date or None)
         return _start_summary(info), _json_details(info)
+
+    def do_refresh_symbols(self, tickers_text):
+        parsed = parse_ticker_list(tickers_text)
+        if not parsed["ok"]:
+            status = (
+                f"❌ **Could not refresh symbols.**  \n"
+                f"{parsed.get('error') or 'Invalid symbols.'}"
+            )
+            details = _json_details(parsed)
+            if self.charts_ticker_dropdown is not None:
+                return status, details, gr.update()
+            return status, details
+        logger.info(f"Dashboard refresh_symbols for {parsed['tickers']}")
+        result = refresh_symbols(tickers_text, force_allow=True)
+        status = _refresh_summary(result)
+        details = _json_details(result)
+        if self.charts_ticker_dropdown is not None:
+            return status, details, self._charts_dropdown_update()
+        return status, details
 
     def do_gather(self, tickers_text):
         parsed = parse_ticker_list(tickers_text)

--- a/src/canswim/db.py
+++ b/src/canswim/db.py
@@ -895,6 +895,38 @@ def sync_forecasts_to_search_db(
             GROUP BY symbol
             """
         )
+        # Refresh backtest_error for these symbols (Charts RR / Scans)
+        try:
+            db_con.execute(
+                f"""--sql
+                DELETE FROM backtest_error
+                WHERE upper(CAST(symbol AS VARCHAR)) IN ({in_list})
+                """
+            )
+            db_con.execute(
+                f"""--sql
+                INSERT INTO backtest_error
+                SELECT
+                    f.symbol,
+                    f.start_date,
+                    mean(
+                        abs(
+                            log(
+                                greatest(f."close_quantile_0.5", 0.01)
+                                / cp.Close
+                            )
+                        )
+                    ) AS mal_error
+                FROM forecast AS f
+                INNER JOIN close_price AS cp
+                  ON upper(CAST(cp.symbol AS VARCHAR)) = upper(CAST(f.symbol AS VARCHAR))
+                 AND CAST(cp.Date AS DATE) = CAST(f.date AS DATE)
+                WHERE upper(CAST(f.symbol AS VARCHAR)) IN ({in_list})
+                GROUP BY f.symbol, f.start_date
+                """
+            )
+        except Exception as e:
+            logger.warning(f"backtest_error refresh after forecast sync: {e}")
 
     logger.info(f"Synced forecast search rows={n} for {syms}")
     return {"ok": True, "symbols": syms, "forecast_rows": int(n)}

--- a/src/canswim/mcp/server.py
+++ b/src/canswim/mcp/server.py
@@ -189,10 +189,12 @@ def gather_tickers(
     name="forecast_tickers",
     description=(
         "Run a forecast for listed stock symbols. "
-        "Fails clearly if market history is incomplete—update market data first. "
-        "Same as CLI `forecast --tickers` and dashboard “Run forecast”. "
-        "Requires MCP_ALLOW_RUNS=1. May take several minutes. "
-        "Optional start_date (YYYY-MM-DD). dry_run=true only checks symbols and start date."
+        "Blank start_date = catch-up: ~12 monthly backtest origins + live week "
+        "(skips starts already on file). Explicit start_date = single origin. "
+        "Fails clearly if market history is incomplete—use refresh_tickers or "
+        "gather_tickers first. Same as CLI `forecast --tickers` and dashboard "
+        "“Run forecast”. Requires MCP_ALLOW_RUNS=1. May take several minutes. "
+        "dry_run=true only checks symbols and origins."
     ),
 )
 def forecast_tickers(
@@ -202,6 +204,28 @@ def forecast_tickers(
 ) -> dict[str, Any]:
     return run_tools.forecast_tickers_impl(
         tickers=tickers, start_date=start_date, dry_run=dry_run
+    )
+
+
+@mcp.tool(
+    name="refresh_tickers",
+    description=(
+        "All-in-one refresh for listed symbols: update market data, then catch-up "
+        "forecasts (monthly origins for ~12 months + live). Best default when a "
+        "user or agent says “gather and forecast” or “refresh these names”. "
+        "Same as dashboard “Refresh symbols”. Requires MCP_ALLOW_RUNS=1. "
+        "May take many minutes for large lists. dry_run=true plans only."
+    ),
+)
+def refresh_tickers(
+    tickers: str,
+    include_covariates: bool = True,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    return run_tools.refresh_tickers_impl(
+        tickers=tickers,
+        include_covariates=include_covariates,
+        dry_run=dry_run,
     )
 
 

--- a/src/canswim/mcp/tools/runs.py
+++ b/src/canswim/mcp/tools/runs.py
@@ -8,6 +8,7 @@ from canswim.run_triggers import (
     forecast_for_tickers,
     gather_for_tickers,
     parse_ticker_list,
+    refresh_symbols,
     require_runs_allowed,
     resolve_start_for_run,
     runs_allowed,
@@ -19,6 +20,7 @@ RUN_TOOL_NAMES = [
     "resolve_forecast_start",
     "gather_tickers",
     "forecast_tickers",
+    "refresh_tickers",
 ]
 
 
@@ -76,6 +78,31 @@ def forecast_tickers_impl(
     if result.get("ok"):
         return ok_result(result)
     return err_result(result.get("error") or "forecast failed", data=result)
+
+
+def refresh_tickers_impl(
+    tickers: str,
+    include_covariates: bool = True,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    """Gather + monthly catch-up forecasts (all-in-one)."""
+    blocked = require_runs_allowed()
+    if blocked is not None:
+        return err_result(blocked["error"], runs_allowed=False)
+
+    parsed = parse_ticker_list(tickers)
+    if not parsed["ok"]:
+        return err_result(parsed.get("error") or "bad tickers", data=parsed)
+
+    result = refresh_symbols(
+        tickers,
+        include_covariates=include_covariates,
+        dry_run=dry_run,
+        force_allow=False,
+    )
+    if result.get("ok"):
+        return ok_result(result)
+    return err_result(result.get("error") or "refresh failed", data=result)
 
 
 def runs_enabled() -> bool:

--- a/src/canswim/run_triggers.py
+++ b/src/canswim/run_triggers.py
@@ -26,12 +26,13 @@ from typing import Any, Optional, Sequence, Union
 import pandas as pd
 from loguru import logger
 
-from canswim.calendar_weeks import resolve_forecast_start
+from canswim.calendar_weeks import list_monthly_catchup_origins, resolve_forecast_start
 from canswim.eligibility import is_valid_ticker_symbol
 from canswim.hfhub import _env_bool
 
 # Soft cap so accidental pastes do not launch huge jobs
 DEFAULT_MAX_TICKERS = 50
+DEFAULT_CATCHUP_MONTHS = 12
 
 # --- Consumer-facing copy (CLI help, GUI, MCP). Operator detail → docs. --------
 
@@ -41,11 +42,10 @@ TICKERS_HELP = (
 )
 
 FORECAST_START_HELP = (
-    "Optional start date (YYYY-MM-DD). Leave blank to use the next available "
-    "market-week start after the latest completed trading week. "
-    "Past dates are moved to the start of that market week "
-    "(if Monday is a holiday, the next open day that week is used). "
-    "Future dates are not allowed."
+    "Optional start date (YYYY-MM-DD). Leave blank for **catch-up**: "
+    "monthly origins for the past ~12 months (first market week of each month) "
+    "plus the live week start—skipping starts already on file. "
+    "A past date snaps to that market week’s first session; future dates are not allowed."
 )
 
 # Kept for docs/CLI epilog only — not primary GUI body copy
@@ -64,11 +64,20 @@ GATHER_BUTTON = "Update market data"
 FORECAST_SECTION_TITLE = "Run a forecast"
 FORECAST_SECTION_HELP = (
     "Create forecasts for the symbols you list. "
+    "Leave start date blank to **catch up** ~12 monthly backtests + the live forecast. "
     "Needs complete local market history—if anything is missing, "
-    "update market data first, then try again."
+    "update market data first (or use **Refresh symbols**)."
 )
 FORECAST_BUTTON = "Run forecast"
 PREVIEW_START_BUTTON = "Check start date"
+
+REFRESH_SYMBOLS_SECTION_TITLE = "Refresh symbols (recommended)"
+REFRESH_SYMBOLS_SECTION_HELP = (
+    "All-in-one for new or stale names: **update market data**, then "
+    "**catch-up forecasts** (monthly origins for the past year + live). "
+    "Skips work already done. Best default for a portfolio list."
+)
+REFRESH_SYMBOLS_BUTTON = "Refresh symbols"
 
 REFRESH_SEARCH_SECTION_TITLE = "Search database (Charts / Scans)"
 REFRESH_SEARCH_SECTION_HELP = (
@@ -110,6 +119,14 @@ RUNS_OPT_IN_HELP = (
 
 # Default min rows in a saved forecast partition (= typical pred_horizon)
 DEFAULT_MIN_FORECAST_ROWS = 42
+
+
+def default_catchup_months() -> int:
+    try:
+        n = int(os.getenv("CATCHUP_MONTHS", str(DEFAULT_CATCHUP_MONTHS)))
+    except (TypeError, ValueError):
+        n = DEFAULT_CATCHUP_MONTHS
+    return max(1, min(36, n))
 
 
 def _cap_start_to_local_prices(
@@ -592,10 +609,16 @@ def forecast_for_tickers(
     max_tickers: int = DEFAULT_MAX_TICKERS,
     force_allow: bool = False,
     dry_run: bool = False,
+    catchup_months: Optional[int] = None,
 ) -> dict[str, Any]:
-    """Run forecast for an explicit ticker list with week-aligned start.
+    """Run forecast for an explicit ticker list.
 
-    ``dry_run=True`` only resolves start + validates tickers (no torch).
+    * **Blank start date** → **catch-up mode**: monthly origins for the past
+      ``catchup_months`` (default 12 / ``CATCHUP_MONTHS``) plus the live week
+      start; skips symbol+start pairs already on file. One origin per ISO week.
+    * **Explicit start date** → single week-aligned origin (existing behavior).
+
+    ``dry_run=True`` only resolves origins + which partitions exist (no torch).
     """
     if not force_allow:
         blocked = require_runs_allowed()
@@ -613,70 +636,108 @@ def forecast_for_tickers(
         }
 
     tickers: list[str] = parsed["tickers"]
-    start_info = resolve_start_for_run(forecast_start_date)
-    if not start_info.get("ok"):
-        return {
-            "ok": False,
-            "error": start_info.get("error") or "Could not resolve forecast start",
-            "tickers": tickers,
-            "rejected": parsed.get("rejected", []),
-            "resolved_start": start_info,
-        }
-
-    resolved = start_info["start"]
     messages: list[str] = list(parsed.get("messages") or [])
-    messages.append(f"Using start date {resolved}.")
+    blank = forecast_start_date is None or not str(forecast_start_date).strip()
+    months = (
+        catchup_months
+        if catchup_months is not None
+        else default_catchup_months()
+    )
 
-    # Cap start to what local prices can support (live week default can land
-    # after the latest close; the model refuses pure-future origins).
-    try:
-        adj, adj_note = _cap_start_to_local_prices(tickers, resolved)
-        if adj != resolved:
-            messages.append(adj_note or f"Adjusted start to {adj} for local prices.")
-            resolved = adj
-            start_info = dict(start_info)
-            start_info["start"] = resolved
-            start_info["reason"] = (start_info.get("reason") or "") + "+capped_to_prices"
-    except Exception as e:
-        logger.debug(f"start cap skipped: {e}")
+    # ---- Resolve origin list ----
+    if blank:
+        mode = "catchup"
+        lc_ts = _latest_close_from_local()
+        lc = lc_ts.strftime("%Y-%m-%d") if lc_ts is not None else None
+        origins = list_monthly_catchup_origins(months=months, latest_close=lc)
+        start_info = resolve_start_for_run(None)
+        start_info = dict(start_info)
+        start_info["mode"] = "catchup"
+        start_info["catchup_months"] = months
+        start_info["origins"] = list(origins)
+        messages.append(
+            f"Catch-up mode: {len(origins)} monthly/live origins "
+            f"(~{months} months + live)."
+        )
+    else:
+        mode = "single"
+        start_info = resolve_start_for_run(forecast_start_date)
+        if not start_info.get("ok"):
+            return {
+                "ok": False,
+                "error": start_info.get("error") or "Could not resolve forecast start",
+                "tickers": tickers,
+                "rejected": parsed.get("rejected", []),
+                "resolved_start": start_info,
+                "mode": mode,
+            }
+        origins = [start_info["start"]]
+        start_info = dict(start_info)
+        start_info["mode"] = "single"
+        start_info["origins"] = list(origins)
+        messages.append(f"Single start date {origins[0]}.")
+
+    # Cap each origin to what local prices can support
+    capped: list[str] = []
+    for o in origins:
+        try:
+            adj, adj_note = _cap_start_to_local_prices(tickers, o)
+            if adj not in capped:
+                capped.append(adj)
+            if adj != o and adj_note:
+                messages.append(adj_note)
+        except Exception as e:
+            logger.debug(f"start cap skipped for {o}: {e}")
+            if o not in capped:
+                capped.append(o)
+    origins = capped
+    start_info["origins"] = list(origins)
+    if origins:
+        start_info["start"] = origins[-1]  # live / newest for display
+
+    # Per-origin already-on-file plan
+    by_start: dict[str, dict[str, Any]] = {}
+    any_to_run = False
+    all_already: set[str] = set()
+    for o in origins:
+        already = set(list_symbols_with_saved_forecast(tickers, o))
+        to_run = [t for t in tickers if t not in already]
+        by_start[o] = {
+            "already": sorted(already),
+            "to_run": to_run,
+            "forecasted": [],
+        }
+        all_already |= already
+        if to_run:
+            any_to_run = True
 
     if dry_run:
-        already = list_symbols_with_saved_forecast(tickers, resolved)
+        need = sum(len(v["to_run"]) for v in by_start.values())
         return {
             "ok": True,
             "dry_run": True,
+            "mode": mode,
             "tickers": tickers,
             "rejected": parsed.get("rejected", []),
             "resolved_start": start_info,
+            "origins": origins,
+            "by_start": by_start,
             "forecasted": [],
             "skipped": [],
-            "already_have_forecast": sorted(already),
+            "already_have_forecast": sorted(all_already),
             "messages": [
                 "Check only: no forecast model was run.",
-                (
-                    ALREADY_FORECAST_MSG.format(
-                        symbols=", ".join(sorted(already)), start=resolved
-                    )
-                    if already
-                    else "No existing forecast found for this start; a full run would load the model."
-                ),
-            ],
+                f"{len(origins)} origin(s); {need} symbol×start job(s) would run.",
+            ]
+            + messages,
+            "catchup_months": months if mode == "catchup" else None,
         }
 
-    # --- Skip expensive model work when partitions already exist ---
-    already = list_symbols_with_saved_forecast(tickers, resolved)
-    to_run = [t for t in tickers if t not in already]
-    if already:
-        messages.append(
-            ALREADY_FORECAST_MSG.format(
-                symbols=", ".join(sorted(already)), start=resolved
-            )
-        )
-    if not to_run:
+    if not any_to_run:
         try:
             from canswim.db import get_db_path, sync_forecasts_to_search_db
 
-            sync_fc = sync_forecasts_to_search_db(get_db_path(), list(already))
+            sync_fc = sync_forecasts_to_search_db(get_db_path(), list(tickers))
             if sync_fc.get("ok") and sync_fc.get("forecast_rows"):
                 messages.append(
                     f"Charts updated with {sync_fc.get('forecast_rows')} forecast rows."
@@ -685,48 +746,53 @@ def forecast_for_tickers(
             messages.append(f"Charts forecast sync note: {e}")
         return {
             "ok": True,
+            "mode": mode,
             "tickers": tickers,
             "rejected": parsed.get("rejected", []),
             "resolved_start": start_info,
+            "origins": origins,
+            "by_start": by_start,
             "forecasted": [],
             "skipped": [],
-            "already_have_forecast": sorted(already),
-            "messages": messages,
+            "already_have_forecast": sorted(all_already),
+            "messages": messages
+            + ["All catch-up / requested starts already on file."],
             "already_saved": True,
             "model_loaded": False,
+            "catchup_months": months if mode == "catchup" else None,
         }
 
+    # Write symbol list for forecaster (union of all to_run)
+    need_any = sorted(
+        {t for v in by_start.values() for t in v["to_run"]}
+    )
     messages.append(
-        f"Will forecast (not on file yet): {', '.join(to_run)}"
+        f"Will forecast {len(need_any)} symbol(s) across "
+        f"{sum(1 for v in by_start.values() if v['to_run'])} start(s)."
     )
 
-    # Write a temporary symbol list and point stock_tickers_list at it
     data_dir = os.getenv("data_dir", "data")
     third = os.getenv("data-3rd-party", "data-3rd-party")
     dest_dir = Path(data_dir) / third
     dest_dir.mkdir(parents=True, exist_ok=True)
     dest_list = dest_dir / "run_tickers.csv"
-    pd.DataFrame({"Symbol": to_run}).to_csv(dest_list, index=False)
 
     prev_list = os.environ.get("stock_tickers_list")
-    os.environ["stock_tickers_list"] = "run_tickers.csv"
     prev_n = os.environ.get("n_stocks")
-    os.environ["n_stocks"] = str(max(len(to_run), 1))
+    os.environ["stock_tickers_list"] = "run_tickers.csv"
 
-    forecasted: list[str] = []
-    skipped: list[str] = []
+    forecasted_all: list[str] = []
+    skipped_all: list[str] = []
+    model_loaded = False
+    last_fail_reason: Optional[str] = None
 
     def _incomplete_result(
         *,
         forecasted_syms: list[str],
         incomplete_syms: list[str],
-        extra_error: Optional[str] = None,
-        already_saved: bool = False,
         reason: str = "prices",
     ) -> dict[str, Any]:
-        if extra_error:
-            err = extra_error
-        elif reason == "covariates":
+        if reason == "covariates":
             err = COVARIATE_FAIL_MSG.format(
                 symbols=", ".join(incomplete_syms) or "requested symbols"
             )
@@ -737,19 +803,21 @@ def forecast_for_tickers(
         return {
             "ok": False,
             "error": err,
+            "mode": mode,
             "tickers": tickers,
             "rejected": parsed.get("rejected", []),
             "resolved_start": start_info,
+            "origins": origins,
+            "by_start": by_start,
             "forecasted": forecasted_syms,
             "skipped": incomplete_syms,
-            "already_have_forecast": sorted(already),
+            "already_have_forecast": sorted(all_already),
             "messages": messages,
-            "already_saved": already_saved,
-            # True only when price history is the likely gap
             "need_gather": reason == "prices",
             "need_covariates": reason == "covariates",
-            "model_loaded": True,
+            "model_loaded": model_loaded,
             "fail_reason": reason,
+            "catchup_months": months if mode == "catchup" else None,
         }
 
     try:
@@ -759,85 +827,90 @@ def forecast_for_tickers(
         cf.all_already_saved = False
         cf.download_model()
         cf.download_data()
-        fsd = pd.Timestamp(resolved)
-        any_saved = False
-        any_group = False
-        for _pos in cf.prep_next_stock_group(forecast_start_date=fsd):
-            any_group = True
-            forecasts = cf.get_forecast(forecast_start_date=fsd)
-            if forecasts:
-                clean = {}
-                for t, ts in forecasts.items():
-                    try:
-                        qdf = (
-                            ts.quantile_df(0.5)
-                            if hasattr(ts, "quantile_df")
-                            else ts.pd_dataframe()
-                        )
-                        if qdf.isna().all().all():
-                            skipped.append(t)
-                            continue
-                    except Exception:
-                        pass
-                    clean[t] = ts
-                if clean:
-                    cf.save_forecast(clean, asof_start=fsd)
-                    forecasted.extend(clean.keys())
-                    any_saved = True
+        model_loaded = True
+
+        for o in origins:
+            plan = by_start[o]
+            to_run = list(plan["to_run"])
+            if not to_run:
+                continue
+            pd.DataFrame({"Symbol": to_run}).to_csv(dest_list, index=False)
+            os.environ["n_stocks"] = str(max(len(to_run), 1))
+            # Forecaster caches symbol list from env at load — set stocks on model if present
+            try:
+                if hasattr(cf, "canswim_model") and cf.canswim_model is not None:
+                    pass  # prep_next_stock_group reloads from stock_tickers_list
+            except Exception:
+                pass
+
+            fsd = pd.Timestamp(o)
+            any_saved = False
+            any_group = False
+            forecasted_o: list[str] = []
+            cf.all_already_saved = False
+            for _pos in cf.prep_next_stock_group(forecast_start_date=fsd):
+                any_group = True
+                forecasts = cf.get_forecast(forecast_start_date=fsd)
+                if forecasts:
+                    clean = {}
+                    for t, ts in forecasts.items():
+                        try:
+                            qdf = (
+                                ts.quantile_df(0.5)
+                                if hasattr(ts, "quantile_df")
+                                else ts.pd_dataframe()
+                            )
+                            if qdf.isna().all().all():
+                                skipped_all.append(t)
+                                continue
+                        except Exception:
+                            pass
+                        clean[t] = ts
+                    if clean:
+                        cf.save_forecast(clean, asof_start=fsd)
+                        forecasted_o.extend(clean.keys())
+                        any_saved = True
+            plan["forecasted"] = forecasted_o
+            forecasted_all.extend(forecasted_o)
+            if not any_group and not getattr(cf, "all_already_saved", False):
+                last_fail_reason = "covariates"
+                messages.append(
+                    f"Start {o}: no eligible symbols in model batch "
+                    f"(tried {', '.join(to_run)})."
+                )
+            elif not any_saved and not getattr(cf, "all_already_saved", False):
+                last_fail_reason = "covariates"
+                messages.append(f"Start {o}: no forecasts saved.")
             else:
                 messages.append(
-                    "No symbols had enough complete history in this batch."
+                    f"Start {o}: new={len(forecasted_o)}, "
+                    f"already={len(plan['already'])}."
                 )
-
-        if not any_group:
-            if getattr(cf, "all_already_saved", False):
-                # Race: files appeared after our pre-check
-                messages.append("Forecasts for this start date already exist.")
-                return {
-                    "ok": True,
-                    "tickers": tickers,
-                    "rejected": parsed.get("rejected", []),
-                    "resolved_start": start_info,
-                    "forecasted": [],
-                    "skipped": [],
-                    "already_have_forecast": sorted(set(already) | set(to_run)),
-                    "messages": messages,
-                    "already_saved": True,
-                    "model_loaded": True,
-                }
-            return _incomplete_result(
-                forecasted_syms=[],
-                incomplete_syms=list(to_run),
-                reason="covariates",
-            )
-        if not any_saved:
-            # Prices often present; model dropped symbols during covariate align
-            return _incomplete_result(
-                forecasted_syms=[],
-                incomplete_syms=[t for t in to_run if t not in forecasted],
-                reason="covariates",
-            )
 
         try:
             cf.upload_data()
         except Exception as e:
             messages.append(f"Cloud upload skipped: {e}")
 
-        # Incomplete only among symbols we tried to run (not ones already on file)
-        incomplete = [t for t in to_run if t not in set(forecasted)]
-        if incomplete:
+        # Success if every to_run for every start got a forecast or was already saved
+        incomplete: list[str] = []
+        for o, plan in by_start.items():
+            for t in plan["to_run"]:
+                if t not in set(plan["forecasted"]):
+                    incomplete.append(f"{t}@{o}")
+
+        if incomplete and not forecasted_all:
             return _incomplete_result(
-                forecasted_syms=list(forecasted),
+                forecasted_syms=[],
                 incomplete_syms=incomplete,
+                reason=last_fail_reason or "covariates",
             )
 
-        # Push new forecast parquet into DuckDB so Charts/Scans see lines
+        # Push parquet → DuckDB (+ backtest_error refresh)
         try:
             from canswim.db import get_db_path, sync_forecasts_to_search_db
 
-            sync_fc = sync_forecasts_to_search_db(
-                get_db_path(), list(set(forecasted) | set(already))
-            )
+            sync_fc = sync_forecasts_to_search_db(get_db_path(), list(tickers))
             if sync_fc.get("ok"):
                 messages.append(
                     f"Charts updated with {sync_fc.get('forecast_rows', 0)} forecast rows."
@@ -845,27 +918,56 @@ def forecast_for_tickers(
         except Exception as e:
             messages.append(f"Charts forecast sync note: {e}")
 
-        return {
-            "ok": True,
+        ok = len(incomplete) == 0
+        out: dict[str, Any] = {
+            "ok": ok,
+            "mode": mode,
             "tickers": tickers,
             "rejected": parsed.get("rejected", []),
             "resolved_start": start_info,
-            "forecasted": forecasted,
-            "skipped": [],
-            "already_have_forecast": sorted(already),
+            "origins": origins,
+            "by_start": by_start,
+            "forecasted": sorted(set(forecasted_all)),
+            "skipped": sorted(set(skipped_all)),
+            "already_have_forecast": sorted(all_already),
             "messages": messages,
             "model_loaded": True,
+            "catchup_months": months if mode == "catchup" else None,
+            "incomplete_starts": incomplete,
         }
+        if not ok:
+            # Single-origin runs hard-fail if any requested symbol is missing
+            # (legacy contract). Catch-up may succeed partially for UX.
+            if mode == "single":
+                return _incomplete_result(
+                    forecasted_syms=list(set(forecasted_all)),
+                    incomplete_syms=[
+                        x.split("@")[0] for x in incomplete
+                    ],
+                    reason=last_fail_reason or "prices",
+                )
+            out["error"] = (
+                f"Partial forecast catch-up: {len(incomplete)} symbol×start "
+                f"still missing. See incomplete_starts / messages."
+            )
+            out["partial"] = True
+            if forecasted_all:
+                out["ok"] = True
+        return out
     except Exception as e:
         logger.exception("forecast_for_tickers failed")
         return {
             "ok": False,
             "error": str(e),
+            "mode": mode,
             "tickers": tickers,
             "resolved_start": start_info,
-            "forecasted": forecasted,
-            "skipped": skipped,
+            "origins": origins,
+            "by_start": by_start,
+            "forecasted": forecasted_all,
+            "skipped": skipped_all,
             "messages": messages,
+            "model_loaded": model_loaded,
         }
     finally:
         if prev_list is None:
@@ -876,3 +978,94 @@ def forecast_for_tickers(
             os.environ.pop("n_stocks", None)
         else:
             os.environ["n_stocks"] = prev_n
+
+
+def refresh_symbols(
+    tickers_text: Union[str, Sequence[str], None],
+    *,
+    include_covariates: bool = True,
+    max_tickers: int = DEFAULT_MAX_TICKERS,
+    force_allow: bool = False,
+    catchup_months: Optional[int] = None,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    """All-in-one: gather market data, then catch-up forecasts for ready symbols.
+
+    Primary path for “refresh my portfolio / new symbol” (GUI, MCP, CLI).
+    """
+    if not force_allow:
+        blocked = require_runs_allowed()
+        if blocked is not None:
+            return blocked
+
+    messages: list[str] = ["Refresh symbols: gather + catch-up forecast."]
+    gather = gather_for_tickers(
+        tickers_text,
+        include_covariates=include_covariates,
+        max_tickers=max_tickers,
+        force_allow=True,  # already gated above
+    )
+    ready = list(gather.get("ready") or [])
+    incomplete = list(gather.get("incomplete") or [])
+    # If gather reports ready empty but ok, use full ticker list
+    if not ready and gather.get("ok") and gather.get("tickers"):
+        ready = list(gather["tickers"])
+
+    out: dict[str, Any] = {
+        "ok": False,
+        "mode": "refresh",
+        "gather": gather,
+        "forecast": None,
+        "ready": ready,
+        "incomplete": incomplete,
+        "messages": messages,
+        "tickers": gather.get("tickers") or [],
+    }
+
+    if not ready:
+        out["error"] = (
+            gather.get("error")
+            or "No symbols ready for forecast after gather "
+            "(often short history / IPOs)."
+        )
+        out["ok"] = False
+        out["need_gather"] = True
+        return out
+
+    if dry_run:
+        fc = forecast_for_tickers(
+            ready,
+            forecast_start_date=None,
+            force_allow=True,
+            dry_run=True,
+            catchup_months=catchup_months,
+            max_tickers=max_tickers,
+        )
+        out["forecast"] = fc
+        out["ok"] = True
+        out["dry_run"] = True
+        out["messages"].append(
+            f"Would catch-up forecast {len(ready)} ready symbol(s)."
+        )
+        return out
+
+    fc = forecast_for_tickers(
+        ready,
+        forecast_start_date=None,
+        force_allow=True,
+        dry_run=False,
+        catchup_months=catchup_months,
+        max_tickers=max_tickers,
+    )
+    out["forecast"] = fc
+    out["ok"] = bool(fc.get("ok")) or bool(fc.get("partial") and fc.get("forecasted"))
+    if incomplete:
+        out["partial"] = True
+        out["messages"].append(
+            f"Gather left {len(incomplete)} symbol(s) not forecast-ready."
+        )
+    if not out["ok"]:
+        out["error"] = fc.get("error") or gather.get("error") or "Refresh incomplete."
+    else:
+        out["messages"].append("Refresh finished for forecast-ready symbols.")
+    return out

--- a/tests/canswim/test_calendar_weeks.py
+++ b/tests/canswim/test_calendar_weeks.py
@@ -8,7 +8,10 @@ import pytest
 from canswim.calendar_weeks import (
     default_live_forecast_start,
     first_session_of_iso_week,
+    first_session_of_month,
     last_completed_week_end,
+    list_monthly_catchup_origins,
+    monthly_catchup_origin,
     resolve_forecast_start,
     snap_to_week_start_on_or_before,
 )
@@ -77,6 +80,43 @@ def test_resolve_holiday_monday_backtest():
     assert r.ok
     assert r.start == "2026-05-26"
     assert r.reason == "snapped_week_start"
+
+
+def test_first_session_of_month_january_2026():
+    # 2026-01-01 holiday → first open Fri 2026-01-02
+    assert first_session_of_month(2026, 1).strftime("%Y-%m-%d") == "2026-01-02"
+
+
+def test_monthly_catchup_origin_snaps_to_week():
+    # Jan 2026 first open Fri 2nd → week start Mon 2025-12-29? 
+    # first_session_of_iso_week(2026-01-02): ISO week of Fri Jan 2 is week with Mon Dec 29 2025
+    o = monthly_catchup_origin(2026, 1)
+    assert o == first_session_of_iso_week("2026-01-02")
+    assert o.strftime("%Y-%m-%d") == first_session_of_iso_week("2026-01-02").strftime(
+        "%Y-%m-%d"
+    )
+
+
+def test_list_monthly_catchup_origins_count_and_live():
+    # Fixed asof so list is deterministic
+    origins = list_monthly_catchup_origins(
+        asof="2026-07-10", months=12, latest_close="2026-07-09"
+    )
+    assert len(origins) >= 10  # ~12 months + live, maybe fewer if deduped
+    assert len(origins) <= 13
+    # Sorted ascending
+    assert origins == sorted(origins)
+    # Live is last
+    live = default_live_forecast_start(
+        asof="2026-07-10", latest_close="2026-07-09"
+    ).strftime("%Y-%m-%d")
+    assert origins[-1] == live
+    # One origin per ISO week
+    weeks = set()
+    for o in origins:
+        t = pd.Timestamp(o)
+        weeks.add((int(t.isocalendar()[0]), int(t.isocalendar()[1])))
+    assert len(weeks) == len(origins)
 
 
 def test_july4_week_start_is_first_session():

--- a/tests/canswim/test_docs_sync.py
+++ b/tests/canswim/test_docs_sync.py
@@ -21,6 +21,7 @@ def test_run_tab_button_labels_in_docs():
         rt.FORECAST_BUTTON,
         rt.PREVIEW_START_BUTTON,
         rt.REFRESH_SEARCH_BUTTON,
+        rt.REFRESH_SYMBOLS_BUTTON,
     }
     for path in ("README.md", "docs/run_triggers.md"):
         text = _read(path)

--- a/tests/canswim/test_run_triggers.py
+++ b/tests/canswim/test_run_triggers.py
@@ -10,6 +10,7 @@ from canswim.run_triggers import (
     forecast_for_tickers,
     gather_for_tickers,
     parse_ticker_list,
+    refresh_symbols,
     require_runs_allowed,
     resolve_start_for_run,
     runs_allowed,
@@ -124,8 +125,82 @@ def test_forecast_dry_run_resolves_start(monkeypatch):
         )
     assert r["ok"] is True
     assert r["dry_run"] is True
+    assert r["mode"] == "single"
     assert r["tickers"] == ["AAPL", "MSFT"]
     assert r["resolved_start"]["start"] == "2026-03-02"
+
+
+def test_forecast_blank_start_is_catchup_dry_run(monkeypatch):
+    monkeypatch.setenv("MCP_ALLOW_RUNS", "1")
+    monkeypatch.setenv("CATCHUP_MONTHS", "6")
+    with patch(
+        "canswim.run_triggers.list_monthly_catchup_origins",
+        return_value=[
+            "2026-01-02",
+            "2026-02-02",
+            "2026-03-02",
+            "2026-04-01",
+            "2026-05-01",
+            "2026-06-01",
+            "2026-07-13",
+        ],
+    ):
+        with patch(
+            "canswim.run_triggers.resolve_start_for_run",
+            return_value={
+                "ok": True,
+                "start": "2026-07-13",
+                "reason": "default_live",
+                "live_default": "2026-07-13",
+                "input": None,
+                "error": None,
+            },
+        ):
+            with patch(
+                "canswim.run_triggers.list_symbols_with_saved_forecast",
+                return_value=[],
+            ):
+                r = forecast_for_tickers("AAPL", dry_run=True)
+    assert r["ok"] is True
+    assert r["mode"] == "catchup"
+    assert r["dry_run"] is True
+    assert len(r["origins"]) == 7
+    assert r["origins"][-1] == "2026-07-13"
+
+
+def test_refresh_symbols_calls_gather_then_forecast(monkeypatch):
+    monkeypatch.setenv("MCP_ALLOW_RUNS", "1")
+    gather_ret = {
+        "ok": True,
+        "tickers": ["AAPL"],
+        "ready": ["AAPL"],
+        "incomplete": [],
+        "messages": [],
+    }
+    fc_ret = {
+        "ok": True,
+        "mode": "catchup",
+        "tickers": ["AAPL"],
+        "forecasted": ["AAPL"],
+        "origins": ["2026-01-02", "2026-07-13"],
+        "already_saved": False,
+        "messages": [],
+    }
+    with patch(
+        "canswim.run_triggers.gather_for_tickers", return_value=gather_ret
+    ) as g:
+        with patch(
+            "canswim.run_triggers.forecast_for_tickers", return_value=fc_ret
+        ) as f:
+            r = refresh_symbols("AAPL", force_allow=True)
+    assert r["ok"] is True
+    assert r["mode"] == "refresh"
+    g.assert_called_once()
+    f.assert_called_once()
+    # forecast called without explicit start (catch-up)
+    assert f.call_args.kwargs.get("forecast_start_date") is None or (
+        f.call_args[0][1] is None if len(f.call_args[0]) > 1 else True
+    )
 
 
 def test_forecast_passes_resolved_start_to_forecaster(monkeypatch):

--- a/tests/canswim/test_ux_split_labels.py
+++ b/tests/canswim/test_ux_split_labels.py
@@ -13,6 +13,7 @@ from canswim.run_triggers import (
     FORECAST_START_HELP,
     GATHER_BUTTON,
     GATHER_SECTION_TITLE,
+    REFRESH_SYMBOLS_BUTTON,
     TICKERS_HELP,
 )
 
@@ -47,6 +48,8 @@ def test_run_tab_has_separate_gather_and_forecast_controls():
     assert "forecastTickers" in src
     assert "gatherBtn" in src
     assert "forecastBtn" in src
+    assert "refreshBtn" in src or "refreshTickers" in src
+    assert "REFRESH_SYMBOLS" in src or REFRESH_SYMBOLS_BUTTON in src
     assert GATHER_SECTION_TITLE in src or "GATHER_SECTION_TITLE" in src
     assert FORECAST_SECTION_TITLE in src or "FORECAST_SECTION_TITLE" in src
     # Two separate status outputs
@@ -56,6 +59,7 @@ def test_run_tab_has_separate_gather_and_forecast_controls():
     assert "refreshDbBtn" in src
     assert "do_refresh_search_db" in inspect.getsource(run_tab_mod.RunTab)
     assert "REFRESH_SEARCH_BUTTON" in src or "Refresh search DB" in src
+    assert "do_refresh_symbols" in inspect.getsource(run_tab_mod.RunTab)
     # JSON is advanced/collapsed, not primary body
     assert "Advanced details" in src
     assert "gatherDetails" in src
@@ -188,6 +192,7 @@ def test_mcp_tool_descriptions_are_plain():
     assert "Requires MCP_ALLOW_RUNS=1" in src
     # Tool description block for forecast should be plain language
     assert "Run a forecast for listed stock symbols" in src
+    assert 'name="refresh_tickers"' in src
 
 
 def test_docs_exist_for_operators():


### PR DESCRIPTION
## Summary
- **Catch-up spacing:** first market day of each month → market-week start; **one origin per ISO week**; default **12 months** + live (`CATCHUP_MONTHS`)
- **Blank forecast start** → catch-up (skip already-saved symbol×start)
- **Refresh symbols** (GUI primary) / MCP **`refresh_tickers`**: gather + catch-up
- Sync forecasts also refreshes **backtest_error** for Charts/Scans

## Why
Users and agents want one default: “refresh these symbols” → data + history for RR/backtest + live forecast, consistent monthly origins across the book.

## Test plan
- [x] `./scripts/ci-local.sh` (165 passed)
- [ ] Dashboard: **Refresh symbols** on a short list; Scans show multiple starts
- [ ] MCP: `refresh_tickers` with `MCP_ALLOW_RUNS=1`