### PR TITLE
fix: consumer Run UX — rename CTA, hide debug banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Two separate steps, same backend (`canswim.run_triggers`). Details: **[docs/run_
 | | Get market data | Run a forecast | Check start date |
 |--|-----------------|----------------|------------------|
 | **CLI** | `gatherdata --tickers "…"` | `forecast --tickers "…" [date] [--dry_run]` | `resolve_start` |
-| **GUI** | **Refresh symbols** / **Update market data** | **Run forecast** | **Check start date** |
+| **GUI** | **Refresh data & forecasts** / **Update market data** | **Run forecast** | **Check start date** |
 | **MCP** | `gather_tickers`* | `forecast_tickers`* | `resolve_forecast_start` |
 
 \*MCP write tools need `MCP_ALLOW_RUNS=1`. Full MCP guide: **[docs/mcp.md](docs/mcp.md)**.
@@ -96,7 +96,7 @@ python -m canswim dashboard --same_data True
 |-----|---------|
 | **Charts** | Price history + forecast bands for a symbol |
 | **Scans** | Filter forecasts by as-of date, reward, risk, confidence |
-| **Run** | **Refresh symbols** / **Update market data** / **Run forecast** / **Check start date** / **Refresh search DB from parquet** |
+| **Run** | **Refresh data & forecasts** (primary) · more options for gather-only / forecast-only / **Rebuild Charts database** |
 | **Advanced Queries** | Read-only SQL against the search DB |
 
 ### Sample screenshots

--- a/docs/data_store.md
+++ b/docs/data_store.md
@@ -37,7 +37,7 @@ python -m canswim dashboard --same_data False
 ```
 
 - The dashboard shows a **search DB status** banner (path, reuse vs rebuild, row counts, whether parquet sources exist).
-- On the **Run** tab, **Refresh search DB from parquet** rebuilds DuckDB without restarting (same as `--same_data False`).
+- On the **Run** tab under More options, **Rebuild Charts database** rebuilds DuckDB without restarting (same as `--same_data False`).
 - With `--same_data True`, optional tables such as `company_profile` are **repaired lazily** if missing (no full wipe).
 - Prefer **`hfhub_sync=False`** for local work so gather does not pull the full HF dataset snapshot.
 - Do not commit gitignored `data/` artifacts or slimmed local-only symbol lists used for experiments (see `AGENTS.md`).
@@ -45,7 +45,7 @@ python -m canswim dashboard --same_data False
 ### If Charts look empty but parquet has data
 
 1. Confirm the status banner DB path matches the data you expect.
-2. Click **Refresh search DB from parquet** on the Run tab (or restart with `--same_data False`).
+2. Click **Rebuild Charts database** on the Run tab under More options (or restart with `--same_data False`).
 3. Charts still read **DuckDB only** — editing parquet alone does not update the UI until sync/rebuild.
 
 ## Related docs

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -74,7 +74,7 @@ Canonical registration: `src/canswim/mcp/server.py`. Update this table in the **
 | `resolve_forecast_start` | Preview week-aligned start (≡ CLI `resolve_start`) | — |
 | `gather_tickers` | Scoped gather (≡ `gatherdata --tickers`) | `MCP_ALLOW_RUNS=1` |
 | `forecast_tickers` | Scoped forecast; blank start = monthly catch-up + live | `MCP_ALLOW_RUNS=1` |
-| `refresh_tickers` | Gather + catch-up forecast (≡ dashboard **Refresh symbols**) | `MCP_ALLOW_RUNS=1` |
+| `refresh_tickers` | Gather + catch-up forecast (≡ dashboard **Refresh data & forecasts**) | `MCP_ALLOW_RUNS=1` |
 
 ### Custom SQL (read-only)
 

--- a/docs/run_triggers.md
+++ b/docs/run_triggers.md
@@ -9,11 +9,11 @@ User-facing actions for a **short list of symbols**. Implementation: `canswim.ru
 
 | Step | What it does | CLI | GUI | MCP |
 |------|----------------|-----|-----|-----|
-| **Refresh symbols** | Gather + catch-up forecasts (**default** GUI path) | MCP `refresh_tickers` (or gather then forecast) | **Refresh symbols** | `refresh_tickers` |
+| **Refresh data & forecasts** | Gather + catch-up forecasts (**default** GUI path) | MCP `refresh_tickers` | **Refresh data & forecasts** | `refresh_tickers` |
 | **Get market data** | Update local prices **and** model fundamentals for listed symbols | `gatherdata --tickers "AAPL,MSFT"` | **Update market data** | `gather_tickers` |
 | **Run a forecast** | Forecast those symbols (blank start = monthly catch-up + live) | `forecast --tickers "AAPL" …` | **Run forecast** | `forecast_tickers` |
 | **Check start date** | Show which forecast start date will be used | `resolve_start` | **Check start date** | `resolve_forecast_start` |
-| **Refresh search DB** | Rebuild DuckDB Charts/Scans cache from parquet | `dashboard --same_data False` | **Refresh search DB from parquet** | (rebuild via dashboard / `MCP_INIT_DB`) |
+| **Rebuild Charts database** | Rebuild DuckDB Charts/Scans cache from parquet | `dashboard --same_data False` | **Rebuild Charts database** | (rebuild via dashboard / `MCP_INIT_DB`) |
 
 MCP write tools need `MCP_ALLOW_RUNS=1`. CLI and dashboard do not.
 
@@ -42,9 +42,9 @@ Scoped writers **merge** into existing parquet by symbol so a short ticker list 
 
 After a successful gather, symbols are **synced into the DuckDB search DB** so Charts/Scans dropdowns include them. See [data_store.md](data_store.md).
 
-## Refresh symbols (recommended)
+## Refresh data & forecasts (recommended)
 
-All-in-one for a short list (portfolio / new names). GUI copy matches this:
+All-in-one for a short list (portfolio / new names). GUI label: **Refresh data & forecasts**.
 
 1. **Market data** — prices + fundamentals (missing-only, ~2y).  
 2. **Catch-up forecasts** — ~12 monthly origins + live for symbols that are ready.  
@@ -52,11 +52,11 @@ All-in-one for a short list (portfolio / new names). GUI copy matches this:
 
 **Skipped:** work already on file; short-history / IPO names (reported in status).
 
-GUI: **Refresh symbols**. MCP: `refresh_tickers`. Agents can say “refresh AAPL, MSFT” and get one consistent pipeline.
+MCP tool name remains `refresh_tickers` (same pipeline).
 
 ## Run a forecast
 
-- Forecasts never invent prices. If OHLCV history is incomplete, the run **fails** and asks you to update market data first (or use **Refresh symbols**).
+- Forecasts never invent prices. If OHLCV history is incomplete, the run **fails** and asks you to update market data first (or use **Refresh data & forecasts**).
 - If prices look fine but ownership/estimates (or alignment) fail, the run fails with a **covariates** message—run **Update market data** again (with fundamentals), then retry.
 - Symbols that **already have a saved forecast** for a given start are **skipped** (no re-run).
 - After a successful forecast, rows are **synced into DuckDB** (including **backtest_error** refresh) for Charts/Scans.

--- a/src/canswim/dashboard/__init__.py
+++ b/src/canswim/dashboard/__init__.py
@@ -8,12 +8,7 @@ from canswim.dashboard.charts import ChartTab
 from canswim.dashboard.scans import ScanTab
 from canswim.dashboard.advanced import AdvancedTab
 from canswim.dashboard.run_tab import RunTab
-from canswim.db import (
-    DataPaths,
-    format_search_db_status_markdown,
-    init_search_db,
-    search_db_status,
-)
+from canswim.db import DataPaths, init_search_db
 
 # Note: It appears that gradio Plot ignores the backend plot lib setting
 # pd.options.plotting.backend = "plotly"
@@ -35,7 +30,6 @@ class CanswimPlayground:
         self.stocks_price_path = paths.stocks_price_path
         self.stock_tickers_path = paths.stock_tickers_path
         self.init_db_result = None  # set by initdb()
-        self.db_status_md = ""
 
     def download_model(self):
         """Load model from HF Hub"""
@@ -64,10 +58,7 @@ class CanswimPlayground:
         )
         mode = "reused" if self.init_db_result.get("reused") else "rebuilt"
         repaired = (self.init_db_result.get("repair") or {}).get("repaired") or []
-        status = self.init_db_result.get("status") or search_db_status(self.db_path)
-        self.db_status_md = format_search_db_status_markdown(
-            status, mode=mode, repaired=repaired
-        )
+        status = self.init_db_result.get("status") or {}
         logger.info(
             f"Search DB {mode}: path={self.db_path} "
             f"ok={status.get('ok')} repaired={repaired}"
@@ -86,7 +77,6 @@ class CanswimPlayground:
             * Model trainer source repo [here](https://github.com/ivelin/canswim). Feedback welcome via github issues.
             """
             )
-            self.dbStatusBanner = gr.Markdown(value=self.db_status_md)
             with gr.Tab("Charts"):
                 charts_tab = ChartTab(
                     canswim_model=self.canswim_model,
@@ -102,7 +92,6 @@ class CanswimPlayground:
                     self.canswim_model,
                     db_path=self.db_path,
                     charts_ticker_dropdown=charts_tab.tickerDropdown,
-                    db_status_banner=self.dbStatusBanner,
                 )
             with gr.Tab("Advanced Queries"):
                 AdvancedTab(

--- a/src/canswim/dashboard/run_tab.py
+++ b/src/canswim/dashboard/run_tab.py
@@ -12,7 +12,6 @@ import gradio as gr
 from loguru import logger
 
 from canswim.db import (
-    format_search_db_status_markdown,
     init_search_db,
     list_tickers,
     search_db_status,
@@ -206,8 +205,8 @@ def _gather_summary(result: dict) -> str:
     lines.append("**What you can do next**")
     if ready and incomplete:
         lines.append(
-            "1. **Recommended:** Paste the ready line into **Refresh symbols** "
-            "(or **Run forecast** with blank start for catch-up)."
+            "1. **Recommended:** Paste the ready line and click "
+            f"**{REFRESH_SYMBOLS_BUTTON}**."
         )
         lines.append(
             "2. Leave the not-ready names off for now "
@@ -218,8 +217,8 @@ def _gather_summary(result: dict) -> str:
         )
     elif ready:
         lines.append(
-            "1. **Recommended:** **Refresh symbols** or **Run forecast** "
-            "(blank start = monthly catch-up + live)."
+            f"1. **Recommended:** **{REFRESH_SYMBOLS_BUTTON}** "
+            "(or **Run forecast** under More options)."
         )
         lines.append(
             "2. Or open **Charts** to review a symbol visually first."
@@ -249,7 +248,7 @@ def _forecast_summary(result: dict) -> str:
             return (
                 f"ℹ️ **Check only — catch-up** ({n_origins} monthly/live origins).\n\n"
                 f"**Jobs that would run:** {need} symbol×start pair(s).\n\n"
-                "No model run. Click **Run forecast** or **Refresh symbols** when ready."
+                f"No model run. Click **{REFRESH_SYMBOLS_BUTTON}** when ready."
             )
         already = _norm_syms(result.get("already_have_forecast") or [])
         if already:
@@ -257,11 +256,11 @@ def _forecast_summary(result: dict) -> str:
                 f"ℹ️ **Check only** — start date `{start}`.\n\n"
                 f"**Would skip (already on file, {len(already)}):** "
                 f"{_fmt_syms(already)}\n\n"
-                "No model run. Click **Run forecast** when ready."
+                f"No model run. Click **{REFRESH_SYMBOLS_BUTTON}** when ready."
             )
         return (
             f"ℹ️ **Check only** — start date `{start}`.\n\n"
-            "No model run. Click **Run forecast** when ready."
+            f"No model run. Click **{REFRESH_SYMBOLS_BUTTON}** when ready."
         )
     if result.get("already_saved") and not result.get("forecasted"):
         already = _norm_syms(
@@ -281,15 +280,14 @@ def _forecast_summary(result: dict) -> str:
         if result.get("need_covariates"):
             head = "❌ **Forecast inputs incomplete.**"
             nexts = (
-                "1. **Recommended:** **Refresh symbols** or **Update market data**, "
+                f"1. **Recommended:** **{REFRESH_SYMBOLS_BUTTON}**, "
                 "then try again.\n\n"
-                "2. See **Advanced details** for which inputs failed."
+                "2. See the technical log for details."
             )
         elif result.get("need_gather"):
             head = "❌ **Need more market data first.**"
             nexts = (
-                "1. **Recommended:** **Refresh symbols** (gather + forecast) "
-                "or **Update market data** then **Run forecast**.\n\n"
+                f"1. **Recommended:** **{REFRESH_SYMBOLS_BUTTON}**.\n\n"
                 "2. Recent IPOs may need more history first."
             )
         else:
@@ -335,7 +333,7 @@ def _forecast_summary(result: dict) -> str:
 
 
 def _refresh_summary(result: dict) -> str:
-    """Primary status for all-in-one Refresh symbols."""
+    """Primary status for all-in-one Refresh data & forecasts."""
     gather = result.get("gather") or {}
     forecast = result.get("forecast") or {}
     ready = _norm_syms(result.get("ready") or gather.get("ready") or [])
@@ -343,66 +341,68 @@ def _refresh_summary(result: dict) -> str:
         result.get("incomplete") or gather.get("incomplete") or []
     )
     lines: list[str] = []
+    btn = REFRESH_SYMBOLS_BUTTON
 
     if result.get("dry_run"):
-        lines.append("ℹ️ **Check only — Refresh symbols** (no downloads / model).")
-        lines.append(f"**Would gather then catch-up:** {_fmt_syms(ready)}")
+        lines.append(f"ℹ️ **Check only — {btn}** (no downloads / model).")
+        lines.append(f"**Would update then forecast:** {_fmt_syms(ready)}")
         if incomplete:
             lines.append(f"**Would skip (not ready):** {_fmt_syms(incomplete)}")
         return "\n\n".join(lines)
 
     if not result.get("ok") and not forecast.get("forecasted"):
         g_part = _gather_summary(gather) if gather else ""
-        head = "❌ **Refresh could not finish.**"
+        head = f"❌ **{btn} could not finish.**"
         if incomplete and not ready:
-            head = "❌ **Refresh stopped — no symbols ready for forecast yet.**"
+            head = (
+                f"❌ **{btn} stopped** — no symbols ready for forecast yet."
+            )
         return (
             f"{head}\n\n"
             f"{result.get('error') or ''}\n\n"
             f"{g_part}\n\n"
             "**What you can do next**\n\n"
-            "1. **Recommended:** Drop short-history / IPO names and "
-            "**Refresh symbols** again.\n\n"
-            "2. See **Advanced details** for the full log."
+            "1. **Recommended:** Drop short-history / IPO names and try again.\n\n"
+            "2. Open **Technical log** for details."
         )
 
     n_orig = len(forecast.get("origins") or [])
     new_fc = _norm_syms(forecast.get("forecasted") or [])
     if result.get("partial") or incomplete:
         lines.append(
-            f"⚠️ **Refresh partial** — **{len(ready)}** ready, "
+            f"⚠️ **{btn} partial** — **{len(ready)}** ready, "
             f"**{len(incomplete)}** not forecast-ready."
         )
     else:
         lines.append(
-            f"✅ **Refresh complete** for **{len(ready)}** symbol"
+            f"✅ **{btn} complete** for **{len(ready)}** symbol"
             f"{'s' if len(ready) != 1 else ''}."
         )
     if ready:
-        lines.append(f"**Forecast-ready:** {_fmt_syms(ready)}")
+        lines.append(f"**Ready for Charts / Scans:** {_fmt_syms(ready)}")
     if incomplete:
         lines.append(
-            f"**Not ready (short history etc.):** {_fmt_syms(incomplete)}"
+            f"**Not ready yet (short history etc.):** {_fmt_syms(incomplete)}"
         )
     if n_orig:
         lines.append(
-            f"**Catch-up origins:** {n_orig} monthly/live starts "
-            f"(skipped ones already on file)."
+            f"**Forecast history:** {n_orig} monthly/live starts "
+            f"(already-saved starts were skipped)."
         )
     if new_fc:
-        lines.append(f"**New forecast files:** {_fmt_syms(new_fc)}")
+        lines.append(f"**New forecasts written for:** {_fmt_syms(new_fc)}")
     elif forecast.get("already_saved"):
-        lines.append("Forecasts were already on file for all ready origins.")
+        lines.append("Forecasts were already up to date for ready symbols.")
     lines.append("**What you can do next**")
     lines.append(
-        "1. **Recommended:** Open **Scans** or **Charts** — backtest history "
-        "and the live forecast should be available for ready names."
+        "1. **Recommended:** Open **Charts** for a symbol, or **Scans** to rank "
+        "by reward/risk and backtest history."
     )
     if incomplete:
         lines.append(
             "2. Leave not-ready names for later (need more trading history)."
         )
-    lines.append("Full log under **Advanced details**.")
+    lines.append("Details under **Technical log** if needed.")
     return "\n\n".join(lines)
 
 
@@ -421,12 +421,12 @@ class RunTab:
         canswim_model=None,
         db_path=None,
         charts_ticker_dropdown=None,
-        db_status_banner=None,
+        db_status_banner=None,  # unused; kept for call-site compatibility
     ):
         self.canswim_model = canswim_model
         self.db_path = db_path
         self.charts_ticker_dropdown = charts_ticker_dropdown
-        self.db_status_banner = db_status_banner
+        self.db_status_banner = None  # no global debug banner
 
         # ---- Primary path only (everything else under More options) ----
         with gr.Group():
@@ -441,8 +441,9 @@ class RunTab:
             self.refreshBtn = gr.Button(REFRESH_SYMBOLS_BUTTON, variant="primary")
             self.refreshStatus = gr.Markdown(
                 value=(
-                    "_Enter one or more symbols, then click **Refresh symbols**. "
-                    "Status of each step appears here when the run finishes._"
+                    "_Enter one or more symbols, then click "
+                    f"**{REFRESH_SYMBOLS_BUTTON}**. "
+                    "Status appears here when the run finishes._"
                 )
             )
             with gr.Accordion("Technical log", open=False):
@@ -509,17 +510,10 @@ class RunTab:
                 self.refreshDbBtn = gr.Button(
                     REFRESH_SEARCH_BUTTON, variant="secondary"
                 )
-                initial_status = ""
-                if self.db_path:
-                    try:
-                        initial_status = format_search_db_status_markdown(
-                            search_db_status(self.db_path)
-                        )
-                    except Exception as e:
-                        logger.debug(f"initial search db status: {e}")
-                        initial_status = ""
-                self.refreshDbStatus = gr.Markdown(value=initial_status)
-                with gr.Accordion("Search DB log", open=False):
+                self.refreshDbStatus = gr.Markdown(
+                    value="_Only needed if Charts stay empty after a data refresh._"
+                )
+                with gr.Accordion("Technical log", open=False):
                     self.refreshDbDetails = gr.Code(
                         language="json",
                         lines=4,
@@ -560,8 +554,6 @@ class RunTab:
         )
 
         db_refresh_outputs = [self.refreshDbStatus, self.refreshDbDetails]
-        if self.db_status_banner is not None:
-            db_refresh_outputs.append(self.db_status_banner)
         if self.charts_ticker_dropdown is not None:
             db_refresh_outputs.append(self.charts_ticker_dropdown)
         self.refreshDbBtn.click(
@@ -678,11 +670,10 @@ class RunTab:
 
     def do_refresh_search_db(self):
         """Rebuild DuckDB search cache from local parquet (full refresh)."""
-        banner = "_Search DB status unavailable._"
         if not self.db_path:
             status = "❌ **No database path configured.**"
             details = _json_details({"ok": False, "error": "db_path missing"})
-            return self._refresh_outputs(status, details, banner, dropdown=False)
+            return self._refresh_outputs(status, details, dropdown=False)
 
         target_col = "Close"
         if self.canswim_model is not None:
@@ -696,33 +687,31 @@ class RunTab:
                 target_column=target_col,
             )
             st = result.get("status") or search_db_status(self.db_path)
-            banner = format_search_db_status_markdown(st, mode="rebuilt")
+            n_sym = (st.get("counts") or {}).get("stock_tickers")
             if st.get("ok"):
-                head = f"✅ **Search DB rebuilt** from parquet → `{self.db_path}`."
-            else:
-                head = (
-                    f"⚠️ **Rebuild finished but search DB looks incomplete.**  \n"
-                    f"Path: `{self.db_path}`"
+                status = (
+                    f"✅ **Charts database rebuilt.** "
+                    f"{n_sym or '—'} symbols available in Charts / Scans."
                 )
-            status = head + "  \n\n" + banner
+            else:
+                status = (
+                    "⚠️ **Rebuild finished, but some Charts data may be missing.** "
+                    "Try **Refresh data & forecasts** for your symbols."
+                )
             details = _json_details(result)
         except Exception as e:
             logger.exception("Search DB refresh failed")
             result = {"ok": False, "error": str(e)}
-            try:
-                st = search_db_status(self.db_path)
-                banner = format_search_db_status_markdown(st)
-            except Exception:
-                banner = f"_Could not read status: {e}_"
-            status = f"❌ **Could not rebuild search DB.**  \n{e}  \n\n{banner}"
+            status = (
+                "❌ **Could not rebuild Charts database.** "
+                "See technical log for details."
+            )
             details = _json_details(result)
 
-        return self._refresh_outputs(status, details, banner, dropdown=True)
+        return self._refresh_outputs(status, details, dropdown=True)
 
-    def _refresh_outputs(self, status, details, banner, *, dropdown: bool):
+    def _refresh_outputs(self, status, details, banner=None, *, dropdown: bool):
         outs = [status, details]
-        if self.db_status_banner is not None:
-            outs.append(banner)
         if self.charts_ticker_dropdown is not None:
             outs.append(
                 self._charts_dropdown_update() if dropdown else gr.update()

--- a/src/canswim/db.py
+++ b/src/canswim/db.py
@@ -202,7 +202,7 @@ def format_search_db_status_markdown(
     if not status.get("db_exists"):
         lines.append(
             "❌ **No DuckDB file yet.** Open with rebuild, or use "
-            "**Refresh search DB from parquet** on the Run tab."
+            "**Rebuild Charts database** on the Run tab (under More options)."
         )
         return "  \n".join(lines)
 
@@ -213,7 +213,7 @@ def format_search_db_status_markdown(
         lines.append(
             "⚠️ **Incomplete search DB** — missing: "
             + (", ".join(missing) if missing else "unknown")
-            + ". Use **Refresh search DB from parquet**."
+            + ". Use **Rebuild Charts database**."
         )
 
     counts = status.get("counts") or {}

--- a/src/canswim/mcp/server.py
+++ b/src/canswim/mcp/server.py
@@ -239,7 +239,7 @@ def forecast_tickers(
         "All-in-one refresh for listed symbols: update market data, then catch-up "
         "forecasts (monthly origins for ~12 months + live). Best default when a "
         "user or agent says “gather and forecast” or “refresh these names”. "
-        "Same as dashboard “Refresh symbols”. Requires MCP_ALLOW_RUNS=1. "
+        "Same as dashboard “Refresh data & forecasts”. Requires MCP_ALLOW_RUNS=1. "
         "May take many minutes for large lists. dry_run=true plans only."
     ),
 )

--- a/src/canswim/run_triggers.py
+++ b/src/canswim/run_triggers.py
@@ -65,10 +65,11 @@ FORECAST_SECTION_HELP = (
 FORECAST_BUTTON = "Run forecast"
 PREVIEW_START_BUTTON = "Check start date"
 
-REFRESH_SYMBOLS_SECTION_TITLE = "Refresh symbols"
+# Primary Run-tab CTA (keep labels self-descriptive for consumers)
+REFRESH_SYMBOLS_SECTION_TITLE = "Refresh data & forecasts"
 # Shown under the primary Run-tab CTA (plain language; keep scannable)
 REFRESH_SYMBOLS_SECTION_HELP = """
-For the symbols you enter, this runs **everything needed** so Charts and Scans
+For the symbols you enter, this does **everything needed** so Charts and Scans
 can show a fresh picture:
 
 1. **Market data** — download or refresh recent prices and fundamentals  
@@ -78,21 +79,20 @@ can show a fresh picture:
    reward/risk and backtest quality—not only today’s forecast.
 3. **Charts list** — add those symbols to the Charts dropdown automatically.
 
-**Skipped automatically:** symbols that already have data/forecasts for a given  
-start, and names with too little trading history (e.g. recent IPOs)—those are  
-reported in the status below.
+**Skipped automatically:** work already on file for a given start, and names  
+with too little trading history (e.g. recent IPOs)—reported in the status below.
 
 **After it finishes:** open **Charts** for a symbol, or **Scans** to rank by  
 reward/risk and backtest. A full run can take several minutes for many symbols.
 """
-REFRESH_SYMBOLS_BUTTON = "Refresh symbols"
+REFRESH_SYMBOLS_BUTTON = "Refresh data & forecasts"
 
 REFRESH_SEARCH_SECTION_TITLE = "Rebuild Charts / Scans database"
 REFRESH_SEARCH_SECTION_HELP = (
-    "Only if Charts look empty while parquet exists. "
-    "Usually not needed after Refresh symbols."
+    "Only if Charts look empty while data files exist. "
+    "Usually not needed after **Refresh data & forecasts**."
 )
-REFRESH_SEARCH_BUTTON = "Refresh search DB from parquet"
+REFRESH_SEARCH_BUTTON = "Rebuild Charts database"
 
 INCOMPLETE_DATA_MSG = (
     "Market history is incomplete or not ready for: {symbols}. "
@@ -1025,7 +1025,7 @@ def refresh_symbols(
         if blocked is not None:
             return blocked
 
-    messages: list[str] = ["Refresh symbols: gather + catch-up forecast."]
+    messages: list[str] = ["Refresh data & forecasts: gather + catch-up forecast."]
     gather = gather_for_tickers(
         tickers_text,
         include_covariates=include_covariates,

--- a/tests/canswim/test_ux_split_labels.py
+++ b/tests/canswim/test_ux_split_labels.py
@@ -46,6 +46,9 @@ def test_refresh_symbols_help_explains_steps():
     assert "12" in h or "monthly" in h
     assert "charts" in h
     assert "skip" in h
+    # Self-descriptive primary CTA (not vague "Refresh symbols")
+    assert "data" in REFRESH_SYMBOLS_BUTTON.lower()
+    assert "forecast" in REFRESH_SYMBOLS_BUTTON.lower()
 
 
 def test_date_policy_summary_not_technical_dump():
@@ -73,7 +76,7 @@ def test_run_tab_has_separate_gather_and_forecast_controls():
     # Search DB rebuild tucked under More options
     assert "refreshDbBtn" in src
     assert "do_refresh_search_db" in inspect.getsource(run_tab_mod.RunTab)
-    assert "REFRESH_SEARCH_BUTTON" in src or "Refresh search DB" in src
+    assert "REFRESH_SEARCH_BUTTON" in src or "Rebuild Charts" in src
     assert "gatherDetails" in src
     assert "forecastDetails" in src
     assert "open=False" in src
@@ -129,7 +132,7 @@ def test_summary_helpers_are_plain():
     assert "Not ready for forecasts yet (15)" in partial
     assert "What you can do next" in partial
     assert "Recommended" in partial
-    assert "Run forecast" in partial
+    assert "Refresh data" in partial or REFRESH_SYMBOLS_BUTTON in partial
     # Compact lists — not full 20+15 dumped three times
     assert "+10 more" in partial or "…" in partial
     assert partial.count("S00") <= 2  # shown in not-ready once, not thrice


### PR DESCRIPTION
## Summary
- Rename primary CTA to **Refresh data & forecasts** (clearer than “Refresh symbols”)
- **Remove** top-of-page search DB debug banner (paths, row counts, parquet flags)
- Rebuild Charts DB stays under More options with plain-language status
- Keeps step-by-step help for what the primary action does

## Test plan
- [x] ci-local
- [ ] Hard-refresh dashboard: no debug banner; new button label