### PR TITLE
fix: simplify Run tab layout

### DIFF
--- a/docs/run_triggers.md
+++ b/docs/run_triggers.md
@@ -9,7 +9,7 @@ User-facing actions for a **short list of symbols**. Implementation: `canswim.ru
 
 | Step | What it does | CLI | GUI | MCP |
 |------|----------------|-----|-----|-----|
-| **Refresh symbols** | Gather + catch-up forecasts (recommended default) | `forecast --tickers …` after gather, or MCP `refresh_tickers` | **Refresh symbols** | `refresh_tickers` |
+| **Refresh symbols** | Gather + catch-up forecasts (**default** GUI path) | MCP `refresh_tickers` (or gather then forecast) | **Refresh symbols** | `refresh_tickers` |
 | **Get market data** | Update local prices **and** model fundamentals for listed symbols | `gatherdata --tickers "AAPL,MSFT"` | **Update market data** | `gather_tickers` |
 | **Run a forecast** | Forecast those symbols (blank start = monthly catch-up + live) | `forecast --tickers "AAPL" …` | **Run forecast** | `forecast_tickers` |
 | **Check start date** | Show which forecast start date will be used | `resolve_start` | **Check start date** | `resolve_forecast_start` |

--- a/src/canswim/dashboard/run_tab.py
+++ b/src/canswim/dashboard/run_tab.py
@@ -304,28 +304,33 @@ def _forecast_summary(result: dict) -> str:
 
     forecasted = _norm_syms(result.get("forecasted") or [])
     already = _norm_syms(result.get("already_have_forecast") or [])
+    incomplete_starts = result.get("incomplete_starts") or []
+    n_miss = len(incomplete_starts)
     if mode == "catchup":
-        lines = [
-            f"✅ **Catch-up forecast complete** — "
-            f"**{n_origins}** monthly/live origin(s)."
-        ]
+        if result.get("partial") or n_miss:
+            n_ok = max(n_origins - n_miss, 0)
+            lines = [
+                f"⚠️ **Catch-up mostly done** — **{n_ok} of {n_origins}** "
+                f"monthly/live origins OK"
+                + (f" ({n_miss} still missing)." if n_miss else ".")
+            ]
+        else:
+            lines = [
+                f"✅ **Catch-up complete** — all **{n_origins}** monthly/live origins OK."
+            ]
     else:
         lines = [f"✅ **Forecast complete** (start `{start}`)."]
-    if result.get("partial"):
-        lines[0] = "⚠️ " + lines[0].replace("✅ ", "")
-        lines.append("_Some symbol×start pairs still missing — see Advanced details._")
+        if result.get("partial"):
+            lines[0] = "⚠️ " + lines[0].replace("✅ ", "")
     if forecasted:
-        lines.append(
-            f"**New forecasts ({len(forecasted)} symbols):** {_fmt_syms(forecasted)}"
-        )
-    if already and mode == "single":
-        lines.append(
-            f"**Already on file, skipped ({len(already)}):** {_fmt_syms(already)}"
-        )
-    lines.append(
-        "**Next:** open **Charts** (reward/risk + history) or **Scans** "
-        "to rank by RR and backtest."
-    )
+        lines.append(f"**Symbols with new forecast data:** {_fmt_syms(forecasted)}")
+    elif not n_miss:
+        lines.append("No new files needed — everything was already on disk.")
+    if n_miss and n_miss <= 5:
+        lines.append(f"**Still missing:** {', '.join(incomplete_starts)}")
+    elif n_miss:
+        lines.append(f"**Still missing:** {n_miss} symbol×start pairs (see Advanced).")
+    lines.append("**Next:** open **Charts** for that symbol, or **Scans** to rank.")
     return "\n\n".join(lines)
 
 
@@ -423,128 +428,108 @@ class RunTab:
         self.charts_ticker_dropdown = charts_ticker_dropdown
         self.db_status_banner = db_status_banner
 
-        gr.Markdown(
-            """
-## Update data & run forecasts
-**Recommended:** **Refresh symbols** (gather + monthly catch-up forecasts + live).  
-Or use the separate steps below for finer control.
-            """
-        )
-
-        # ---- Primary: Refresh symbols ----
+        # ---- Primary path only (everything else under More options) ----
         with gr.Group():
             gr.Markdown(
-                f"### {REFRESH_SYMBOLS_SECTION_TITLE}\n{REFRESH_SYMBOLS_SECTION_HELP}"
+                f"### {REFRESH_SYMBOLS_SECTION_TITLE}\n"
+                f"{REFRESH_SYMBOLS_SECTION_HELP}"
             )
             self.refreshTickers = gr.Textbox(
-                label="Symbols to refresh",
-                lines=3,
-                placeholder="AAPL, MSFT, NVDA",
+                label="Symbols",
+                lines=2,
+                placeholder="LLY, AAPL, MSFT",
                 info=TICKERS_HELP,
             )
             self.refreshBtn = gr.Button(REFRESH_SYMBOLS_BUTTON, variant="primary")
             self.refreshStatus = gr.Markdown(
-                value=(
-                    "_Enter symbols, then click **Refresh symbols**. "
-                    "Blank forecast start uses ~12 monthly backtests + live._"
-                )
+                value="_Enter symbols → **Refresh symbols**. That is usually all you need._"
             )
-            with gr.Accordion("Advanced details", open=False):
+            with gr.Accordion("Technical log", open=False):
                 self.refreshDetails = gr.Code(
-                    label="Technical log",
+                    label="JSON log",
                     language="json",
-                    lines=10,
+                    lines=6,
                     interactive=False,
                     value="",
                 )
 
-        gr.Markdown("---")
-
-        # ---- Gather panel ----
-        with gr.Group():
-            gr.Markdown(f"### {GATHER_SECTION_TITLE}\n{GATHER_SECTION_HELP}")
-            self.gatherTickers = gr.Textbox(
-                label="Symbols to update",
-                lines=3,
-                placeholder="AAPL, MSFT",
-                info=TICKERS_HELP,
-            )
-            self.gatherBtn = gr.Button(GATHER_BUTTON, variant="primary")
-            self.gatherStatus = gr.Markdown(
-                value="_Enter symbols, then click Update market data._"
-            )
-            with gr.Accordion("Advanced details", open=False):
-                self.gatherDetails = gr.Code(
-                    label="Technical log",
-                    language="json",
-                    lines=8,
-                    interactive=False,
-                    value="",
+        with gr.Accordion("More options (rarely needed)", open=False):
+            with gr.Group():
+                gr.Markdown(
+                    f"#### {GATHER_SECTION_TITLE}\n{GATHER_SECTION_HELP}"
                 )
-
-        gr.Markdown("---")
-
-        # ---- Forecast panel ----
-        with gr.Group():
-            gr.Markdown(f"### {FORECAST_SECTION_TITLE}\n{FORECAST_SECTION_HELP}")
-            self.forecastTickers = gr.Textbox(
-                label="Symbols to forecast",
-                lines=3,
-                placeholder="AAPL, MSFT",
-                info=TICKERS_HELP,
-            )
-            with gr.Row():
-                self.forecastDate = gr.Textbox(
-                    label="Start date (optional)",
-                    value="",
-                    placeholder="YYYY-MM-DD — leave blank for the default",
-                    info=FORECAST_START_HELP,
+                self.gatherTickers = gr.Textbox(
+                    label="Symbols",
+                    lines=2,
+                    placeholder="AAPL, MSFT",
                 )
-                self.resolveBtn = gr.Button(PREVIEW_START_BUTTON, scale=0)
-            self.forecastBtn = gr.Button(FORECAST_BUTTON, variant="primary")
-            self.forecastStatus = gr.Markdown(
-                value="_Enter symbols, optionally check the start date, then run a forecast._"
-            )
-            with gr.Accordion("Advanced details", open=False):
-                self.forecastDetails = gr.Code(
-                    label="Technical log",
-                    language="json",
-                    lines=8,
-                    interactive=False,
-                    value="",
-                )
-
-        gr.Markdown("---")
-
-        # ---- Search DB refresh (parquet → DuckDB) ----
-        with gr.Group():
-            gr.Markdown(
-                f"### {REFRESH_SEARCH_SECTION_TITLE}\n{REFRESH_SEARCH_SECTION_HELP}"
-            )
-            self.refreshDbBtn = gr.Button(REFRESH_SEARCH_BUTTON, variant="secondary")
-            initial_status = ""
-            if self.db_path:
-                try:
-                    initial_status = format_search_db_status_markdown(
-                        search_db_status(self.db_path)
+                self.gatherBtn = gr.Button(GATHER_BUTTON, variant="secondary")
+                self.gatherStatus = gr.Markdown(value="")
+                with gr.Accordion("Gather log", open=False):
+                    self.gatherDetails = gr.Code(
+                        language="json",
+                        lines=4,
+                        interactive=False,
+                        value="",
                     )
-                except Exception as e:
-                    logger.debug(f"initial search db status: {e}")
-                    initial_status = "_Search DB status unavailable._"
-            self.refreshDbStatus = gr.Markdown(value=initial_status)
-            with gr.Accordion("Advanced details", open=False):
-                self.refreshDbDetails = gr.Code(
-                    label="Technical log",
-                    language="json",
-                    lines=8,
-                    interactive=False,
-                    value="",
-                )
 
+            with gr.Group():
+                gr.Markdown(
+                    f"#### {FORECAST_SECTION_TITLE}\n{FORECAST_SECTION_HELP}"
+                )
+                self.forecastTickers = gr.Textbox(
+                    label="Symbols",
+                    lines=2,
+                    placeholder="LLY",
+                )
+                with gr.Row():
+                    self.forecastDate = gr.Textbox(
+                        label="Start date (optional)",
+                        value="",
+                        placeholder="Blank = monthly catch-up + live",
+                        info=FORECAST_START_HELP,
+                    )
+                    self.resolveBtn = gr.Button(PREVIEW_START_BUTTON, scale=0)
+                self.forecastBtn = gr.Button(FORECAST_BUTTON, variant="secondary")
+                self.forecastStatus = gr.Markdown(value="")
+                with gr.Accordion("Forecast log", open=False):
+                    self.forecastDetails = gr.Code(
+                        language="json",
+                        lines=4,
+                        interactive=False,
+                        value="",
+                    )
+
+            with gr.Group():
+                gr.Markdown(
+                    f"#### {REFRESH_SEARCH_SECTION_TITLE}\n"
+                    f"{REFRESH_SEARCH_SECTION_HELP}"
+                )
+                self.refreshDbBtn = gr.Button(
+                    REFRESH_SEARCH_BUTTON, variant="secondary"
+                )
+                initial_status = ""
+                if self.db_path:
+                    try:
+                        initial_status = format_search_db_status_markdown(
+                            search_db_status(self.db_path)
+                        )
+                    except Exception as e:
+                        logger.debug(f"initial search db status: {e}")
+                        initial_status = ""
+                self.refreshDbStatus = gr.Markdown(value=initial_status)
+                with gr.Accordion("Search DB log", open=False):
+                    self.refreshDbDetails = gr.Code(
+                        language="json",
+                        lines=4,
+                        interactive=False,
+                        value="",
+                    )
+
+        # ---- wire events ----
         refresh_outputs = [self.refreshStatus, self.refreshDetails]
         if self.charts_ticker_dropdown is not None:
             refresh_outputs.append(self.charts_ticker_dropdown)
-
         self.refreshBtn.click(
             fn=self.do_refresh_symbols,
             inputs=[self.refreshTickers],
@@ -554,7 +539,6 @@ Or use the separate steps below for finer control.
         gather_outputs = [self.gatherStatus, self.gatherDetails]
         if self.charts_ticker_dropdown is not None:
             gather_outputs.append(self.charts_ticker_dropdown)
-
         self.gatherBtn.click(
             fn=self.do_gather,
             inputs=[self.gatherTickers],
@@ -571,15 +555,15 @@ Or use the separate steps below for finer control.
             outputs=[self.forecastStatus, self.forecastDetails],
         )
 
-        refresh_outputs = [self.refreshDbStatus, self.refreshDbDetails]
+        db_refresh_outputs = [self.refreshDbStatus, self.refreshDbDetails]
         if self.db_status_banner is not None:
-            refresh_outputs.append(self.db_status_banner)
+            db_refresh_outputs.append(self.db_status_banner)
         if self.charts_ticker_dropdown is not None:
-            refresh_outputs.append(self.charts_ticker_dropdown)
+            db_refresh_outputs.append(self.charts_ticker_dropdown)
         self.refreshDbBtn.click(
             fn=self.do_refresh_search_db,
             inputs=[],
-            outputs=refresh_outputs,
+            outputs=db_refresh_outputs,
         )
 
     def _charts_dropdown_update(self):

--- a/src/canswim/run_triggers.py
+++ b/src/canswim/run_triggers.py
@@ -53,38 +53,29 @@ DATE_POLICY_SUMMARY = (
     "Start dates use market weeks (see docs/run_triggers.md)."
 )
 
-GATHER_SECTION_TITLE = "Get market data"
-GATHER_SECTION_HELP = (
-    "Download recent prices for the symbols you list. "
-    "Uses local files when they already cover about the last two years; "
-    "only requests from the internet what is missing or out of date."
-)
+GATHER_SECTION_TITLE = "Get market data only"
+GATHER_SECTION_HELP = "Prices + fundamentals only (no model run)."
 GATHER_BUTTON = "Update market data"
 
-FORECAST_SECTION_TITLE = "Run a forecast"
+FORECAST_SECTION_TITLE = "Run forecast only"
 FORECAST_SECTION_HELP = (
-    "Create forecasts for the symbols you list. "
-    "Leave start date blank to **catch up** ~12 monthly backtests + the live forecast. "
-    "Needs complete local market history—if anything is missing, "
-    "update market data first (or use **Refresh symbols**)."
+    "Model only. Blank start = ~12 monthly catch-ups + live. "
+    "Needs market data already on file."
 )
 FORECAST_BUTTON = "Run forecast"
 PREVIEW_START_BUTTON = "Check start date"
 
-REFRESH_SYMBOLS_SECTION_TITLE = "Refresh symbols (recommended)"
+REFRESH_SYMBOLS_SECTION_TITLE = "Refresh symbols"
 REFRESH_SYMBOLS_SECTION_HELP = (
-    "All-in-one for new or stale names: **update market data**, then "
-    "**catch-up forecasts** (monthly origins for the past year + live). "
-    "Skips work already done. Best default for a portfolio list."
+    "One step: update market data, then catch-up forecasts "
+    "(~12 monthly backtests + live). Skips work already done."
 )
 REFRESH_SYMBOLS_BUTTON = "Refresh symbols"
 
-REFRESH_SEARCH_SECTION_TITLE = "Search database (Charts / Scans)"
+REFRESH_SEARCH_SECTION_TITLE = "Rebuild Charts / Scans database"
 REFRESH_SEARCH_SECTION_HELP = (
-    "Charts and Scans read the local DuckDB search cache, not parquet files directly. "
-    "Parquet under data/ is the system of record. "
-    "After bulk data changes—or if Charts look empty while parquet exists—"
-    "use **Refresh search DB from parquet** to rebuild the cache."
+    "Only if Charts look empty while parquet exists. "
+    "Usually not needed after Refresh symbols."
 )
 REFRESH_SEARCH_BUTTON = "Refresh search DB from parquet"
 

--- a/tests/canswim/test_ux_split_labels.py
+++ b/tests/canswim/test_ux_split_labels.py
@@ -44,24 +44,24 @@ def test_date_policy_summary_not_technical_dump():
 
 def test_run_tab_has_separate_gather_and_forecast_controls():
     src = inspect.getsource(run_tab_mod.RunTab.__init__)
+    # Primary path: Refresh symbols
+    assert "refreshBtn" in src or "refreshTickers" in src
+    assert "REFRESH_SYMBOLS" in src or REFRESH_SYMBOLS_BUTTON in src
+    assert "do_refresh_symbols" in inspect.getsource(run_tab_mod.RunTab)
+    # Secondary still present but under collapsed "More options"
+    assert "More options" in src
     assert "gatherTickers" in src
     assert "forecastTickers" in src
     assert "gatherBtn" in src
     assert "forecastBtn" in src
-    assert "refreshBtn" in src or "refreshTickers" in src
-    assert "REFRESH_SYMBOLS" in src or REFRESH_SYMBOLS_BUTTON in src
     assert GATHER_SECTION_TITLE in src or "GATHER_SECTION_TITLE" in src
     assert FORECAST_SECTION_TITLE in src or "FORECAST_SECTION_TITLE" in src
-    # Two separate status outputs
     assert "gatherStatus" in src
     assert "forecastStatus" in src
-    # Search DB refresh (parquet → DuckDB)
+    # Search DB rebuild tucked under More options
     assert "refreshDbBtn" in src
     assert "do_refresh_search_db" in inspect.getsource(run_tab_mod.RunTab)
     assert "REFRESH_SEARCH_BUTTON" in src or "Refresh search DB" in src
-    assert "do_refresh_symbols" in inspect.getsource(run_tab_mod.RunTab)
-    # JSON is advanced/collapsed, not primary body
-    assert "Advanced details" in src
     assert "gatherDetails" in src
     assert "forecastDetails" in src
     assert "open=False" in src


### PR DESCRIPTION
## Summary
Run tab felt busy (multiple primary buttons, long help, search DB always visible).

- **Primary only:** Symbols + **Refresh symbols** + status
- **More options** (collapsed): gather only, forecast only, rebuild search DB
- Catch-up status: **N of M origins OK** instead of vague partial warning

## Test plan
- [x] local CI
- [ ] Restart dashboard; Run tab shows one purple button by default