### PR TITLE
feat(mcp): schema export + hardened read-only SQL

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -8,7 +8,7 @@ Expose precomputed TiDE forecasts and local market data to MCP clients (Claude D
 
 | Mode | How | Tools |
 |------|-----|--------|
-| **Read-only (default)** | `python -m canswim mcp` | health, list, forecast/scan/price queries, `run_select` (SELECT only) |
+| **Read-only (default)** | `python -m canswim mcp` | health, list, forecast/scan/price queries, `get_db_schema`, `run_select` (SELECT / WITH…SELECT only) |
 | **Runs allowed** | `MCP_ALLOW_RUNS=1` (or `CANSWIM_ALLOW_RUNS=1`) | also `gather_tickers`, `forecast_tickers`, `refresh_tickers` |
 
 CLI `--tickers` and the dashboard **Run** tab do **not** need `MCP_ALLOW_RUNS`. Write tools share the same backend as CLI/GUI: [run_triggers.md](run_triggers.md).
@@ -69,11 +69,23 @@ Canonical registration: `src/canswim/mcp/server.py`. Update this table in the **
 | `scan_forecasts` | Universe scan (≡ dashboard Scans) | — |
 | `get_close_price` | Historical closes | — |
 | `get_backtest_error` | Forecast vs actual error (mean abs log-error) | — |
-| `run_select` | Single `SELECT` only (≡ Advanced Queries) | — |
+| `get_db_schema` | Tables, columns, indexes, row counts + markdown (for agent SQL) | — |
+| `run_select` | Single read-only `SELECT` or `WITH…SELECT` (≡ Advanced Queries) | — |
 | `resolve_forecast_start` | Preview week-aligned start (≡ CLI `resolve_start`) | — |
 | `gather_tickers` | Scoped gather (≡ `gatherdata --tickers`) | `MCP_ALLOW_RUNS=1` |
 | `forecast_tickers` | Scoped forecast; blank start = monthly catch-up + live | `MCP_ALLOW_RUNS=1` |
 | `refresh_tickers` | Gather + catch-up forecast (≡ dashboard **Refresh symbols**) | `MCP_ALLOW_RUNS=1` |
+
+### Custom SQL (read-only)
+
+1. Call **`get_db_schema`** so the client AI sees tables, types, and indexes.
+2. Call **`run_select`** with one `SELECT` or `WITH … SELECT` statement.
+3. Guards:
+   - Statement must start with `SELECT` or `WITH` (and contain `SELECT`).
+   - DDL/DML keywords, multi-statement `;`, `PRAGMA`, `ATTACH`, `COPY`, etc. are **rejected**.
+   - DuckDB is opened **read-only** (`connect_readonly`).
+   - Results are wrapped with `LIMIT` (default 5000).
+4. **Writes are never free-form SQL** — only gated tools (`gather_tickers`, `forecast_tickers`, `refresh_tickers`) when `MCP_ALLOW_RUNS=1`.
 
 ## Related docs
 

--- a/src/canswim/db.py
+++ b/src/canswim/db.py
@@ -1377,25 +1377,75 @@ def get_backtest_error(
 
 _FORBIDDEN_SQL = re.compile(
     r"\b(INSERT|UPDATE|DELETE|DROP|ALTER|CREATE|ATTACH|COPY|EXPORT|IMPORT|"
-    r"TRUNCATE|REPLACE|GRANT|REVOKE|CALL|EXECUTE|PRAGMA|LOAD|INSTALL|"
-    r"CHECKPOINT|VACUUM|FORCE|SET)\b",
+    r"TRUNCATE|REPLACE\s+INTO|GRANT|REVOKE|CALL|EXECUTE|PRAGMA|LOAD|INSTALL|"
+    r"CHECKPOINT|VACUUM|FORCE\b|SET\s+\w|MERGE|UPSERT|DETACH|UNLOAD|"
+    r"BEGIN|COMMIT|ROLLBACK|TRANSACTION)\b",
     re.IGNORECASE,
 )
 
+# Human-oriented purpose notes for MCP / agent SQL authoring
+SEARCH_TABLE_DOCS: dict[str, str] = {
+    "stock_tickers": (
+        "Universe of symbols available in Charts/Scans dropdown. "
+        "Column is usually Symbol or symbol."
+    ),
+    "forecast": (
+        "Quantile forecast paths. One row per (symbol, start_date, date) where "
+        "date is the forecast horizon calendar date and start_date is the origin. "
+        "Quantile columns: close_quantile_0.01 … close_quantile_0.99 "
+        "(0.5 ≈ median). Used for charts and scans."
+    ),
+    "latest_forecast": (
+        "Per-symbol max(start_date) of available forecasts. "
+        "Join to forecast on symbol + start_date = latest_forecast.date."
+    ),
+    "close_price": (
+        "Historical closes (Date, Symbol/symbol, Close). "
+        "Used for prior_close, charts, and backtest_error."
+    ),
+    "backtest_error": (
+        "Mean absolute log-error of median forecast vs actual close, "
+        "per (symbol, start_date). Lower is better model fit on that origin."
+    ),
+    "company_profile": (
+        "Optional company metadata: name, sector, industry, country, "
+        "exchange, mkt_cap, website, description. One row per symbol."
+    ),
+}
+
+
+def _strip_sql_comments(sql: str) -> str:
+    without = re.sub(r"/\*.*?\*/", "", sql.strip(), flags=re.DOTALL)
+    without = re.sub(r"--[^\n]*", "", without).strip()
+    return without
+
 
 def is_select_only(sql: str) -> bool:
+    """True only for a single read-only SELECT (or WITH … SELECT) statement.
+
+    Writes, DDL, multi-statements, and PRAGMA/ATTACH/etc. are rejected.
+    Free-form SQL for analytics must go through this gate; mutations use
+    dedicated gather/forecast/refresh tools only.
+    """
     stripped = sql.strip()
     if not stripped:
         return False
-    # allow leading comments
-    without_comments = re.sub(r"/\*.*?\*/", "", stripped, flags=re.DOTALL)
-    without_comments = re.sub(r"--[^\n]*", "", without_comments).strip()
-    if not without_comments.upper().startswith("SELECT"):
+    without_comments = _strip_sql_comments(stripped)
+    if not without_comments:
+        return False
+    head = without_comments.lstrip().upper()
+    # Allow CTE form: WITH … SELECT …
+    if not (head.startswith("SELECT") or head.startswith("WITH")):
         return False
     if _FORBIDDEN_SQL.search(without_comments):
         return False
-    # single statement
+    # single statement (trailing semicolon ok)
     if ";" in without_comments.rstrip(";"):
+        return False
+    # WITH must eventually contain SELECT (not WITH RECURSIVE abuse alone)
+    if head.startswith("WITH") and not re.search(
+        r"\bSELECT\b", without_comments, re.IGNORECASE
+    ):
         return False
     return True
 
@@ -1410,10 +1460,12 @@ def run_select(
     *,
     row_limit: int = DEFAULT_ROW_LIMIT,
 ) -> pd.DataFrame:
-    """Run a SELECT-only query (AdvancedTab guard)."""
+    """Run a SELECT-only query (Advanced tab + MCP). Always opens read-only."""
     if not is_select_only(sql):
         raise SelectOnlyError(
-            "Only single SELECT statements are allowed (no DDL/DML/multi-statement)."
+            "Only single read-only SELECT (or WITH … SELECT) statements are allowed. "
+            "No DDL/DML/multi-statement. Writes must use dedicated tools "
+            "(gather_tickers / forecast_tickers / refresh_tickers)."
         )
     wrapped = f"SELECT * FROM ({sql.rstrip().rstrip(';')}) AS _q LIMIT {int(row_limit)}"
     with connect_readonly(db_path) as db_con:
@@ -1424,6 +1476,194 @@ def run_select(
         if "date" in c.lower() or pd.api.types.is_datetime64_any_dtype(df[c])
     ]
     return _format_date_columns(df, date_like)
+
+
+def describe_search_schema(
+    db_path: Optional[str] = None,
+    *,
+    include_row_counts: bool = True,
+    include_sample_values: bool = False,
+) -> dict[str, Any]:
+    """Export DuckDB search-schema for MCP/agent SQL authoring.
+
+    Includes tables, columns (name/type/nullable), indexes, optional row
+    counts, and short purpose notes. Read-only connection only.
+    """
+    path = db_path or get_db_path()
+    out: dict[str, Any] = {
+        "db_path": path,
+        "db_exists": Path(path).is_file(),
+        "read_only": True,
+        "sql_policy": (
+            "Custom SQL via run_select: single SELECT or WITH…SELECT only; "
+            "enforced + DuckDB read-only connection. "
+            "Mutations only via gather_tickers / forecast_tickers / refresh_tickers "
+            "when MCP_ALLOW_RUNS=1."
+        ),
+        "tables": [],
+        "indexes": [],
+        "expected_tables": list(SEARCH_TABLES),
+        "notes": [
+            "Parquet under data/ is the system of record; this DuckDB is the "
+            "search/UI cache (Charts, Scans, MCP).",
+            "forecast.start_date = forecast origin; forecast.date = horizon day.",
+            "Join company_profile on upper(symbol) for sector/industry filters.",
+        ],
+    }
+    if not out["db_exists"]:
+        out["error"] = f"Database file not found: {path}"
+        return out
+
+    try:
+        with connect_readonly(path) as con:
+            existing = sorted(_list_main_tables(con))
+            out["table_names"] = existing
+
+            # Columns from information_schema
+            cols_df = con.execute(
+                """
+                SELECT table_name, column_name, data_type, is_nullable,
+                       ordinal_position
+                FROM information_schema.columns
+                WHERE table_schema = 'main'
+                ORDER BY table_name, ordinal_position
+                """
+            ).fetchdf()
+
+            by_table: dict[str, list[dict[str, Any]]] = {}
+            for _, row in cols_df.iterrows():
+                t = str(row["table_name"])
+                by_table.setdefault(t, []).append(
+                    {
+                        "name": str(row["column_name"]),
+                        "type": str(row["data_type"]),
+                        "nullable": str(row["is_nullable"]).upper()
+                        in ("YES", "TRUE", "1"),
+                        "position": int(row["ordinal_position"])
+                        if row["ordinal_position"] is not None
+                        else None,
+                    }
+                )
+
+            # Indexes (DuckDB catalog)
+            indexes: list[dict[str, Any]] = []
+            try:
+                idx_df = con.execute(
+                    """
+                    SELECT database_name, schema_name, table_name, index_name,
+                           is_unique, is_primary, sql
+                    FROM duckdb_indexes()
+                    WHERE schema_name = 'main' OR schema_name IS NULL
+                    """
+                ).fetchdf()
+                for _, row in idx_df.iterrows():
+                    indexes.append(
+                        {
+                            "table": str(row.get("table_name") or ""),
+                            "name": str(row.get("index_name") or ""),
+                            "unique": bool(row.get("is_unique")),
+                            "primary": bool(row.get("is_primary"))
+                            if row.get("is_primary") is not None
+                            else False,
+                            "sql": str(row.get("sql") or "") or None,
+                        }
+                    )
+            except Exception as e:
+                logger.debug(f"duckdb_indexes unavailable: {e}")
+                # Fallback: try sqlite_master-style (may be empty on DuckDB)
+                try:
+                    for r in con.execute(
+                        "SELECT name, tbl_name, sql FROM sqlite_master "
+                        "WHERE type = 'index'"
+                    ).fetchall():
+                        indexes.append(
+                            {
+                                "table": str(r[1]),
+                                "name": str(r[0]),
+                                "unique": None,
+                                "primary": False,
+                                "sql": r[2],
+                            }
+                        )
+                except Exception:
+                    pass
+            out["indexes"] = indexes
+
+            idx_by_table: dict[str, list[dict[str, Any]]] = {}
+            for ix in indexes:
+                idx_by_table.setdefault(ix["table"], []).append(ix)
+
+            tables_out: list[dict[str, Any]] = []
+            for t in existing:
+                entry: dict[str, Any] = {
+                    "name": t,
+                    "purpose": SEARCH_TABLE_DOCS.get(t, "Search/UI table."),
+                    "columns": by_table.get(t, []),
+                    "indexes": idx_by_table.get(t, []),
+                }
+                if include_row_counts:
+                    try:
+                        n = con.execute(f'SELECT count(*) FROM "{t}"').fetchone()[0]
+                        entry["row_count"] = int(n)
+                    except Exception:
+                        entry["row_count"] = None
+                if include_sample_values and by_table.get(t):
+                    try:
+                        sample = con.execute(
+                            f'SELECT * FROM "{t}" LIMIT 3'
+                        ).fetchdf()
+                        entry["sample_rows"] = dataframe_to_records(sample)
+                    except Exception:
+                        entry["sample_rows"] = []
+                tables_out.append(entry)
+            out["tables"] = tables_out
+
+            # Compact markdown for agent context windows
+            out["markdown"] = format_schema_markdown(out)
+    except Exception as e:
+        logger.warning(f"describe_search_schema({path}): {e}")
+        out["error"] = str(e)
+    return out
+
+
+def format_schema_markdown(schema: dict[str, Any]) -> str:
+    """Compact Markdown schema dump for MCP client context."""
+    lines = [
+        f"# CANSWIM search DB schema",
+        f"Path: `{schema.get('db_path')}`",
+        "",
+        schema.get("sql_policy") or "",
+        "",
+    ]
+    for note in schema.get("notes") or []:
+        lines.append(f"- {note}")
+    lines.append("")
+    for t in schema.get("tables") or []:
+        rc = t.get("row_count")
+        rc_s = f" ({rc:,} rows)" if isinstance(rc, int) else ""
+        lines.append(f"## {t.get('name')}{rc_s}")
+        if t.get("purpose"):
+            lines.append(t["purpose"])
+        lines.append("")
+        lines.append("| column | type | nullable |")
+        lines.append("|--------|------|----------|")
+        for c in t.get("columns") or []:
+            null_s = "yes" if c.get("nullable") else "no"
+            lines.append(
+                f"| `{c.get('name')}` | {c.get('type')} | {null_s} |"
+            )
+        ixs = t.get("indexes") or []
+        if ixs:
+            lines.append("")
+            lines.append("**Indexes:**")
+            for ix in ixs:
+                u = " UNIQUE" if ix.get("unique") else ""
+                sql = ix.get("sql") or ""
+                lines.append(f"- `{ix.get('name')}`{u}" + (f" — `{sql}`" if sql else ""))
+        lines.append("")
+    if schema.get("error"):
+        lines.append(f"**Error:** {schema['error']}")
+    return "\n".join(lines)
 
 
 def dataframe_to_records(df: pd.DataFrame) -> list[dict[str, Any]]:

--- a/src/canswim/mcp/server.py
+++ b/src/canswim/mcp/server.py
@@ -145,10 +145,36 @@ def get_backtest_error(
 
 
 @mcp.tool(
+    name="get_db_schema",
+    description=(
+        "Export the local DuckDB search database schema for analytics SQL: "
+        "tables, columns (name/type/nullable), indexes, optional row counts, "
+        "and purpose notes. Also returns a compact markdown summary for agent "
+        "context. Use this before writing complex run_select queries. Read-only. "
+        "format: 'json' | 'markdown' | 'both' (default both)."
+    ),
+)
+def get_db_schema(
+    include_row_counts: bool = True,
+    include_sample_values: bool = False,
+    format: str = "both",
+) -> dict[str, Any]:
+    return query.get_db_schema_impl(
+        include_row_counts=include_row_counts,
+        include_sample_values=include_sample_values,
+        format=format,
+    )
+
+
+@mcp.tool(
     name="run_select",
     description=(
-        "Run a single read-only SELECT against the local DuckDB search database "
-        "(Advanced Queries tab). DDL/DML and multi-statements are rejected."
+        "Run a single read-only SQL query against the local DuckDB search database "
+        "(same as Advanced Queries). Allowed: one SELECT or WITH…SELECT. "
+        "DDL/DML/multi-statement/PRAGMA/ATTACH are rejected. Connection is always "
+        "read-only. Writes only via gather_tickers / forecast_tickers / refresh_tickers "
+        "when MCP_ALLOW_RUNS=1. Call get_db_schema first for table/index layout. "
+        "Results capped by row_limit (default 5000)."
     ),
 )
 def run_select(sql: str, row_limit: int = 5000) -> dict[str, Any]:

--- a/src/canswim/mcp/tools/meta.py
+++ b/src/canswim/mcp/tools/meta.py
@@ -22,6 +22,7 @@ READ_TOOL_NAMES = [
     "scan_forecasts",
     "get_close_price",
     "get_backtest_error",
+    "get_db_schema",
     "run_select",
     "resolve_forecast_start",
 ]
@@ -30,6 +31,7 @@ READ_TOOL_NAMES = [
 WRITE_TOOL_NAMES = [
     "gather_tickers",
     "forecast_tickers",
+    "refresh_tickers",
 ]
 
 TOOL_NAMES = READ_TOOL_NAMES + WRITE_TOOL_NAMES
@@ -67,8 +69,10 @@ def get_server_info_impl() -> dict[str, Any]:
             "runs_allowed": allow_runs,
             "model": (
                 "TiDE precomputed forecasts (read tools). "
-                "Write tools gather_tickers/forecast_tickers require MCP_ALLOW_RUNS=1 "
-                "and may load torch for forecast."
+                "Custom SQL: run_select is SELECT/WITH only on a read-only DuckDB "
+                "connection; get_db_schema exports tables/indexes for query authoring. "
+                "Write tools gather_tickers/forecast_tickers/refresh_tickers require "
+                "MCP_ALLOW_RUNS=1 and may load torch for forecast."
             ),
             "db_path": get_db_path(),
             "tools": TOOL_NAMES,

--- a/src/canswim/mcp/tools/query.py
+++ b/src/canswim/mcp/tools/query.py
@@ -1,14 +1,20 @@
-"""Advanced SELECT-only SQL tool."""
+"""Advanced SELECT-only SQL + schema export for MCP clients."""
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Optional
 
-from canswim.db import SelectOnlyError, dataframe_to_records, run_select
+from canswim.db import (
+    SelectOnlyError,
+    dataframe_to_records,
+    describe_search_schema,
+    run_select,
+)
 from canswim.mcp.tools._common import ensure_db_ready, err_result, ok_result, resolve_db_path
 
 
 def run_select_impl(sql: str, row_limit: int = 5000) -> dict[str, Any]:
+    """Execute a single read-only SELECT (or WITH…SELECT). Never opens R/W."""
     ready, msg = ensure_db_ready()
     if not ready:
         return err_result(msg)
@@ -17,8 +23,66 @@ def run_select_impl(sql: str, row_limit: int = 5000) -> dict[str, Any]:
     db_path = resolve_db_path()
     try:
         df = run_select(db_path, sql, row_limit=row_limit)
-        return ok_result({"row_count": len(df), "rows": dataframe_to_records(df)})
+        return ok_result(
+            {
+                "row_count": len(df),
+                "rows": dataframe_to_records(df),
+                "read_only": True,
+                "row_limit": int(row_limit),
+            }
+        )
     except SelectOnlyError as e:
-        return err_result(str(e))
+        return err_result(str(e), read_only=True)
+    except Exception as e:
+        return err_result(str(e), read_only=True)
+
+
+def get_db_schema_impl(
+    include_row_counts: bool = True,
+    include_sample_values: bool = False,
+    format: str = "both",
+) -> dict[str, Any]:
+    """Export search DuckDB schema (tables, columns, indexes) for agent SQL.
+
+    ``format``: ``json`` | ``markdown`` | ``both`` (default both).
+    """
+    ready, msg = ensure_db_ready()
+    if not ready:
+        # Still try to describe if file exists — agents need schema even if
+        # optional tables missing; ensure_db_ready is strict on core tables.
+        db_path = resolve_db_path()
+        from pathlib import Path
+
+        if not Path(db_path).is_file():
+            return err_result(msg)
+        # fall through with partial DB
+
+    db_path = resolve_db_path()
+    try:
+        schema = describe_search_schema(
+            db_path,
+            include_row_counts=include_row_counts,
+            include_sample_values=include_sample_values,
+        )
+        if schema.get("error") and not schema.get("tables"):
+            return err_result(schema["error"], data=schema)
+
+        fmt = (format or "both").strip().lower()
+        data: dict[str, Any] = {
+            "db_path": schema.get("db_path"),
+            "read_only": True,
+            "sql_policy": schema.get("sql_policy"),
+            "notes": schema.get("notes"),
+            "expected_tables": schema.get("expected_tables"),
+            "table_names": schema.get("table_names"),
+        }
+        if fmt in ("json", "both"):
+            data["tables"] = schema.get("tables")
+            data["indexes"] = schema.get("indexes")
+        if fmt in ("markdown", "both"):
+            data["markdown"] = schema.get("markdown") or ""
+        if schema.get("error"):
+            data["warning"] = schema["error"]
+        return ok_result(data)
     except Exception as e:
         return err_result(str(e))

--- a/tests/canswim/test_db.py
+++ b/tests/canswim/test_db.py
@@ -416,9 +416,14 @@ def test_sync_company_profiles_to_search_db(mini_db, tmp_path: Path):
 def test_is_select_only():
     assert is_select_only("SELECT 1") is True
     assert is_select_only("select * from forecast") is True
+    assert is_select_only(
+        "WITH x AS (SELECT 1 AS a) SELECT * FROM x"
+    ) is True
     assert is_select_only("INSERT INTO forecast VALUES (1)") is False
     assert is_select_only("DROP TABLE forecast") is False
     assert is_select_only("SELECT 1; DROP TABLE forecast") is False
+    assert is_select_only("PRAGMA show_tables") is False
+    assert is_select_only("ATTACH 'x.db' AS other") is False
 
 
 def test_run_select_rejects_dml(mini_db):
@@ -429,6 +434,20 @@ def test_run_select_rejects_dml(mini_db):
 def test_run_select_allows_select(mini_db):
     df = run_select(mini_db, "SELECT symbol FROM stock_tickers ORDER BY symbol")
     assert len(df) == 2
+
+
+def test_describe_search_schema(mini_db):
+    from canswim.db import describe_search_schema
+
+    schema = describe_search_schema(mini_db, include_row_counts=True)
+    assert schema["db_exists"] is True
+    assert schema["read_only"] is True
+    names = {t["name"] for t in schema["tables"]}
+    assert "stock_tickers" in names
+    assert "forecast" in names
+    md = schema.get("markdown") or ""
+    assert "stock_tickers" in md
+    assert "sql_policy" in schema
 
 
 def test_dataframe_to_records():

--- a/tests/canswim/test_mcp_tools.py
+++ b/tests/canswim/test_mcp_tools.py
@@ -72,14 +72,21 @@ def test_tool_names_cover_surface():
         "scan_forecasts",
         "get_close_price",
         "get_backtest_error",
+        "get_db_schema",
         "run_select",
         "resolve_forecast_start",
         "gather_tickers",
         "forecast_tickers",
+        "refresh_tickers",
     }
     assert set(TOOL_NAMES) == expected
-    assert set(WRITE_TOOL_NAMES) == {"gather_tickers", "forecast_tickers"}
+    assert set(WRITE_TOOL_NAMES) == {
+        "gather_tickers",
+        "forecast_tickers",
+        "refresh_tickers",
+    }
     assert "resolve_forecast_start" in READ_TOOL_NAMES
+    assert "get_db_schema" in READ_TOOL_NAMES
 
 
 def test_health_and_info(mcp_env, monkeypatch):
@@ -160,8 +167,31 @@ def test_close_and_error(mcp_env):
 def test_run_select_ok_and_reject(mcp_env):
     ok = query.run_select_impl("SELECT symbol FROM stock_tickers")
     assert ok["ok"] is True
+    assert ok["data"]["read_only"] is True
+    # CTE allowed
+    cte = query.run_select_impl(
+        "WITH t AS (SELECT symbol FROM stock_tickers) SELECT * FROM t"
+    )
+    assert cte["ok"] is True
     bad = query.run_select_impl("DROP TABLE forecast")
     assert bad["ok"] is False
+    bad2 = query.run_select_impl("INSERT INTO stock_tickers VALUES ('ZZZ')")
+    assert bad2["ok"] is False
+    bad3 = query.run_select_impl("SELECT 1; DELETE FROM forecast")
+    assert bad3["ok"] is False
+
+
+def test_get_db_schema(mcp_env):
+    res = query.get_db_schema_impl(include_row_counts=True, format="both")
+    assert res["ok"] is True
+    data = res["data"]
+    assert data["read_only"] is True
+    assert "stock_tickers" in (data.get("table_names") or [])
+    tables = {t["name"]: t for t in (data.get("tables") or [])}
+    assert "forecast" in tables
+    assert any(c["name"].lower() in ("symbol",) for c in tables["stock_tickers"]["columns"])
+    assert "markdown" in data and "stock_tickers" in data["markdown"]
+    assert "sql_policy" in data
 
 
 def test_server_registers_tools(mcp_env):
@@ -174,6 +204,8 @@ def test_server_registers_tools(mcp_env):
         names = set(tool_manager._tools.keys())
         assert "list_tickers" in names
         assert "run_select" in names
+        assert "get_db_schema" in names
+        assert "refresh_tickers" in names
     else:
         # Fallback: tools list API if present
         tools = getattr(mcp_server.mcp, "list_tools", None)


### PR DESCRIPTION
## Summary
- **`get_db_schema`**: tables, columns, indexes, row counts, purpose notes + markdown dump for MCP client AI
- **`run_select`**: single `SELECT` or `WITH…SELECT` only; broader DDL/DML/PRAGMA/ATTACH rejection; always `connect_readonly`
- Writes never via free-form SQL — only `gather_tickers` / `forecast_tickers` / `refresh_tickers` when `MCP_ALLOW_RUNS=1`
- Docs + tests; `WRITE_TOOL_NAMES` includes `refresh_tickers`

## Agent workflow
1. `get_db_schema` → understand layout
2. `run_select` → analytics query
3. Mutations only via dedicated refresh/gather/forecast tools

## Test plan
- [x] `./scripts/ci-local.sh` (167 passed)
- [ ] Restart MCP client and call `get_db_schema` / `run_select`