### PR TITLE
release: 0.0.20260714 operator UX + MCP progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 All notable releases are documented here. Versioning follows date-style `0.0.YYYYMMDD` unless noted.
 
+## 0.0.20260714
+
+Operator UX and data-refresh wave on top of 0.0.20260713 (Run tab, catch-up forecasts, MCP schema/SQL, progress).
+
+### Highlights
+
+- **Refresh data & forecasts** — all-in-one gather + ~12 monthly catch-up origins + live (GUI · CLI · MCP `refresh_tickers`)
+- **Run tab** — one primary path; short help + “What this does” accordion; single progress bar; Charts replot after refresh
+- **Charts universe** — dropdown from CSV ∪ price parquet ∪ forecast hive (not `few_stocks` only); symbols added after refresh
+- **Search DB handshake** — rebuild Charts/Scans DuckDB from parquet when needed
+- **MCP** — `get_db_schema` + hardened read-only `run_select`; **live progress streaming** (`notifications/progress` + info logs) on `refresh_tickers` / `forecast_tickers` / `gather_tickers`
+- **Cross-tab Gradio fix** — Run handlers no longer depend on Charts-tab inputs (fixes hard Error toast on refresh)
+- **Gather status UX** — multi-bucket ready / short-history / IPO messaging
+
+### Requirements for end users
+
+- Python ≥ 3.10
+- Optional but typical: **FMP API key** for fundamentals, ownership, estimates, and company profiles
+- Default model checkpoint on **Hugging Face** (public; swappable)
+- Local disk for parquet + DuckDB under `data/`
+
+**NOT FINANCIAL OR INVESTMENT ADVICE. USE AT YOUR OWN RISK.**
+
+### Install
+
+```bash
+pip install canswim==0.0.20260714
+python -m canswim -h
+python -m canswim dashboard --same_data True
+python -m canswim mcp
+```
+
 ## 0.0.20260713
 
 Stability and quality release on top of the 0.0.20260711 operator toolkit (GUI / MCP / scoped gather·forecast).

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Flags: `python -m canswim -h` is the source of truth. Local site preview: `pip i
 
 ```bash
 pip install canswim
-# pin a release: pip install canswim==0.0.20260713
+# pin a release: pip install canswim==0.0.20260714
 
 # dev checkout
 pip install -e ".[dev]"

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -76,6 +76,19 @@ Canonical registration: `src/canswim/mcp/server.py`. Update this table in the **
 | `forecast_tickers` | Scoped forecast; blank start = monthly catch-up + live | `MCP_ALLOW_RUNS=1` |
 | `refresh_tickers` | Gather + catch-up forecast (≡ dashboard **Refresh data & forecasts**) | `MCP_ALLOW_RUNS=1` |
 
+### Progress streaming (long runs)
+
+`refresh_tickers`, `forecast_tickers`, and `gather_tickers` stream **live progress** while they run:
+
+| Channel | When the client sees it |
+|---------|-------------------------|
+| MCP `notifications/progress` | Client includes a `progressToken` in the tool call request meta (standard MCP progress protocol). Values are **0–100** with `total=100` and a human `message` (e.g. “Step 2/2: catch-up forecasts…”, origin/symbol stages). |
+| MCP log (`info`) | Same stage messages, when the client supports logging notifications. |
+
+Progress is the **same pipeline** as the dashboard Run-tab bar (`run_triggers` → `progress_cb`). Work runs off the MCP event loop so notifications can flush mid-run. Final tool result is still the usual `{ok, data|error}` payload when the job finishes.
+
+Clients that omit `progressToken` get only the final result (no error).
+
 ### Custom SQL (read-only)
 
 1. Call **`get_db_schema`** so the client AI sees tables, types, and indexes.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = canswim
-version = 0.0.20260713
+version = 0.0.20260714
 author = Ivelin Ivanov
 author_email = ivelin117@gmail.com
 description = Developer toolkit for CANSLIM-style investors (CLI, Gradio GUI, MCP)

--- a/src/canswim/dashboard/run_tab.py
+++ b/src/canswim/dashboard/run_tab.py
@@ -29,6 +29,7 @@ from canswim.run_triggers import (
     REFRESH_SEARCH_SECTION_HELP,
     REFRESH_SEARCH_SECTION_TITLE,
     REFRESH_SYMBOLS_BUTTON,
+    REFRESH_SYMBOLS_SECTION_DETAILS,
     REFRESH_SYMBOLS_SECTION_HELP,
     REFRESH_SYMBOLS_SECTION_TITLE,
     TICKERS_HELP,
@@ -439,29 +440,21 @@ class RunTab:
         with gr.Group():
             gr.Markdown(f"### {REFRESH_SYMBOLS_SECTION_TITLE}")
             gr.Markdown(REFRESH_SYMBOLS_SECTION_HELP.strip())
+            with gr.Accordion("What this does", open=False):
+                gr.Markdown(REFRESH_SYMBOLS_SECTION_DETAILS.strip())
             self.refreshTickers = gr.Textbox(
                 label="Symbols to refresh",
-                lines=2,
+                lines=1,
+                max_lines=3,
                 placeholder="LLY, AAPL, MSFT",
                 info=TICKERS_HELP,
             )
             self.refreshBtn = gr.Button(REFRESH_SYMBOLS_BUTTON, variant="primary")
-            self.refreshProgress = gr.Textbox(
-                label="Progress",
-                value="",
-                interactive=False,
-                lines=1,
-                max_lines=2,
-                show_label=True,
-                visible=True,
-                placeholder="Progress updates appear here while a run is active…",
-            )
+            # Single progress UI: gr.Progress() on the handler (no separate Progress textbox —
+            # that doubled the bar with Gradio's built-in progress).
             self.refreshStatus = gr.Markdown(
                 value=(
-                    "_Enter one or more symbols, then click "
-                    f"**{REFRESH_SYMBOLS_BUTTON}**. "
-                    "Progress updates while the run is active; "
-                    "a full summary appears when it finishes._"
+                    f"_Enter symbols, then **{REFRESH_SYMBOLS_BUTTON}**._"
                 )
             )
             with gr.Accordion("Technical log", open=False):
@@ -540,17 +533,17 @@ class RunTab:
                     )
 
         # ---- wire events ----
-        # progress + status + log (+ Charts dropdown + replot when charts_tab given)
-        refresh_inputs = [self.refreshTickers]
+        # IMPORTANT: do NOT take Charts-tab widgets as *inputs* here.
+        # Cross-tab inputs are not delivered by Gradio (handler gets fewer
+        # values than declared → hard Error toast; refresh never runs).
+        # Replot uses default confidence (80) via handler defaults.
         refresh_outputs = [
-            self.refreshProgress,
             self.refreshStatus,
             self.refreshDetails,
         ]
         if self.charts_ticker_dropdown is not None:
             refresh_outputs.append(self.charts_ticker_dropdown)
         if self.charts_tab is not None:
-            refresh_inputs.append(self.charts_tab.lowq)
             refresh_outputs.extend(
                 [
                     self.charts_tab.plotComponent,
@@ -560,16 +553,16 @@ class RunTab:
             )
         self.refreshBtn.click(
             fn=self.do_refresh_symbols,
-            inputs=refresh_inputs,
+            inputs=[self.refreshTickers],
             outputs=refresh_outputs,
+            # One progress chrome only (handler uses gr.Progress for %).
+            show_progress="full",
         )
 
-        gather_inputs = [self.gatherTickers]
         gather_outputs = [self.gatherStatus, self.gatherDetails]
         if self.charts_ticker_dropdown is not None:
             gather_outputs.append(self.charts_ticker_dropdown)
         if self.charts_tab is not None:
-            gather_inputs.append(self.charts_tab.lowq)
             gather_outputs.extend(
                 [
                     self.charts_tab.plotComponent,
@@ -579,20 +572,19 @@ class RunTab:
             )
         self.gatherBtn.click(
             fn=self.do_gather,
-            inputs=gather_inputs,
+            inputs=[self.gatherTickers],
             outputs=gather_outputs,
+            show_progress="full",
         )
         self.resolveBtn.click(
             fn=self.preview_start,
             inputs=[self.forecastDate],
             outputs=[self.forecastStatus, self.forecastDetails],
         )
-        forecast_inputs = [self.forecastTickers, self.forecastDate]
         forecast_outputs = [self.forecastStatus, self.forecastDetails]
         if self.charts_ticker_dropdown is not None:
             forecast_outputs.append(self.charts_ticker_dropdown)
         if self.charts_tab is not None:
-            forecast_inputs.append(self.charts_tab.lowq)
             forecast_outputs.extend(
                 [
                     self.charts_tab.plotComponent,
@@ -602,18 +594,15 @@ class RunTab:
             )
         self.forecastBtn.click(
             fn=self.do_forecast,
-            inputs=forecast_inputs,
+            inputs=[self.forecastTickers, self.forecastDate],
             outputs=forecast_outputs,
+            show_progress="full",
         )
 
-        db_refresh_inputs = []
         db_refresh_outputs = [self.refreshDbStatus, self.refreshDbDetails]
         if self.charts_ticker_dropdown is not None:
             db_refresh_outputs.append(self.charts_ticker_dropdown)
         if self.charts_tab is not None:
-            db_refresh_inputs.append(self.charts_tab.lowq)
-            # Need current dropdown value for replot after rebuild
-            db_refresh_inputs.append(self.charts_tab.tickerDropdown)
             db_refresh_outputs.extend(
                 [
                     self.charts_tab.plotComponent,
@@ -623,8 +612,9 @@ class RunTab:
             )
         self.refreshDbBtn.click(
             fn=self.do_refresh_search_db,
-            inputs=db_refresh_inputs,
+            inputs=[],
             outputs=db_refresh_outputs,
+            show_progress="full",
         )
 
     def _charts_dropdown_update(self, prefer=None):
@@ -730,8 +720,20 @@ class RunTab:
         info = resolve_start_for_run(forecast_date or None)
         return _start_summary(info), _json_details(info)
 
-    def do_refresh_symbols(self, tickers_text, lowq=80, progress=gr.Progress()):
-        """Run refresh with Gradio progress bar + live progress text + Charts replot."""
+    def _charts_lowq_default(self) -> int:
+        """Confidence for post-run replot without reading Charts-tab inputs.
+
+        Cross-tab Gradio inputs are unreliable; default matches Charts Radio.
+        """
+        return 80
+
+    def do_refresh_symbols(self, tickers_text, progress=gr.Progress()):
+        """Run refresh with a single Gradio progress bar + Charts replot on finish.
+
+        Not a generator: intermediate yields + gr.Progress both draw bars (double UI).
+        Live % comes only from ``progress``; status/details update once at the end.
+        """
+        lowq = self._charts_lowq_default()
         parsed = parse_ticker_list(tickers_text)
         if not parsed["ok"]:
             status = (
@@ -739,32 +741,14 @@ class RunTab:
                 f"{parsed.get('error') or 'Invalid symbols.'}"
             )
             details = _json_details(parsed)
-            return self._pack_run_outputs(
-                "—", status, details, replot=False
-            )
+            return self._pack_run_outputs(status, details, replot=False)
 
-        n = len(parsed["tickers"])
         logger.info(f"Dashboard refresh_symbols for {parsed['tickers']}")
         progress(0.0, desc="Starting…")
-        # Stream an immediate "working" line so the user is not stuck on a timer alone
-        yield self._pack_run_outputs(
-            f"0% · Starting for {n} symbol(s)…",
-            f"⏳ **Working…**  \n"
-            f"**{REFRESH_SYMBOLS_BUTTON}** for `{', '.join(parsed['tickers'][:12])}`"
-            + (f" +{n - 12} more" if n > 12 else "")
-            + "  \n"
-            "Step 1/2: updating market data (this can take a few minutes).",
-            "",
-            replot=False,
-        )
-
-        last_desc = {"text": "Working…"}
 
         def progress_cb(frac: float, desc: str = "") -> None:
-            label = desc or "Working…"
-            last_desc["text"] = label
             try:
-                progress(frac, desc=label)
+                progress(frac, desc=desc or "Working…")
             except Exception:
                 pass
 
@@ -781,17 +765,9 @@ class RunTab:
         progress(1.0, desc="Done")
         status = _refresh_summary(result)
         details = _json_details(result)
-        if result.get("ok") and not result.get("partial"):
-            final_prog = "100% · Complete"
-        elif result.get("partial"):
-            final_prog = "100% · Finished with partial results"
-        else:
-            final_prog = f"Stopped · {last_desc['text']}"
-
         prefer = result.get("ready") or result.get("forecasted") or parsed["tickers"]
         # Replot so Charts tab shows new forecasts without re-selecting the symbol
-        yield self._pack_run_outputs(
-            final_prog,
+        return self._pack_run_outputs(
             status,
             details,
             prefer=prefer,
@@ -799,7 +775,8 @@ class RunTab:
             replot=True,
         )
 
-    def do_gather(self, tickers_text, lowq=80):
+    def do_gather(self, tickers_text):
+        lowq = self._charts_lowq_default()
         parsed = parse_ticker_list(tickers_text)
         if not parsed["ok"]:
             status = (
@@ -817,7 +794,8 @@ class RunTab:
             status, details, prefer=prefer, lowq=lowq, replot=True
         )
 
-    def do_forecast(self, tickers_text, forecast_date, lowq=80, progress=gr.Progress()):
+    def do_forecast(self, tickers_text, forecast_date, progress=gr.Progress()):
+        lowq = self._charts_lowq_default()
         parsed = parse_ticker_list(tickers_text)
         if not parsed["ok"]:
             status = (
@@ -862,8 +840,9 @@ class RunTab:
             status, details, prefer=prefer, lowq=lowq, replot=True
         )
 
-    def do_refresh_search_db(self, lowq=80, current_ticker=None):
+    def do_refresh_search_db(self):
         """Rebuild DuckDB search cache from local parquet (full refresh)."""
+        lowq = self._charts_lowq_default()
         if not self.db_path:
             status = "❌ **No database path configured.**"
             details = _json_details({"ok": False, "error": "db_path missing"})
@@ -902,7 +881,6 @@ class RunTab:
             )
             details = _json_details(result)
 
-        prefer = [current_ticker] if current_ticker else None
         return self._pack_run_outputs(
-            status, details, prefer=prefer, lowq=lowq, replot=True
+            status, details, prefer=None, lowq=lowq, replot=True
         )

--- a/src/canswim/mcp/server.py
+++ b/src/canswim/mcp/server.py
@@ -7,6 +7,7 @@ registered for discoverability but require ``MCP_ALLOW_RUNS=1`` to execute.
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any, Optional
 
 from dotenv import load_dotenv
@@ -14,11 +15,12 @@ from dotenv import load_dotenv
 load_dotenv(override=True)
 
 from loguru import logger  # noqa: E402
-from mcp.server.fastmcp import FastMCP  # noqa: E402
+from mcp.server.fastmcp import Context, FastMCP  # noqa: E402
 
 from canswim.mcp import __version__ as SERVER_VERSION  # noqa: E402
 from canswim.mcp.tools import forecasts, meta, prices, query, tickers  # noqa: E402
 from canswim.mcp.tools import runs as run_tools  # noqa: E402
+from canswim.mcp.tools._common import bind_mcp_progress  # noqa: E402
 from canswim.run_triggers import runs_allowed  # noqa: E402
 
 if runs_allowed():
@@ -199,15 +201,22 @@ def resolve_forecast_start(start_date: Optional[str] = None) -> dict[str, Any]:
         "Get / update market data for listed stock symbols (comma or newline separated). "
         "Only downloads what is missing or out of date (~last 2 years for forecast use). "
         "Same as CLI `gatherdata --tickers` and dashboard “Update market data”. "
+        "Streams progress notifications when the client sends a progressToken. "
         "Requires MCP_ALLOW_RUNS=1."
     ),
 )
-def gather_tickers(
+async def gather_tickers(
     tickers: str,
     include_covariates: bool = True,
+    ctx: Context | None = None,
 ) -> dict[str, Any]:
-    return run_tools.gather_tickers_impl(
-        tickers=tickers, include_covariates=include_covariates
+    # Run in a worker so MCP progress/log notifications can flush during the call
+    progress_cb = bind_mcp_progress(ctx)
+    return await asyncio.to_thread(
+        run_tools.gather_tickers_impl,
+        tickers,
+        include_covariates,
+        progress_cb,
     )
 
 
@@ -219,17 +228,24 @@ def gather_tickers(
         "(skips starts already on file). Explicit start_date = single origin. "
         "Fails clearly if market history is incomplete—use refresh_tickers or "
         "gather_tickers first. Same as CLI `forecast --tickers` and dashboard "
-        "“Run forecast”. Requires MCP_ALLOW_RUNS=1. May take several minutes. "
-        "dry_run=true only checks symbols and origins."
+        "“Run forecast”. Streams progress (origins / symbols) when the client "
+        "sends a progressToken. Requires MCP_ALLOW_RUNS=1. May take several "
+        "minutes. dry_run=true only checks symbols and origins."
     ),
 )
-def forecast_tickers(
+async def forecast_tickers(
     tickers: str,
     start_date: Optional[str] = None,
     dry_run: bool = False,
+    ctx: Context | None = None,
 ) -> dict[str, Any]:
-    return run_tools.forecast_tickers_impl(
-        tickers=tickers, start_date=start_date, dry_run=dry_run
+    progress_cb = bind_mcp_progress(ctx)
+    return await asyncio.to_thread(
+        run_tools.forecast_tickers_impl,
+        tickers,
+        start_date,
+        dry_run,
+        progress_cb,
     )
 
 
@@ -239,19 +255,26 @@ def forecast_tickers(
         "All-in-one refresh for listed symbols: update market data, then catch-up "
         "forecasts (monthly origins for ~12 months + live). Best default when a "
         "user or agent says “gather and forecast” or “refresh these names”. "
-        "Same as dashboard “Refresh data & forecasts”. Requires MCP_ALLOW_RUNS=1. "
-        "May take many minutes for large lists. dry_run=true plans only."
+        "Same as dashboard “Refresh data & forecasts”. Streams live progress "
+        "(notifications/progress + info logs) when the client sends a "
+        "progressToken — same stages as the Run-tab progress bar. "
+        "Requires MCP_ALLOW_RUNS=1. May take many minutes for large lists. "
+        "dry_run=true plans only."
     ),
 )
-def refresh_tickers(
+async def refresh_tickers(
     tickers: str,
     include_covariates: bool = True,
     dry_run: bool = False,
+    ctx: Context | None = None,
 ) -> dict[str, Any]:
-    return run_tools.refresh_tickers_impl(
-        tickers=tickers,
-        include_covariates=include_covariates,
-        dry_run=dry_run,
+    progress_cb = bind_mcp_progress(ctx)
+    return await asyncio.to_thread(
+        run_tools.refresh_tickers_impl,
+        tickers,
+        include_covariates,
+        dry_run,
+        progress_cb,
     )
 
 

--- a/src/canswim/mcp/tools/_common.py
+++ b/src/canswim/mcp/tools/_common.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
 from loguru import logger
 
@@ -12,6 +13,67 @@ from canswim.db import (
     init_search_db,
     tables_present,
 )
+
+# Matches canswim.run_triggers.ProgressCb: (fraction 0..1, description) -> None
+ProgressCb = Optional[Callable[[float, str], None]]
+
+
+def bind_mcp_progress(ctx: Any) -> ProgressCb:
+    """Bridge run_triggers ``progress_cb`` → MCP ``notifications/progress`` + info logs.
+
+    Designed for use with ``asyncio.to_thread``: the callback is sync and may run
+    on a worker thread while the FastMCP event loop is free to flush notifications.
+
+    Clients only receive ``notifications/progress`` when they pass a
+    ``progressToken`` in the tool request meta (MCP progress protocol). Info logs
+    are still sent when the client supports logging.
+    """
+    if ctx is None:
+        return None
+
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = None
+
+    def progress_cb(frac: float, desc: str = "") -> None:
+        try:
+            f = max(0.0, min(1.0, float(frac)))
+        except (TypeError, ValueError):
+            f = 0.0
+        msg = (str(desc).strip() if desc is not None else "") or None
+        # 0..100 with total=100 → clear percent for clients
+        progress_val = f * 100.0
+        total = 100.0
+
+        async def _emit() -> None:
+            try:
+                await ctx.report_progress(
+                    progress=progress_val, total=total, message=msg
+                )
+            except Exception:
+                pass
+            if msg:
+                try:
+                    await ctx.info(msg)
+                except Exception:
+                    pass
+
+        if loop is None or not loop.is_running():
+            try:
+                asyncio.run(_emit())
+            except Exception:
+                pass
+            return
+
+        try:
+            fut = asyncio.run_coroutine_threadsafe(_emit(), loop)
+            fut.result(timeout=5.0)
+        except Exception:
+            # Best-effort: never fail the run because progress notify failed
+            pass
+
+    return progress_cb
 
 
 def resolve_db_path() -> str:

--- a/src/canswim/mcp/tools/runs.py
+++ b/src/canswim/mcp/tools/runs.py
@@ -13,7 +13,7 @@ from canswim.run_triggers import (
     resolve_start_for_run,
     runs_allowed,
 )
-from canswim.mcp.tools._common import err_result, ok_result
+from canswim.mcp.tools._common import ProgressCb, err_result, ok_result
 
 
 RUN_TOOL_NAMES = [
@@ -37,6 +37,7 @@ def resolve_forecast_start_impl(
 def gather_tickers_impl(
     tickers: str,
     include_covariates: bool = True,
+    progress_cb: ProgressCb = None,
 ) -> dict[str, Any]:
     blocked = require_runs_allowed()
     if blocked is not None:
@@ -46,11 +47,27 @@ def gather_tickers_impl(
     if not parsed["ok"]:
         return err_result(parsed.get("error") or "bad tickers", data=parsed)
 
+    if progress_cb is not None:
+        try:
+            progress_cb(0.05, "Updating market data…")
+        except Exception:
+            pass
+
     result = gather_for_tickers(
         tickers,
         include_covariates=include_covariates,
         force_allow=False,
     )
+    if progress_cb is not None:
+        try:
+            progress_cb(
+                1.0,
+                "Market data update complete."
+                if result.get("ok")
+                else "Market data update finished with errors.",
+            )
+        except Exception:
+            pass
     if result.get("ok"):
         return ok_result(result)
     return err_result(result.get("error") or "gather failed", data=result)
@@ -60,6 +77,7 @@ def forecast_tickers_impl(
     tickers: str,
     start_date: Optional[str] = None,
     dry_run: bool = False,
+    progress_cb: ProgressCb = None,
 ) -> dict[str, Any]:
     blocked = require_runs_allowed()
     if blocked is not None:
@@ -74,6 +92,7 @@ def forecast_tickers_impl(
         forecast_start_date=start_date,
         dry_run=dry_run,
         force_allow=False,
+        progress_cb=progress_cb,
     )
     if result.get("ok"):
         return ok_result(result)
@@ -84,8 +103,13 @@ def refresh_tickers_impl(
     tickers: str,
     include_covariates: bool = True,
     dry_run: bool = False,
+    progress_cb: ProgressCb = None,
 ) -> dict[str, Any]:
-    """Gather + monthly catch-up forecasts (all-in-one)."""
+    """Gather + monthly catch-up forecasts (all-in-one).
+
+    ``progress_cb(fraction 0..1, desc)`` streams to MCP clients when bound
+    via :func:`canswim.mcp.tools._common.bind_mcp_progress`.
+    """
     blocked = require_runs_allowed()
     if blocked is not None:
         return err_result(blocked["error"], runs_allowed=False)
@@ -99,6 +123,7 @@ def refresh_tickers_impl(
         include_covariates=include_covariates,
         dry_run=dry_run,
         force_allow=False,
+        progress_cb=progress_cb,
     )
     if result.get("ok"):
         return ok_result(result)

--- a/src/canswim/run_triggers.py
+++ b/src/canswim/run_triggers.py
@@ -70,23 +70,19 @@ PREVIEW_START_BUTTON = "Check start date"
 
 # Primary Run-tab CTA (keep labels self-descriptive for consumers)
 REFRESH_SYMBOLS_SECTION_TITLE = "Refresh data & forecasts"
-# Shown under the primary Run-tab CTA (plain language; keep scannable)
-REFRESH_SYMBOLS_SECTION_HELP = """
-For the symbols you enter, this does **everything needed** so Charts and Scans
-can show a fresh picture:
+# Short main-screen blurb (details live under a collapsible accordion on the Run tab)
+REFRESH_SYMBOLS_SECTION_HELP = (
+    "Market data + ~12 months of catch-up forecasts + Charts list. "
+    "Skips work already on file and short-history names. Can take a few minutes."
+)
+# Optional detail for accordion / docs — not the primary Run-tab body
+REFRESH_SYMBOLS_SECTION_DETAILS = """
+1. **Market data** — download or refresh prices and fundamentals (local files when already complete).
+2. **Catch-up forecasts** — ~12 monthly origins plus the live start (reward/risk and backtest history).
+3. **Charts list** — symbols appear in the Charts dropdown automatically.
 
-1. **Market data** — download or refresh recent prices and fundamentals  
-   (uses local files when already complete; only fetches what’s missing or stale).
-2. **Catch-up forecasts** — run the model for about the **last 12 months**  
-   (one origin per month) **plus** the latest live start, so you get history for  
-   reward/risk and backtest quality—not only today’s forecast.
-3. **Charts list** — add those symbols to the Charts dropdown automatically.
-
-**Skipped automatically:** work already on file for a given start, and names  
-with too little trading history (e.g. recent IPOs)—reported in the status below.
-
-**After it finishes:** open **Charts** for a symbol, or **Scans** to rank by  
-reward/risk and backtest. A full run can take several minutes for many symbols.
+Skipped: starts already saved; names with too little trading history (e.g. recent IPOs).  
+When done: open **Charts** or **Scans**. See also docs/run_triggers.md.
 """
 REFRESH_SYMBOLS_BUTTON = "Refresh data & forecasts"
 

--- a/tests/canswim/test_mcp_tools.py
+++ b/tests/canswim/test_mcp_tools.py
@@ -114,6 +114,70 @@ def test_write_tools_blocked_without_opt_in(mcp_env, monkeypatch):
     assert f["ok"] is False
 
 
+def test_bind_mcp_progress_streams_report_and_info():
+    """progress_cb from run_triggers → MCP report_progress + info."""
+    import asyncio
+
+    from canswim.mcp.tools._common import bind_mcp_progress
+
+    class _FakeCtx:
+        def __init__(self):
+            self.progress: list[tuple] = []
+            self.logs: list[str] = []
+
+        async def report_progress(self, progress, total=None, message=None):
+            self.progress.append((progress, total, message))
+
+        async def info(self, message, **extra):
+            self.logs.append(message)
+
+    async def _run():
+        ctx = _FakeCtx()
+        cb = bind_mcp_progress(ctx)
+        assert cb is not None
+        # Simulate worker-thread style calls on the same loop via to_thread
+        def _work():
+            cb(0.02, "Step 1/2: updating market data…")
+            cb(0.5, "Catch-up origin 3/13…")
+            cb(1.0, "Refresh data & forecasts complete.")
+
+        await asyncio.to_thread(_work)
+        return ctx
+
+    ctx = asyncio.run(_run())
+    assert len(ctx.progress) == 3
+    assert ctx.progress[0][0] == pytest.approx(2.0)
+    assert ctx.progress[0][1] == 100.0
+    assert "market data" in (ctx.progress[0][2] or "").lower()
+    assert ctx.progress[-1][0] == pytest.approx(100.0)
+    assert len(ctx.logs) == 3
+    assert "complete" in ctx.logs[-1].lower()
+
+
+def test_refresh_impl_forwards_progress_cb(monkeypatch):
+    monkeypatch.setenv("MCP_ALLOW_RUNS", "1")
+    seen: list[tuple[float, str]] = []
+
+    def _cb(frac: float, desc: str = "") -> None:
+        seen.append((frac, desc))
+
+    from unittest.mock import patch
+
+    with patch(
+        "canswim.mcp.tools.runs.refresh_symbols",
+        return_value={
+            "ok": True,
+            "ready": ["WWD"],
+            "incomplete": [],
+            "gather": {"ok": True},
+            "forecast": {"ok": True, "forecasted": ["WWD"]},
+        },
+    ) as rs:
+        out = run_tools.refresh_tickers_impl("WWD", progress_cb=_cb)
+    assert out["ok"] is True
+    assert rs.call_args.kwargs.get("progress_cb") is _cb
+
+
 def test_resolve_forecast_start_always_available(mcp_env, monkeypatch):
     monkeypatch.delenv("MCP_ALLOW_RUNS", raising=False)
     r = run_tools.resolve_forecast_start_impl(start_date="2026-03-05")

--- a/tests/canswim/test_ux_split_labels.py
+++ b/tests/canswim/test_ux_split_labels.py
@@ -40,15 +40,24 @@ def test_consumer_copy_avoids_dev_jargon():
 
 
 def test_refresh_symbols_help_explains_steps():
+    # Main-screen blurb stays short; details are separate / accordion.
     h = REFRESH_SYMBOLS_SECTION_HELP.lower()
     assert "market data" in h
     assert "forecast" in h
-    assert "12" in h or "monthly" in h
+    assert "12" in h or "monthly" in h or "catch-up" in h
     assert "charts" in h
     assert "skip" in h
+    # Not a multi-paragraph wall on the main screen
+    assert REFRESH_SYMBOLS_SECTION_HELP.count("\n") <= 2
+    assert len(REFRESH_SYMBOLS_SECTION_HELP) < 280
     # Self-descriptive primary CTA (not vague "Refresh symbols")
     assert "data" in REFRESH_SYMBOLS_BUTTON.lower()
     assert "forecast" in REFRESH_SYMBOLS_BUTTON.lower()
+    from canswim.run_triggers import REFRESH_SYMBOLS_SECTION_DETAILS
+
+    d = REFRESH_SYMBOLS_SECTION_DETAILS.lower()
+    assert "market data" in d
+    assert "catch-up" in d or "monthly" in d
 
 
 def test_date_policy_summary_not_technical_dump():
@@ -59,14 +68,18 @@ def test_date_policy_summary_not_technical_dump():
 
 def test_run_tab_has_separate_gather_and_forecast_controls():
     src = inspect.getsource(run_tab_mod.RunTab.__init__)
-    # Primary path: Refresh data & forecasts + progress line
+    run_src = inspect.getsource(run_tab_mod.RunTab)
+    # Primary path: Refresh data & forecasts; single gr.Progress (no Progress textbox)
     assert "refreshBtn" in src or "refreshTickers" in src
     assert "REFRESH_SYMBOLS" in src or REFRESH_SYMBOLS_BUTTON in src
-    assert "refreshProgress" in src
-    assert "do_refresh_symbols" in inspect.getsource(run_tab_mod.RunTab)
-    assert "gr.Progress" in inspect.getsource(run_tab_mod.RunTab)
+    assert "refreshProgress" not in src
+    assert "do_refresh_symbols" in run_src
+    assert "gr.Progress" in run_src
+    assert "show_progress" in src
+    # Do not wire Charts-tab widgets as inputs (cross-tab Gradio bug)
+    assert "charts_tab.lowq" not in src
+    assert "What this does" in src
     # After refresh, Charts plot must be re-rendered (same-symbol case)
-    run_src = inspect.getsource(run_tab_mod.RunTab)
     assert "_replot_charts" in run_src
     assert "charts_tab" in src
     # Secondary still present but under collapsed "More options"
@@ -81,7 +94,7 @@ def test_run_tab_has_separate_gather_and_forecast_controls():
     assert "forecastStatus" in src
     # Search DB rebuild tucked under More options
     assert "refreshDbBtn" in src
-    assert "do_refresh_search_db" in inspect.getsource(run_tab_mod.RunTab)
+    assert "do_refresh_search_db" in run_src
     assert "REFRESH_SEARCH_BUTTON" in src or "Rebuild Charts" in src
     assert "gatherDetails" in src
     assert "forecastDetails" in src
@@ -214,6 +227,8 @@ def test_mcp_tool_descriptions_are_plain():
     # Tool description block for forecast should be plain language
     assert "Run a forecast for listed stock symbols" in src
     assert 'name="refresh_tickers"' in src
+    assert "progressToken" in src or "progress" in src.lower()
+    assert "bind_mcp_progress" in src
 
 
 def test_docs_exist_for_operators():


### PR DESCRIPTION
## Summary

- **Release 0.0.20260714** — version bump, CHANGELOG, README pin
- **Run tab** — compact help, single progress bar, fix cross-tab Gradio Error on refresh
- **MCP** — stream `refresh_tickers` / `forecast_tickers` / `gather_tickers` progress (`notifications/progress` + info logs)
- CHANGELOG also covers operator wave already on main since 0.0.20260713 (catch-up refresh, Charts universe, schema/SQL, etc.)

## Test plan

- [x] `./scripts/ci-local.sh` — 173 passed
- [x] Coverage run: 173 passed, ~47% overall (run_triggers ~76%, mcp server ~70%)
- [ ] GitHub Actions Tests green
- [ ] After merge: tag `v0.0.20260714`, build, twine upload, `gh release create`