### PR TITLE
fix: explain Refresh symbols on Run tab

### DIFF
--- a/docs/run_triggers.md
+++ b/docs/run_triggers.md
@@ -44,11 +44,13 @@ After a successful gather, symbols are **synced into the DuckDB search DB** so C
 
 ## Refresh symbols (recommended)
 
-All-in-one for a short list (portfolio / new names):
+All-in-one for a short list (portfolio / new names). GUI copy matches this:
 
-1. **Gather** prices + fundamentals (missing-only, ~2y).  
-2. **Catch-up forecast** for symbols that are ready (see below).  
-3. **Sync** forecasts + backtest errors into DuckDB for Charts/Scans.
+1. **Market data** — prices + fundamentals (missing-only, ~2y).  
+2. **Catch-up forecasts** — ~12 monthly origins + live for symbols that are ready.  
+3. **Charts list + DuckDB** — symbols appear in Charts; forecasts and backtest errors sync for Scans.
+
+**Skipped:** work already on file; short-history / IPO names (reported in status).
 
 GUI: **Refresh symbols**. MCP: `refresh_tickers`. Agents can say “refresh AAPL, MSFT” and get one consistent pipeline.
 

--- a/src/canswim/dashboard/run_tab.py
+++ b/src/canswim/dashboard/run_tab.py
@@ -430,19 +430,20 @@ class RunTab:
 
         # ---- Primary path only (everything else under More options) ----
         with gr.Group():
-            gr.Markdown(
-                f"### {REFRESH_SYMBOLS_SECTION_TITLE}\n"
-                f"{REFRESH_SYMBOLS_SECTION_HELP}"
-            )
+            gr.Markdown(f"### {REFRESH_SYMBOLS_SECTION_TITLE}")
+            gr.Markdown(REFRESH_SYMBOLS_SECTION_HELP.strip())
             self.refreshTickers = gr.Textbox(
-                label="Symbols",
+                label="Symbols to refresh",
                 lines=2,
                 placeholder="LLY, AAPL, MSFT",
                 info=TICKERS_HELP,
             )
             self.refreshBtn = gr.Button(REFRESH_SYMBOLS_BUTTON, variant="primary")
             self.refreshStatus = gr.Markdown(
-                value="_Enter symbols → **Refresh symbols**. That is usually all you need._"
+                value=(
+                    "_Enter one or more symbols, then click **Refresh symbols**. "
+                    "Status of each step appears here when the run finishes._"
+                )
             )
             with gr.Accordion("Technical log", open=False):
                 self.refreshDetails = gr.Code(

--- a/src/canswim/run_triggers.py
+++ b/src/canswim/run_triggers.py
@@ -66,10 +66,25 @@ FORECAST_BUTTON = "Run forecast"
 PREVIEW_START_BUTTON = "Check start date"
 
 REFRESH_SYMBOLS_SECTION_TITLE = "Refresh symbols"
-REFRESH_SYMBOLS_SECTION_HELP = (
-    "One step: update market data, then catch-up forecasts "
-    "(~12 monthly backtests + live). Skips work already done."
-)
+# Shown under the primary Run-tab CTA (plain language; keep scannable)
+REFRESH_SYMBOLS_SECTION_HELP = """
+For the symbols you enter, this runs **everything needed** so Charts and Scans
+can show a fresh picture:
+
+1. **Market data** — download or refresh recent prices and fundamentals  
+   (uses local files when already complete; only fetches what’s missing or stale).
+2. **Catch-up forecasts** — run the model for about the **last 12 months**  
+   (one origin per month) **plus** the latest live start, so you get history for  
+   reward/risk and backtest quality—not only today’s forecast.
+3. **Charts list** — add those symbols to the Charts dropdown automatically.
+
+**Skipped automatically:** symbols that already have data/forecasts for a given  
+start, and names with too little trading history (e.g. recent IPOs)—those are  
+reported in the status below.
+
+**After it finishes:** open **Charts** for a symbol, or **Scans** to rank by  
+reward/risk and backtest. A full run can take several minutes for many symbols.
+"""
 REFRESH_SYMBOLS_BUTTON = "Refresh symbols"
 
 REFRESH_SEARCH_SECTION_TITLE = "Rebuild Charts / Scans database"

--- a/tests/canswim/test_ux_split_labels.py
+++ b/tests/canswim/test_ux_split_labels.py
@@ -14,6 +14,7 @@ from canswim.run_triggers import (
     GATHER_BUTTON,
     GATHER_SECTION_TITLE,
     REFRESH_SYMBOLS_BUTTON,
+    REFRESH_SYMBOLS_SECTION_HELP,
     TICKERS_HELP,
 )
 
@@ -29,11 +30,22 @@ def test_consumer_copy_avoids_dev_jargon():
         FORECAST_SECTION_TITLE,
         GATHER_BUTTON,
         FORECAST_BUTTON,
+        REFRESH_SYMBOLS_SECTION_HELP,
+        REFRESH_SYMBOLS_BUTTON,
     ):
         assert "ISO week" not in s
         assert "TiDE" not in s
         assert "week-aligned starts:" not in s.lower()
         assert "CLI equivalent" not in s
+
+
+def test_refresh_symbols_help_explains_steps():
+    h = REFRESH_SYMBOLS_SECTION_HELP.lower()
+    assert "market data" in h
+    assert "forecast" in h
+    assert "12" in h or "monthly" in h
+    assert "charts" in h
+    assert "skip" in h
 
 
 def test_date_policy_summary_not_technical_dump():


### PR DESCRIPTION
## Summary
Users were guessing what **Refresh symbols** does. The primary Run panel now shows plain-language steps (market data → catch-up forecasts → Charts list), what is skipped, and what to do next.

## Test plan
- [x] ci-local + UX string tests
- [ ] Hard-refresh dashboard Run tab and read the new blurb