### PR TITLE
feat: progress bar for Refresh data & forecasts

### DIFF
--- a/src/canswim/dashboard/__init__.py
+++ b/src/canswim/dashboard/__init__.py
@@ -91,7 +91,7 @@ class CanswimPlayground:
                 RunTab(
                     self.canswim_model,
                     db_path=self.db_path,
-                    charts_ticker_dropdown=charts_tab.tickerDropdown,
+                    charts_tab=charts_tab,
                 )
             with gr.Tab("Advanced Queries"):
                 AdvancedTab(

--- a/src/canswim/dashboard/run_tab.py
+++ b/src/canswim/dashboard/run_tab.py
@@ -439,11 +439,22 @@ class RunTab:
                 info=TICKERS_HELP,
             )
             self.refreshBtn = gr.Button(REFRESH_SYMBOLS_BUTTON, variant="primary")
+            self.refreshProgress = gr.Textbox(
+                label="Progress",
+                value="",
+                interactive=False,
+                lines=1,
+                max_lines=2,
+                show_label=True,
+                visible=True,
+                placeholder="Progress updates appear here while a run is active…",
+            )
             self.refreshStatus = gr.Markdown(
                 value=(
                     "_Enter one or more symbols, then click "
                     f"**{REFRESH_SYMBOLS_BUTTON}**. "
-                    "Status appears here when the run finishes._"
+                    "Progress updates while the run is active; "
+                    "a full summary appears when it finishes._"
                 )
             )
             with gr.Accordion("Technical log", open=False):
@@ -522,7 +533,12 @@ class RunTab:
                     )
 
         # ---- wire events ----
-        refresh_outputs = [self.refreshStatus, self.refreshDetails]
+        # progress line + status + log (+ optional Charts dropdown)
+        refresh_outputs = [
+            self.refreshProgress,
+            self.refreshStatus,
+            self.refreshDetails,
+        ]
         if self.charts_ticker_dropdown is not None:
             refresh_outputs.append(self.charts_ticker_dropdown)
         self.refreshBtn.click(
@@ -589,25 +605,80 @@ class RunTab:
         info = resolve_start_for_run(forecast_date or None)
         return _start_summary(info), _json_details(info)
 
-    def do_refresh_symbols(self, tickers_text):
+    def do_refresh_symbols(self, tickers_text, progress=gr.Progress()):
+        """Run refresh with Gradio progress bar + live progress text."""
+
+        def _out(prog_text, status, details, dropdown=None):
+            if self.charts_ticker_dropdown is not None:
+                return prog_text, status, details, dropdown
+            return prog_text, status, details
+
         parsed = parse_ticker_list(tickers_text)
         if not parsed["ok"]:
             status = (
-                f"❌ **Could not refresh symbols.**  \n"
+                f"❌ **Could not start {REFRESH_SYMBOLS_BUTTON}.**  \n"
                 f"{parsed.get('error') or 'Invalid symbols.'}"
             )
             details = _json_details(parsed)
-            if self.charts_ticker_dropdown is not None:
-                return status, details, gr.update()
-            return status, details
+            return _out(
+                "—",
+                status,
+                details,
+                gr.update() if self.charts_ticker_dropdown is not None else None,
+            )
+
+        n = len(parsed["tickers"])
         logger.info(f"Dashboard refresh_symbols for {parsed['tickers']}")
-        result = refresh_symbols(tickers_text, force_allow=True)
+        progress(0.0, desc="Starting…")
+        # Stream an immediate "working" line so the user is not stuck on a timer alone
+        yield _out(
+            f"0% · Starting for {n} symbol(s)…",
+            f"⏳ **Working…**  \n"
+            f"**{REFRESH_SYMBOLS_BUTTON}** for `{', '.join(parsed['tickers'][:12])}`"
+            + (f" +{n - 12} more" if n > 12 else "")
+            + "  \n"
+            "Step 1/2: updating market data (this can take a few minutes).",
+            "",
+            gr.update() if self.charts_ticker_dropdown is not None else None,
+        )
+
+        last_desc = {"text": "Working…"}
+
+        def progress_cb(frac: float, desc: str = "") -> None:
+            pct = int(max(0.0, min(1.0, float(frac))) * 100)
+            label = desc or "Working…"
+            last_desc["text"] = label
+            try:
+                progress(frac, desc=label)
+            except Exception:
+                pass
+
+        try:
+            result = refresh_symbols(
+                tickers_text,
+                force_allow=True,
+                progress_cb=progress_cb,
+            )
+        except Exception as e:
+            logger.exception("refresh_symbols failed")
+            result = {"ok": False, "error": str(e), "tickers": parsed["tickers"]}
+
+        progress(1.0, desc="Done")
         status = _refresh_summary(result)
         details = _json_details(result)
+        final_prog = f"100% · {last_desc['text']}" if result.get("ok") else (
+            f"Stopped · {last_desc['text']}"
+        )
+        if result.get("ok") and not result.get("partial"):
+            final_prog = "100% · Complete"
+        elif result.get("partial"):
+            final_prog = "100% · Finished with partial results"
+
+        dd = None
         if self.charts_ticker_dropdown is not None:
             prefer = result.get("ready") or parsed["tickers"]
-            return status, details, self._charts_dropdown_update(prefer=prefer)
-        return status, details
+            dd = self._charts_dropdown_update(prefer=prefer)
+        yield _out(final_prog, status, details, dd)
 
     def do_gather(self, tickers_text):
         parsed = parse_ticker_list(tickers_text)
@@ -629,7 +700,12 @@ class RunTab:
             return status, details, self._charts_dropdown_update(prefer=prefer)
         return status, details
 
-    def do_forecast(self, tickers_text, forecast_date):
+    def do_forecast(self, tickers_text, forecast_date, progress=gr.Progress()):
+        def _out(status, details, dropdown=None):
+            if self.charts_ticker_dropdown is not None:
+                return status, details, dropdown
+            return status, details
+
         parsed = parse_ticker_list(tickers_text)
         if not parsed["ok"]:
             status = (
@@ -637,9 +713,11 @@ class RunTab:
                 f"{parsed.get('error') or 'Invalid symbols.'}"
             )
             details = _json_details(parsed)
-            if self.charts_ticker_dropdown is not None:
-                return status, details, gr.update()
-            return status, details
+            return _out(
+                status,
+                details,
+                gr.update() if self.charts_ticker_dropdown is not None else None,
+            )
         # catch-up if blank; single origin if date set
         if forecast_date and str(forecast_date).strip():
             start_preview = resolve_start_for_run(forecast_date)
@@ -649,24 +727,38 @@ class RunTab:
                     f"{start_preview.get('error') or ''}"
                 )
                 details = _json_details(start_preview)
-                if self.charts_ticker_dropdown is not None:
-                    return status, details, gr.update()
-                return status, details
+                return _out(
+                    status,
+                    details,
+                    gr.update() if self.charts_ticker_dropdown is not None else None,
+                )
         logger.info(
             f"Dashboard forecast for {parsed['tickers']} "
             f"start={forecast_date or 'catch-up'}"
         )
+
+        def progress_cb(frac: float, desc: str = "") -> None:
+            try:
+                progress(frac, desc=desc or "Forecasting…")
+            except Exception:
+                pass
+
+        progress(0.0, desc="Starting forecast…")
         result = forecast_for_tickers(
             tickers_text,
             forecast_start_date=forecast_date or None,
             force_allow=True,
+            progress_cb=progress_cb,
         )
+        progress(1.0, desc="Done")
         status = _forecast_summary(result)
         details = _json_details(result)
         if self.charts_ticker_dropdown is not None:
             prefer = result.get("forecasted") or parsed["tickers"]
-            return status, details, self._charts_dropdown_update(prefer=prefer)
-        return status, details
+            return _out(
+                status, details, self._charts_dropdown_update(prefer=prefer)
+            )
+        return _out(status, details)
 
     def do_refresh_search_db(self):
         """Rebuild DuckDB search cache from local parquet (full refresh)."""

--- a/src/canswim/dashboard/run_tab.py
+++ b/src/canswim/dashboard/run_tab.py
@@ -395,8 +395,8 @@ def _refresh_summary(result: dict) -> str:
         lines.append("Forecasts were already up to date for ready symbols.")
     lines.append("**What you can do next**")
     lines.append(
-        "1. **Recommended:** Open **Charts** for a symbol, or **Scans** to rank "
-        "by reward/risk and backtest history."
+        "1. **Recommended:** Open **Charts** (already refreshed for the first "
+        "ready symbol) or **Scans** to rank by reward/risk and backtest history."
     )
     if incomplete:
         lines.append(
@@ -421,11 +421,18 @@ class RunTab:
         canswim_model=None,
         db_path=None,
         charts_ticker_dropdown=None,
+        charts_tab=None,
         db_status_banner=None,  # unused; kept for call-site compatibility
     ):
         self.canswim_model = canswim_model
         self.db_path = db_path
-        self.charts_ticker_dropdown = charts_ticker_dropdown
+        # Prefer full charts_tab (replot after refresh); fallback to dropdown only
+        self.charts_tab = charts_tab
+        self.charts_ticker_dropdown = (
+            charts_tab.tickerDropdown
+            if charts_tab is not None
+            else charts_ticker_dropdown
+        )
         self.db_status_banner = None  # no global debug banner
 
         # ---- Primary path only (everything else under More options) ----
@@ -533,7 +540,8 @@ class RunTab:
                     )
 
         # ---- wire events ----
-        # progress line + status + log (+ optional Charts dropdown)
+        # progress + status + log (+ Charts dropdown + replot when charts_tab given)
+        refresh_inputs = [self.refreshTickers]
         refresh_outputs = [
             self.refreshProgress,
             self.refreshStatus,
@@ -541,18 +549,37 @@ class RunTab:
         ]
         if self.charts_ticker_dropdown is not None:
             refresh_outputs.append(self.charts_ticker_dropdown)
+        if self.charts_tab is not None:
+            refresh_inputs.append(self.charts_tab.lowq)
+            refresh_outputs.extend(
+                [
+                    self.charts_tab.plotComponent,
+                    self.charts_tab.rrTable,
+                    self.charts_tab.companyInfo,
+                ]
+            )
         self.refreshBtn.click(
             fn=self.do_refresh_symbols,
-            inputs=[self.refreshTickers],
+            inputs=refresh_inputs,
             outputs=refresh_outputs,
         )
 
+        gather_inputs = [self.gatherTickers]
         gather_outputs = [self.gatherStatus, self.gatherDetails]
         if self.charts_ticker_dropdown is not None:
             gather_outputs.append(self.charts_ticker_dropdown)
+        if self.charts_tab is not None:
+            gather_inputs.append(self.charts_tab.lowq)
+            gather_outputs.extend(
+                [
+                    self.charts_tab.plotComponent,
+                    self.charts_tab.rrTable,
+                    self.charts_tab.companyInfo,
+                ]
+            )
         self.gatherBtn.click(
             fn=self.do_gather,
-            inputs=[self.gatherTickers],
+            inputs=gather_inputs,
             outputs=gather_outputs,
         )
         self.resolveBtn.click(
@@ -560,21 +587,43 @@ class RunTab:
             inputs=[self.forecastDate],
             outputs=[self.forecastStatus, self.forecastDetails],
         )
+        forecast_inputs = [self.forecastTickers, self.forecastDate]
         forecast_outputs = [self.forecastStatus, self.forecastDetails]
         if self.charts_ticker_dropdown is not None:
             forecast_outputs.append(self.charts_ticker_dropdown)
+        if self.charts_tab is not None:
+            forecast_inputs.append(self.charts_tab.lowq)
+            forecast_outputs.extend(
+                [
+                    self.charts_tab.plotComponent,
+                    self.charts_tab.rrTable,
+                    self.charts_tab.companyInfo,
+                ]
+            )
         self.forecastBtn.click(
             fn=self.do_forecast,
-            inputs=[self.forecastTickers, self.forecastDate],
+            inputs=forecast_inputs,
             outputs=forecast_outputs,
         )
 
+        db_refresh_inputs = []
         db_refresh_outputs = [self.refreshDbStatus, self.refreshDbDetails]
         if self.charts_ticker_dropdown is not None:
             db_refresh_outputs.append(self.charts_ticker_dropdown)
+        if self.charts_tab is not None:
+            db_refresh_inputs.append(self.charts_tab.lowq)
+            # Need current dropdown value for replot after rebuild
+            db_refresh_inputs.append(self.charts_tab.tickerDropdown)
+            db_refresh_outputs.extend(
+                [
+                    self.charts_tab.plotComponent,
+                    self.charts_tab.rrTable,
+                    self.charts_tab.companyInfo,
+                ]
+            )
         self.refreshDbBtn.click(
             fn=self.do_refresh_search_db,
-            inputs=[],
+            inputs=db_refresh_inputs,
             outputs=db_refresh_outputs,
         )
 
@@ -601,18 +650,88 @@ class RunTab:
             logger.warning(f"Could not refresh Charts dropdown: {e}")
             return gr.update()
 
+    def _replot_charts(self, prefer=None, lowq=80):
+        """Force Charts plot/RR/company to reload after data changes.
+
+        Gradio does not re-fire dropdown.change when value stays the same, so
+        switching back to Charts after a Run-tab refresh would show a stale chart.
+        """
+        if self.charts_tab is None:
+            return ()
+        prefer_list = [
+            str(p).strip().upper()
+            for p in (prefer or [])
+            if p and str(p).strip()
+        ]
+        ticker = None
+        try:
+            choices = list_tickers(self.db_path) if self.db_path else []
+            choice_set = set(choices)
+            for p in prefer_list:
+                if p in choice_set:
+                    ticker = p
+                    break
+            if ticker is None and choices:
+                ticker = choices[0]
+            if ticker is None and prefer_list:
+                ticker = prefer_list[0]
+        except Exception:
+            ticker = prefer_list[0] if prefer_list else None
+        if not ticker:
+            return gr.update(), gr.update(), gr.update()
+        try:
+            lowq_i = int(lowq) if lowq is not None else 80
+        except (TypeError, ValueError):
+            lowq_i = 80
+        try:
+            out = self.charts_tab.plot_forecast(ticker, lowq_i)
+            if isinstance(out, dict):
+                return (
+                    out.get(self.charts_tab.plotComponent),
+                    out.get(self.charts_tab.rrTable),
+                    out.get(self.charts_tab.companyInfo)
+                    or self.charts_tab._company_md(ticker),
+                )
+            company = (
+                out[2]
+                if len(out) > 2
+                else self.charts_tab._company_md(ticker)
+            )
+            return out[0], out[1], company
+        except Exception as e:
+            logger.warning(f"Charts replot after Run action failed: {e}")
+            return gr.update(), gr.update(), gr.update()
+
+    def _pack_run_outputs(
+        self,
+        *core,
+        prefer=None,
+        lowq=80,
+        replot: bool = False,
+        dropdown_update=None,
+    ):
+        """Append optional dropdown + chart replot outputs for wired handlers."""
+        outs = list(core)
+        if self.charts_ticker_dropdown is not None:
+            if dropdown_update is not None:
+                outs.append(dropdown_update)
+            elif replot or prefer is not None:
+                outs.append(self._charts_dropdown_update(prefer=prefer))
+            else:
+                outs.append(gr.update())
+        if self.charts_tab is not None:
+            if replot:
+                outs.extend(self._replot_charts(prefer=prefer, lowq=lowq))
+            else:
+                outs.extend((gr.update(), gr.update(), gr.update()))
+        return tuple(outs)
+
     def preview_start(self, forecast_date):
         info = resolve_start_for_run(forecast_date or None)
         return _start_summary(info), _json_details(info)
 
-    def do_refresh_symbols(self, tickers_text, progress=gr.Progress()):
-        """Run refresh with Gradio progress bar + live progress text."""
-
-        def _out(prog_text, status, details, dropdown=None):
-            if self.charts_ticker_dropdown is not None:
-                return prog_text, status, details, dropdown
-            return prog_text, status, details
-
+    def do_refresh_symbols(self, tickers_text, lowq=80, progress=gr.Progress()):
+        """Run refresh with Gradio progress bar + live progress text + Charts replot."""
         parsed = parse_ticker_list(tickers_text)
         if not parsed["ok"]:
             status = (
@@ -620,18 +739,15 @@ class RunTab:
                 f"{parsed.get('error') or 'Invalid symbols.'}"
             )
             details = _json_details(parsed)
-            return _out(
-                "—",
-                status,
-                details,
-                gr.update() if self.charts_ticker_dropdown is not None else None,
+            return self._pack_run_outputs(
+                "—", status, details, replot=False
             )
 
         n = len(parsed["tickers"])
         logger.info(f"Dashboard refresh_symbols for {parsed['tickers']}")
         progress(0.0, desc="Starting…")
         # Stream an immediate "working" line so the user is not stuck on a timer alone
-        yield _out(
+        yield self._pack_run_outputs(
             f"0% · Starting for {n} symbol(s)…",
             f"⏳ **Working…**  \n"
             f"**{REFRESH_SYMBOLS_BUTTON}** for `{', '.join(parsed['tickers'][:12])}`"
@@ -639,13 +755,12 @@ class RunTab:
             + "  \n"
             "Step 1/2: updating market data (this can take a few minutes).",
             "",
-            gr.update() if self.charts_ticker_dropdown is not None else None,
+            replot=False,
         )
 
         last_desc = {"text": "Working…"}
 
         def progress_cb(frac: float, desc: str = "") -> None:
-            pct = int(max(0.0, min(1.0, float(frac))) * 100)
             label = desc or "Working…"
             last_desc["text"] = label
             try:
@@ -666,21 +781,25 @@ class RunTab:
         progress(1.0, desc="Done")
         status = _refresh_summary(result)
         details = _json_details(result)
-        final_prog = f"100% · {last_desc['text']}" if result.get("ok") else (
-            f"Stopped · {last_desc['text']}"
-        )
         if result.get("ok") and not result.get("partial"):
             final_prog = "100% · Complete"
         elif result.get("partial"):
             final_prog = "100% · Finished with partial results"
+        else:
+            final_prog = f"Stopped · {last_desc['text']}"
 
-        dd = None
-        if self.charts_ticker_dropdown is not None:
-            prefer = result.get("ready") or parsed["tickers"]
-            dd = self._charts_dropdown_update(prefer=prefer)
-        yield _out(final_prog, status, details, dd)
+        prefer = result.get("ready") or result.get("forecasted") or parsed["tickers"]
+        # Replot so Charts tab shows new forecasts without re-selecting the symbol
+        yield self._pack_run_outputs(
+            final_prog,
+            status,
+            details,
+            prefer=prefer,
+            lowq=lowq,
+            replot=True,
+        )
 
-    def do_gather(self, tickers_text):
+    def do_gather(self, tickers_text, lowq=80):
         parsed = parse_ticker_list(tickers_text)
         if not parsed["ok"]:
             status = (
@@ -688,24 +807,17 @@ class RunTab:
                 f"{parsed.get('error') or 'Invalid symbols.'}"
             )
             details = _json_details(parsed)
-            if self.charts_ticker_dropdown is not None:
-                return status, details, gr.update()
-            return status, details
+            return self._pack_run_outputs(status, details, replot=False)
         logger.info(f"Dashboard gather for {parsed['tickers']}")
         result = gather_for_tickers(tickers_text, force_allow=True)
         status = _gather_summary(result)
         details = _json_details(result)
-        if self.charts_ticker_dropdown is not None:
-            prefer = result.get("ready") or parsed["tickers"]
-            return status, details, self._charts_dropdown_update(prefer=prefer)
-        return status, details
+        prefer = result.get("ready") or parsed["tickers"]
+        return self._pack_run_outputs(
+            status, details, prefer=prefer, lowq=lowq, replot=True
+        )
 
-    def do_forecast(self, tickers_text, forecast_date, progress=gr.Progress()):
-        def _out(status, details, dropdown=None):
-            if self.charts_ticker_dropdown is not None:
-                return status, details, dropdown
-            return status, details
-
+    def do_forecast(self, tickers_text, forecast_date, lowq=80, progress=gr.Progress()):
         parsed = parse_ticker_list(tickers_text)
         if not parsed["ok"]:
             status = (
@@ -713,11 +825,7 @@ class RunTab:
                 f"{parsed.get('error') or 'Invalid symbols.'}"
             )
             details = _json_details(parsed)
-            return _out(
-                status,
-                details,
-                gr.update() if self.charts_ticker_dropdown is not None else None,
-            )
+            return self._pack_run_outputs(status, details, replot=False)
         # catch-up if blank; single origin if date set
         if forecast_date and str(forecast_date).strip():
             start_preview = resolve_start_for_run(forecast_date)
@@ -727,11 +835,7 @@ class RunTab:
                     f"{start_preview.get('error') or ''}"
                 )
                 details = _json_details(start_preview)
-                return _out(
-                    status,
-                    details,
-                    gr.update() if self.charts_ticker_dropdown is not None else None,
-                )
+                return self._pack_run_outputs(status, details, replot=False)
         logger.info(
             f"Dashboard forecast for {parsed['tickers']} "
             f"start={forecast_date or 'catch-up'}"
@@ -753,19 +857,17 @@ class RunTab:
         progress(1.0, desc="Done")
         status = _forecast_summary(result)
         details = _json_details(result)
-        if self.charts_ticker_dropdown is not None:
-            prefer = result.get("forecasted") or parsed["tickers"]
-            return _out(
-                status, details, self._charts_dropdown_update(prefer=prefer)
-            )
-        return _out(status, details)
+        prefer = result.get("forecasted") or parsed["tickers"]
+        return self._pack_run_outputs(
+            status, details, prefer=prefer, lowq=lowq, replot=True
+        )
 
-    def do_refresh_search_db(self):
+    def do_refresh_search_db(self, lowq=80, current_ticker=None):
         """Rebuild DuckDB search cache from local parquet (full refresh)."""
         if not self.db_path:
             status = "❌ **No database path configured.**"
             details = _json_details({"ok": False, "error": "db_path missing"})
-            return self._refresh_outputs(status, details, dropdown=False)
+            return self._pack_run_outputs(status, details, replot=False)
 
         target_col = "Close"
         if self.canswim_model is not None:
@@ -800,12 +902,7 @@ class RunTab:
             )
             details = _json_details(result)
 
-        return self._refresh_outputs(status, details, dropdown=True)
-
-    def _refresh_outputs(self, status, details, banner=None, *, dropdown: bool):
-        outs = [status, details]
-        if self.charts_ticker_dropdown is not None:
-            outs.append(
-                self._charts_dropdown_update() if dropdown else gr.update()
-            )
-        return tuple(outs)
+        prefer = [current_ticker] if current_ticker else None
+        return self._pack_run_outputs(
+            status, details, prefer=prefer, lowq=lowq, replot=True
+        )

--- a/src/canswim/run_triggers.py
+++ b/src/canswim/run_triggers.py
@@ -21,7 +21,10 @@ import os
 import re
 import tempfile
 from pathlib import Path
-from typing import Any, Optional, Sequence, Union
+from typing import Any, Callable, Optional, Sequence, Union
+
+# fraction in [0, 1], human-readable desc for UI progress bars
+ProgressCb = Optional[Callable[[float, str], None]]
 
 import pandas as pd
 from loguru import logger
@@ -133,6 +136,15 @@ def default_catchup_months() -> int:
     except (TypeError, ValueError):
         n = DEFAULT_CATCHUP_MONTHS
     return max(1, min(36, n))
+
+
+def _report_progress(cb: ProgressCb, fraction: float, desc: str = "") -> None:
+    if cb is None:
+        return
+    try:
+        cb(max(0.0, min(1.0, float(fraction))), str(desc or ""))
+    except Exception:
+        pass
 
 
 def _cap_start_to_local_prices(
@@ -626,6 +638,7 @@ def forecast_for_tickers(
     force_allow: bool = False,
     dry_run: bool = False,
     catchup_months: Optional[int] = None,
+    progress_cb: ProgressCb = None,
 ) -> dict[str, Any]:
     """Run forecast for an explicit ticker list.
 
@@ -635,12 +648,14 @@ def forecast_for_tickers(
     * **Explicit start date** → single week-aligned origin (existing behavior).
 
     ``dry_run=True`` only resolves origins + which partitions exist (no torch).
+    ``progress_cb(fraction, desc)`` optional UI progress (0..1).
     """
     if not force_allow:
         blocked = require_runs_allowed()
         if blocked is not None:
             return blocked
 
+    _report_progress(progress_cb, 0.0, "Planning forecast starts…")
     parsed = parse_ticker_list(tickers_text, max_tickers=max_tickers)
     if not parsed["ok"]:
         return {
@@ -750,6 +765,9 @@ def forecast_for_tickers(
         }
 
     if not any_to_run:
+        _report_progress(
+            progress_cb, 0.9, "All starts already on file — updating Charts…"
+        )
         try:
             from canswim.db import (
                 ensure_symbols_in_search_db,
@@ -770,6 +788,7 @@ def forecast_for_tickers(
                 )
         except Exception as e:
             messages.append(f"Charts forecast sync note: {e}")
+        _report_progress(progress_cb, 1.0, "Already up to date.")
         return {
             "ok": True,
             "mode": mode,
@@ -792,9 +811,15 @@ def forecast_for_tickers(
     need_any = sorted(
         {t for v in by_start.values() for t in v["to_run"]}
     )
+    n_starts_todo = sum(1 for v in by_start.values() if v["to_run"])
     messages.append(
         f"Will forecast {len(need_any)} symbol(s) across "
-        f"{sum(1 for v in by_start.values() if v['to_run'])} start(s)."
+        f"{n_starts_todo} start(s)."
+    )
+    _report_progress(
+        progress_cb,
+        0.05,
+        f"Loading model — {n_starts_todo} forecast start(s) to run…",
     )
 
     data_dir = os.getenv("data_dir", "data")
@@ -854,12 +879,24 @@ def forecast_for_tickers(
         cf.download_model()
         cf.download_data()
         model_loaded = True
+        _report_progress(progress_cb, 0.12, "Model ready — running forecasts…")
 
+        starts_done = 0
         for o in origins:
             plan = by_start[o]
             to_run = list(plan["to_run"])
             if not to_run:
                 continue
+            starts_done += 1
+            frac = 0.12 + 0.75 * (starts_done - 1) / max(n_starts_todo, 1)
+            sym_hint = ", ".join(to_run[:4]) + (
+                f" +{len(to_run) - 4}" if len(to_run) > 4 else ""
+            )
+            _report_progress(
+                progress_cb,
+                frac,
+                f"Forecast {starts_done}/{n_starts_todo}: start {o} ({sym_hint})…",
+            )
             pd.DataFrame({"Symbol": to_run}).to_csv(dest_list, index=False)
             os.environ["n_stocks"] = str(max(len(to_run), 1))
             # Forecaster caches symbol list from env at load — set stocks on model if present
@@ -912,6 +949,11 @@ def forecast_for_tickers(
                     f"Start {o}: new={len(forecasted_o)}, "
                     f"already={len(plan['already'])}."
                 )
+            _report_progress(
+                progress_cb,
+                0.12 + 0.75 * starts_done / max(n_starts_todo, 1),
+                f"Finished start {starts_done}/{n_starts_todo} ({o}).",
+            )
 
         try:
             cf.upload_data()
@@ -933,6 +975,7 @@ def forecast_for_tickers(
             )
 
         # Push parquet → DuckDB (+ backtest_error refresh) and Charts symbol list
+        _report_progress(progress_cb, 0.92, "Updating Charts / Scans database…")
         try:
             from canswim.db import (
                 ensure_symbols_in_search_db,
@@ -954,6 +997,8 @@ def forecast_for_tickers(
                 )
         except Exception as e:
             messages.append(f"Charts forecast sync note: {e}")
+
+        _report_progress(progress_cb, 1.0, "Forecast complete.")
 
         ok = len(incomplete) == 0
         out: dict[str, Any] = {
@@ -1025,10 +1070,12 @@ def refresh_symbols(
     force_allow: bool = False,
     catchup_months: Optional[int] = None,
     dry_run: bool = False,
+    progress_cb: ProgressCb = None,
 ) -> dict[str, Any]:
     """All-in-one: gather market data, then catch-up forecasts for ready symbols.
 
     Primary path for “refresh my portfolio / new symbol” (GUI, MCP, CLI).
+    ``progress_cb(fraction, desc)`` optional UI progress (0..1).
     """
     if not force_allow:
         blocked = require_runs_allowed()
@@ -1036,6 +1083,9 @@ def refresh_symbols(
             return blocked
 
     messages: list[str] = ["Refresh data & forecasts: gather + catch-up forecast."]
+    _report_progress(
+        progress_cb, 0.02, "Step 1/2: updating market data…"
+    )
     gather = gather_for_tickers(
         tickers_text,
         include_covariates=include_covariates,
@@ -1067,6 +1117,7 @@ def refresh_symbols(
         )
         out["ok"] = False
         out["need_gather"] = True
+        _report_progress(progress_cb, 1.0, "Stopped — no forecast-ready symbols.")
         return out
 
     if dry_run:
@@ -1077,6 +1128,7 @@ def refresh_symbols(
             dry_run=True,
             catchup_months=catchup_months,
             max_tickers=max_tickers,
+            progress_cb=progress_cb,
         )
         out["forecast"] = fc
         out["ok"] = True
@@ -1086,6 +1138,16 @@ def refresh_symbols(
         )
         return out
 
+    _report_progress(
+        progress_cb,
+        0.28,
+        f"Step 2/2: catch-up forecasts for {len(ready)} symbol(s)…",
+    )
+
+    def _fc_progress(frac: float, desc: str = "") -> None:
+        # Map forecast 0..1 into overall 0.28..0.98
+        _report_progress(progress_cb, 0.28 + 0.70 * float(frac), desc)
+
     fc = forecast_for_tickers(
         ready,
         forecast_start_date=None,
@@ -1093,6 +1155,7 @@ def refresh_symbols(
         dry_run=False,
         catchup_months=catchup_months,
         max_tickers=max_tickers,
+        progress_cb=_fc_progress,
     )
     out["forecast"] = fc
     out["ok"] = bool(fc.get("ok")) or bool(fc.get("partial") and fc.get("forecasted"))
@@ -1103,6 +1166,8 @@ def refresh_symbols(
         )
     if not out["ok"]:
         out["error"] = fc.get("error") or gather.get("error") or "Refresh incomplete."
+        _report_progress(progress_cb, 1.0, "Finished with errors.")
     else:
         out["messages"].append("Refresh finished for forecast-ready symbols.")
+        _report_progress(progress_cb, 1.0, "Refresh data & forecasts complete.")
     return out

--- a/tests/canswim/test_run_triggers.py
+++ b/tests/canswim/test_run_triggers.py
@@ -203,6 +203,43 @@ def test_refresh_symbols_calls_gather_then_forecast(monkeypatch):
     )
 
 
+def test_refresh_symbols_progress_callback(monkeypatch):
+    monkeypatch.setenv("MCP_ALLOW_RUNS", "1")
+    seen: list[tuple[float, str]] = []
+
+    def _cb(frac: float, desc: str = "") -> None:
+        seen.append((frac, desc))
+
+    with patch(
+        "canswim.run_triggers.gather_for_tickers",
+        return_value={
+            "ok": True,
+            "tickers": ["AAPL"],
+            "ready": ["AAPL"],
+            "incomplete": [],
+            "messages": [],
+        },
+    ):
+        with patch(
+            "canswim.run_triggers.forecast_for_tickers",
+            return_value={
+                "ok": True,
+                "mode": "catchup",
+                "tickers": ["AAPL"],
+                "forecasted": ["AAPL"],
+                "origins": ["2026-07-13"],
+                "messages": [],
+            },
+        ) as f:
+            r = refresh_symbols("AAPL", force_allow=True, progress_cb=_cb)
+    assert r["ok"] is True
+    assert seen, "progress_cb should be invoked"
+    assert seen[0][0] < seen[-1][0] or seen[-1][0] == 1.0
+    assert any("market data" in d.lower() for _, d in seen)
+    # progress_cb forwarded into forecast
+    assert f.call_args.kwargs.get("progress_cb") is not None
+
+
 def test_forecast_passes_resolved_start_to_forecaster(monkeypatch):
     monkeypatch.setenv("MCP_ALLOW_RUNS", "1")
     monkeypatch.setenv("data_dir", "/tmp/canswim_test_data_unused")

--- a/tests/canswim/test_ux_split_labels.py
+++ b/tests/canswim/test_ux_split_labels.py
@@ -65,6 +65,10 @@ def test_run_tab_has_separate_gather_and_forecast_controls():
     assert "refreshProgress" in src
     assert "do_refresh_symbols" in inspect.getsource(run_tab_mod.RunTab)
     assert "gr.Progress" in inspect.getsource(run_tab_mod.RunTab)
+    # After refresh, Charts plot must be re-rendered (same-symbol case)
+    run_src = inspect.getsource(run_tab_mod.RunTab)
+    assert "_replot_charts" in run_src
+    assert "charts_tab" in src
     # Secondary still present but under collapsed "More options"
     assert "More options" in src
     assert "gatherTickers" in src

--- a/tests/canswim/test_ux_split_labels.py
+++ b/tests/canswim/test_ux_split_labels.py
@@ -59,10 +59,12 @@ def test_date_policy_summary_not_technical_dump():
 
 def test_run_tab_has_separate_gather_and_forecast_controls():
     src = inspect.getsource(run_tab_mod.RunTab.__init__)
-    # Primary path: Refresh symbols
+    # Primary path: Refresh data & forecasts + progress line
     assert "refreshBtn" in src or "refreshTickers" in src
     assert "REFRESH_SYMBOLS" in src or REFRESH_SYMBOLS_BUTTON in src
+    assert "refreshProgress" in src
     assert "do_refresh_symbols" in inspect.getsource(run_tab_mod.RunTab)
+    assert "gr.Progress" in inspect.getsource(run_tab_mod.RunTab)
     # Secondary still present but under collapsed "More options"
     assert "More options" in src
     assert "gatherTickers" in src


### PR DESCRIPTION
## Summary
Long refreshes only showed a timer. Now:
- Gradio **progress bar** with descriptive steps
- **Progress** text under the button (`28% · Forecast 3/13: start 2025-06-02…`)
- Immediate “Working…” status on click
- Wired through gather → multi-origin catch-up → Charts sync

## Test plan
- [x] ci-local
- [ ] Run **Refresh data & forecasts** for 1–2 symbols and watch progress line update