### PR TITLE
fix: zero-fill fund covariates for ETFs like IPOs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ For a brief introduction read [this blog post](https://medium.com/@ivelin.atanas
 | Doc | Contents |
 |-----|----------|
 | **[docs/cli.md](docs/cli.md)** | CLI tasks, recipes, env vars |
-| **[docs/run_triggers.md](docs/run_triggers.md)** | Get market data / run forecast (CLI · GUI · MCP) |
+| **[docs/run_triggers.md](docs/run_triggers.md)** | Get market data / run forecast (CLI · GUI · MCP); stocks · IPOs · ETFs |
 | **[docs/mcp.md](docs/mcp.md)** | MCP server (tools, opt-in writes) |
 | **[docs/data_store.md](docs/data_store.md)** | Parquet (SoT) vs DuckDB (search/UI) |
 | **[AGENTS.md](AGENTS.md)** | CI, merge rules, docs DoD for agents |

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ Intro: [blog post](https://medium.com/@ivelin.atanasoff.ivanov/canswim-a-deep-le
 | Page | Contents |
 |------|----------|
 | [CLI](cli.md) | Tasks, recipes, env vars (`python -m canswim -h` is flag SoT) |
-| [Gather & forecast](run_triggers.md) | CLI · GUI · MCP shared contract |
+| [Gather & forecast](run_triggers.md) | CLI · GUI · MCP shared contract; stocks vs IPOs vs ETFs |
 | [MCP](mcp.md) | Tools, read-only default, `MCP_ALLOW_RUNS` |
 | [Data store](data_store.md) | Parquet (system of record) vs DuckDB (search/UI) |
 

--- a/docs/run_triggers.md
+++ b/docs/run_triggers.md
@@ -100,17 +100,30 @@ python -m canswim forecast --tickers "AAPL,MSFT" --forecast_start_date 2026-03-0
 
 More CLI recipes: [cli.md](cli.md). MCP: [mcp.md](mcp.md).
 
-## Missing fundamentals (IPO / thin coverage)
+## Missing fundamentals (IPO / ETF / fund-thin)
 
 The model stack uses **zero-fill / sentinel fill** when a symbol has prices but no
-earnings, key metrics, institutional ownership, or analyst estimates (common for
-recent IPOs and small caps). That keeps feature dimensionality fixed for train
-and forecast so those names are not dropped solely for missing fundamentals.
+earnings, key metrics, institutional ownership, or analyst estimates. That keeps
+feature dimensionality fixed for train and forecast so those names are not
+dropped solely for missing fundamentals.
+
+Applies to:
+
+| Case | Why fund rows are missing |
+|------|---------------------------|
+| **Recent IPOs / thin coverage** | Too new or sparse for FMP fundamentals |
+| **ETFs / funds** | No corporate EPS, key metrics, or sell-side estimates by design |
+| **Batch of only fund-thin names** | No peer in the same run to copy a column template from |
+
+When the batch has **no** fund rows at all (e.g. refresh **XLF** alone), the
+pipeline still builds train-shaped columns from a fixed earnings schema and/or a
+disk template (covered large-cap symbols such as AAPL) so Darts
+`past_covariates` / `future_covariates` dims match the checkpoint.
 
 - Prices remain ground-truth (no invented OHLCV). Short price history still fails
   readiness checks (~2y for forecast-scoped runs).
-- Ownership fill: `0`. Earnings / estimates: same padding style as sparse known
-  series (`-1` / zero columns aligned to the price calendar when a template exists).
+- Ownership fill: `0`. Earnings / estimates: `-1` / zero columns aligned to the
+  price calendar (same idea as IPO imputation, issue #33).
 
 ## Design rules
 

--- a/docs/run_triggers.md
+++ b/docs/run_triggers.md
@@ -100,36 +100,97 @@ python -m canswim forecast --tickers "AAPL,MSFT" --forecast_start_date 2026-03-0
 
 More CLI recipes: [cli.md](cli.md). MCP: [mcp.md](mcp.md).
 
-## Missing fundamentals (IPO / ETF / fund-thin)
+## Symbol classes: stocks, IPOs, and ETFs (same model)
 
-The model stack uses **zero-fill / sentinel fill** when a symbol has prices but no
-earnings, key metrics, institutional ownership, or analyst estimates. That keeps
-feature dimensionality fixed for train and forecast so those names are not
-dropped solely for missing fundamentals.
+canswim uses **one TiDE checkpoint** and a **fixed feature layout** for every
+symbol at train and at inference. The model does not have separate ETF/IPO
+heads. What changes is **how much real CANSLIM-style fund data** is available
+and what we **impute** so the tensor width still matches training.
 
-Applies to:
+### One model, fixed feature width
 
-| Case | Why fund rows are missing |
-|------|---------------------------|
-| **Recent IPOs / thin coverage** | Too new or sparse for FMP fundamentals |
-| **ETFs / funds** | No corporate EPS, key metrics, or sell-side estimates by design |
-| **Batch of only fund-thin names** | No peer in the same run to copy a column template from |
+| Layer | Role | Always required? |
+|-------|------|------------------|
+| **Target** | Stock/ETF **Close** (or configured target column) | **Yes** — ground-truth bars only (no invented OHLCV) |
+| **Past covariates** | Own OHLC+volume, earnings, key metrics, ownership, splits, broad market / sectors / industry funds | **Yes as a block** — missing *fund* slices are zero-/sentinel-filled |
+| **Future covariates** | Dividends, analyst estimate paths, holidays | **Yes as a block** — missing estimates zero-filled |
 
-When the batch has **no** fund rows at all (e.g. refresh **XLF** alone), the
-pipeline still builds train-shaped columns from a fixed earnings schema and/or a
-disk template (covered large-cap symbols such as AAPL) so Darts
-`past_covariates` / `future_covariates` dims match the checkpoint.
+Training and forecast both call the same covariate stack (`canswim.covariates`).
+If a column that existed at train is missing at forecast, Darts raises a
+**dimensionality** error. That is why fund-thin names must **impute columns**,
+not drop them.
 
-- Prices remain ground-truth (no invented OHLCV). Short price history still fails
-  readiness checks (~2y for forecast-scoped runs).
-- Ownership fill: `0`. Earnings / estimates: `-1` / zero columns aligned to the
-  price calendar (same idea as IPO imputation, issue #33).
+### Three operator-facing classes (MECE)
+
+| Class | Examples | What “rich CANSLIM data” means here | Typical gaps |
+|-------|----------|--------------------------------------|--------------|
+| **A. Covered stocks** | LLY, AAPL, MSFT | Full(ish) price history **and** corporate fundamentals: earnings calendar, key metrics, institutional ownership, sell-side estimates | Occasional sparse fields only |
+| **B. IPOs / thin equities** | Recent listings | Price history often short; fundamentals **late or empty** | Not enough **sessions** for min history; fund rows missing until coverage catches up |
+| **C. ETFs / funds** | XLF, SPY, sector & theme ETFs | **Prices + market context** matter; no corporate EPS / key metrics / equity research “by design” | Fund rows **never** appear (empty filter for that symbol) |
+
+These classes share **market-context** past covariates (broad indexes, sectors,
+industry funds) and the **own-price** past block. They differ on **issuer-level**
+fundamentals.
+
+### Data requirements: train vs inference
+
+Same rules on both paths unless noted.
+
+| Requirement | Covered stocks (A) | IPOs / thin (B) | ETFs / funds (C) |
+|-------------|--------------------|-----------------|------------------|
+| **OHLCV history** | Full train window or ~2y scoped | Must eventually reach ~**2 years of sessions** for forecast-scoped readiness | Same price floor as stocks (~2y scoped) |
+| **Own OHLC+volume as past covs** | Real | Real when listed | Real (ETF prints) |
+| **Earnings / key metrics / ownership** | Real when present | **Zero-fill** missing (#33) | **Zero-fill** missing (same mechanism; expected permanent) |
+| **Analyst estimates (future)** | Real when present | **Zero-fill** missing | **Zero-fill** missing |
+| **Broad / sector / industry funds** | Shared series (all symbols) | Shared series | Shared series (often the informative path for ETFs) |
+| **Dividends / splits / holidays** | Real or empty-padded | Same | Same |
+| **Train inclusion** | Preferred “rich” examples | Included if prices + imputed fund dims work | Can be included the same way; model still learns price+market features |
+| **Forecast / Refresh** | Default path | Fail **history** if too short; else impute fund | Fail **history** if too short; else impute fund (empty batch OK) |
+
+**Hard fail (cannot invent):** insufficient **price** history for the forecast
+window / min samples. Status talks about short history / IPOs.
+
+**Soft gap (impute, do not drop columns):** missing earnings, key metrics,
+ownership, estimates — whether temporary (IPO) or structural (ETF).
+
+### How imputation works (train + inference)
+
+1. Build real series per symbol when parquet has rows.
+2. If some symbols in the batch lack a block, **copy the column template** from a
+   peer that has it and fill with `0` (ownership) or `-1` / zeros (earn, kms,
+   estimates), aligned to that symbol’s **price calendar**.
+3. If the **entire batch** has no fund rows (e.g. refresh **XLF** alone), there is
+   no peer template:
+   - **Earnings:** fixed train schema columns (always emit the same names/order).
+   - **Key metrics / analyst estimates:** load a **disk template** from covered
+     large caps (e.g. AAPL family) and zero-fill those columns for the thin name.
+4. Stack into past/future covariates with the **same width** as training so one
+   checkpoint works for A/B/C.
+
+Implementation: `canswim.covariates` (issue #33 for IPOs; empty-batch / ETF path
+extends the same idea).
+
+### What this means for operators
+
+| You want to… | Expectation |
+|--------------|-------------|
+| Refresh **LLY / AAPL** | Market data + real fundamentals when APIs have them; catch-up forecasts as usual |
+| Refresh a **new IPO** | May **stop** until ~2y of sessions; fundamentals imputed once prices are ready |
+| Refresh **XLF** or a sector ETF | Prices + market funds load; **no corporate fund rows** — imputed automatically; forecast should not fail on dimensionality alone |
+| Mix ETF + stocks in one list | Peers can supply templates; still fine if only ETFs (empty-batch path) |
+
+**Interpretation note:** For ETFs (and heavily imputed IPOs), the model is driven
+mainly by **price path + broad/sector context**, not issuer fundamentals. That is
+intentional with a single shared head—not a second “ETF model.”
+
+**NOT FINANCIAL OR INVESTMENT ADVICE. USE AT YOUR OWN RISK.**
 
 ## Design rules
 
 1. One orchestration for CLI / GUI / MCP.
 2. Missing-only remote calls for forecast-scoped gather; train stays full-history.
-3. Fail closed on incomplete forecast data (prices or covariates).
+3. Fail closed on incomplete **price** history; **impute** optional fundamentals so feature width stays fixed.
 4. Consumer copy in the product; policy detail in this doc.
 5. Parquet is the system of record; DuckDB is the search/UI cache ([data_store.md](data_store.md)).
-6. Impute missing optional fundamentals rather than excluding symbols (train + forecast).
+6. Same model for covered stocks, IPOs, and ETFs — different real-data density, same tensor schema.
+7. Impute missing optional fundamentals rather than excluding symbols (train + forecast).

--- a/src/canswim/covariates.py
+++ b/src/canswim/covariates.py
@@ -2,13 +2,35 @@ from pandas.tseries.offsets import BDay
 import pandas as pd
 from darts import TimeSeries
 from darts.dataprocessing.transformers import MissingValuesFiller
-from typing import Union
+from typing import Optional, Union
 import numpy as np
 from loguru import logger
 import os
 
 fiscal_periods = ["quarter", "annual"]
 fiscal_freq = {"annual": "Y", "quarter": "Q"}
+
+# When a scoped forecast batch has no fund rows at all (e.g. sector ETF XLF alone),
+# zero-fill still needs a column template. Load one of these well-covered names
+# without the batch filter so feature dim matches training.
+_TEMPLATE_SYMBOLS = ("AAPL", "MSFT", "GOOGL", "AMZN", "NVDA", "META", "JPM")
+
+# Earnings columns after prepare_earn_series date-splitting / category coding.
+# Order matches insert(loc=n_cols) behavior (year→month→day inserted at same loc
+# yields day, month, year as final order).
+_EARN_FEATURE_COLS = (
+    "eps",
+    "epsEstimated",
+    "time",
+    "revenue",
+    "revenueEstimated",
+    "updatedFromDate_day",
+    "updatedFromDate_month",
+    "updatedFromDate_year",
+    "fiscalDateEnding_day",
+    "fiscalDateEnding_month",
+    "fiscalDateEnding_year",
+)
 
 
 # credit for implementation: https://stackoverflow.com/a/39068260/12015435
@@ -76,9 +98,32 @@ class Covariates:
         return t_earn
 
     def prepare_earn_series(self, tickers=None, stock_price_series: dict = None):
+        """Earnings past-covs; missing names (IPOs, ETFs, thin coverage) are zero-filled.
+
+        Fund-thin symbols never have EPS/revenue history; we still emit the train
+        schema so past_covariates dim matches the checkpoint (same idea as #33).
+        """
         logger.info("preparing past covariates: earnings estimates ")
+        price_map = stock_price_series if isinstance(stock_price_series, dict) else {}
+        ticker_list = list(price_map.keys()) if price_map else list(tickers or [])
+        t_earn_series = {}
+
+        earn_src = getattr(self, "earnings_loaded_df", None)
+        if earn_src is None or (hasattr(earn_src, "empty") and earn_src.empty):
+            # No earnings in this batch (e.g. sector ETF alone) — fixed schema
+            if price_map:
+                logger.info(
+                    "No earnings loaded for this batch (common for ETFs / fund-thin "
+                    f"names); zero-filling {len(_EARN_FEATURE_COLS)} earn columns"
+                )
+                for t, prices in price_map.items():
+                    t_earn_series[t] = self._zero_cov_from_columns(
+                        _EARN_FEATURE_COLS, prices, fillna_value=-1
+                    )
+            return t_earn_series
+
         # convert date strings to numerical representation
-        earn_df = self.earnings_loaded_df.copy()
+        earn_df = earn_src.copy()
         # logger.info("self.earnings_loaded_df.columns", self.earnings_loaded_df.columns)
         ufd = pd.to_datetime(earn_df["updatedFromDate"])
         ufd_year = ufd.dt.year
@@ -109,16 +154,7 @@ class Covariates:
         earn_df["time"] = pd.Categorical(
             earn_df["time"], categories=["bmo", "amc"]
         ).codes
-        # earn_df["time"] = (
-        #     earn_df["time"]
-        #     .replace(["bmo", "amc", "--", "dmh"], [0, 1, -1, -1], inplace=False)
-        #     .astype("int32")
-        # )
         # convert earnings dataframe to series
-        t_earn_series = {}
-        # Prefer full price dict when provided so missing symbols can be zero-filled
-        price_map = stock_price_series if isinstance(stock_price_series, dict) else {}
-        ticker_list = list(price_map.keys()) if price_map else list(tickers or [])
         for t in ticker_list:
             try:
                 # logger.info(f'ticker: {t}')
@@ -140,19 +176,29 @@ class Covariates:
                 t_earn_series[t] = tes
             except (KeyError, AssertionError, ValueError) as e:
                 logger.warning(
-                    f"No earnings series for {t} ({type(e)}: {e}); will zero-fill if template exists"
+                    f"No earnings series for {t} ({type(e)}: {e}); will zero-fill"
                 )
 
-        # Issue #33: keep IPOs / thin coverage in train by imputing missing earn covs
-        if t_earn_series and price_map:
-            template = next(iter(t_earn_series.values()))
-            for t, prices in price_map.items():
-                if t not in t_earn_series:
-                    logger.info(
-                        f"Zero-filling earnings covariates for {t} "
-                        f"({len(template.components)} columns)"
+        # Issue #33 / fund-thin (ETF, IPO): impute missing earn covs so dim matches train
+        if price_map:
+            template = next(iter(t_earn_series.values()), None)
+            if template is None:
+                logger.info(
+                    "No earnings in batch; zero-filling "
+                    f"{len(_EARN_FEATURE_COLS)} columns for all requested symbols"
+                )
+                for t, prices in price_map.items():
+                    t_earn_series[t] = self._zero_cov_from_columns(
+                        _EARN_FEATURE_COLS, prices, fillna_value=-1
                     )
-                    t_earn_series[t] = self._zero_cov_like(template, prices)
+            else:
+                for t, prices in price_map.items():
+                    if t not in t_earn_series:
+                        logger.info(
+                            f"Zero-filling earnings covariates for {t} "
+                            f"({len(template.components)} columns)"
+                        )
+                        t_earn_series[t] = self._zero_cov_like(template, prices)
 
         return t_earn_series
 
@@ -359,12 +405,47 @@ class Covariates:
 
     def _zero_cov_like(self, template: TimeSeries, like: TimeSeries) -> TimeSeries:
         """Zero-filled series with template columns, aligned to like's time index."""
+        return self._zero_cov_from_columns(list(template.components), like)
+
+    def _zero_cov_from_columns(
+        self, columns, like: TimeSeries, fillna_value: float = 0.0
+    ) -> TimeSeries:
+        """Zero-filled series with explicit column names, aligned to like's index."""
         from canswim.eligibility import timeseries_from_observed_df
 
         idx = pd.DatetimeIndex(pd.to_datetime(like.time_index)).normalize()
-        cols = list(template.components)
-        df = pd.DataFrame(0.0, index=idx, columns=cols)
+        cols = list(columns)
+        df = pd.DataFrame(float(fillna_value), index=idx, columns=cols)
         return timeseries_from_observed_df(df)
+
+    def _parquet_path(self, filename: str) -> str:
+        data_dir = getattr(self, "data_dir", None) or os.getenv("data_dir", "data")
+        third = getattr(self, "data_3rd_party", None) or os.getenv(
+            "data-3rd-party", "data-3rd-party"
+        )
+        # Some loaders use bare "data/data-3rd-party/..." paths historically
+        candidate = os.path.join(data_dir, third, filename)
+        if os.path.isfile(candidate):
+            return candidate
+        legacy = os.path.join("data", "data-3rd-party", filename)
+        return legacy if os.path.isfile(legacy) else candidate
+
+    def _read_template_symbol_frame(self, filename: str) -> Optional[pd.DataFrame]:
+        """Load fund rows for a well-covered template ticker (not the forecast batch)."""
+        path = self._parquet_path(filename)
+        if not os.path.isfile(path):
+            logger.warning(f"Template parquet missing: {path}")
+            return None
+        try:
+            df = pd.read_parquet(
+                path, filters=[("Symbol", "in", list(_TEMPLATE_SYMBOLS))]
+            )
+        except Exception as e:
+            logger.warning(f"Could not load template from {path}: {e}")
+            return None
+        if df is None or df.empty:
+            return None
+        return df
 
     @staticmethod
     def _align_series_on_common_index(a: TimeSeries, b: TimeSeries):
@@ -408,47 +489,49 @@ class Covariates:
         return timeseries_from_observed_df(aligned)
 
     def prepare_key_metrics(self, stock_price_series=None):
+        """Key metrics past-covs; missing names (IPOs, ETFs) are zero-filled to train dim."""
         logger.info("preparing past covariates: key metrics")
-        kms_loaded_df = self.kms_loaded_df.copy()
+        t_kms_series = {}
+        stock_price_series = stock_price_series or {}
+        kms_src = getattr(self, "kms_loaded_df", None)
+        if kms_src is None or (hasattr(kms_src, "empty") and kms_src.empty):
+            cols = self._key_metrics_template_columns()
+            if cols and stock_price_series:
+                logger.info(
+                    "No key metrics loaded for this batch (common for ETFs / "
+                    f"fund-thin names); zero-filling {len(cols)} columns"
+                )
+                for t, prices in stock_price_series.items():
+                    t_kms_series[t] = self._zero_cov_from_columns(
+                        cols, prices, fillna_value=-1
+                    )
+            return t_kms_series
+
+        kms_loaded_df = kms_src.copy()
         # logger.info(kms_loaded_df)
         kms_loaded_df = kms_loaded_df[~kms_loaded_df.index.duplicated(keep="first")]
         assert kms_loaded_df.index.is_unique
-        kms_loaded_df.index
-        len(kms_loaded_df.index)
-        # kms_loaded_df["date"] = pd.to_datetime(kms_loaded_df["date"])
         kms_unique = kms_loaded_df.drop_duplicates()  # subset=["symbol", "date"])
         assert not kms_unique.duplicated().any()
-        # kms_unique = kms_unique.set_index(keys=["symbol", "date"])
         assert not kms_unique.index.has_duplicates
         kms_loaded_df = kms_unique.copy()
-        # convert earnings reporting time - Before Market Open / After Market Close - categories to numerical representation
+        # convert period categories to numerical representation
         if "period" in kms_loaded_df.columns:
             kms_loaded_df["period"] = pd.Categorical(
                 kms_loaded_df["period"], categories=["_", "Q1", "Q2", "Q3", "Q4"]
             ).codes
-        # kms_loaded_df["period"] = (
-        #     kms_loaded_df["period"]
-        #     .replace(["Q1", "Q2", "Q3", "Q4"], [1, 2, 3, 4], inplace=False)
-        #     .astype("int32")
-        # )
 
-        t_kms_series = {}
         for t, prices in stock_price_series.items():
             try:
                 # logger.info(f"ticker {t}")
                 kms_df = kms_loaded_df.loc[[t]].copy()
-                # logger.info(f'ticker_series[{t}] start time, end time: {ticker_series[t].start_time()}, {ticker_series[t].end_time()}')
-                # logger.info(f'kms_ser_df start time, end time: {kms_df.index[0]}, {kms_df.index[-1]}')
                 kms_df = kms_df.droplevel("Symbol")
                 kms_df.index = pd.to_datetime(kms_df.index)
-                # logger.info(f'index type for {t}: {type(t_kms.index)}')
                 kms_df = kms_df[~kms_df.index.duplicated(keep="last")]
                 assert kms_df.index.is_unique
                 kms_df = kms_df.dropna()
-                # logger.info("kms_df\n", kms_df[kms_df.isnull()])
                 assert not kms_df.isnull().values.any()
                 assert len(kms_df) > 0, f"No key metrics available for {t}"
-                # logger.info(f'{t} earnings: \n{t_kms.columns}')
                 kms_df = self.df_index_to_biz_days(kms_df)
                 # Weekend/holiday mapping can create duplicate biz-day labels
                 # (issue #75: pandas reindex raises ValueError).
@@ -459,33 +542,58 @@ class Covariates:
                 tkms_series_tmp = TimeSeries.from_dataframe(
                     kms_df, freq="B", fill_missing_dates=True
                 )
-                # logger.info(f'kms_series_tmp start time, end time: {tkms_series_tmp.start_time()}, {tkms_series_tmp.end_time()}')
                 kms_df_ext = tkms_series_tmp.pd_dataframe()
                 kms_df_ext.ffill(inplace=True)
                 kms_ser = TimeSeries.from_dataframe(
                     kms_df_ext, freq="B", fillna_value=-1
                 )
                 kms_ser_padded = self.pad_covs(cov_series=kms_ser, price_series=prices)
-                # logger.info(f'kms_ser_padded start time, end time: {kms_ser_padded.start_time()}, {kms_ser_padded.end_time()}')
                 assert (
                     len(kms_ser_padded.gaps()) == 0
                 ), f"found gaps in tmks series: \n{kms_ser_padded.gaps()}"
                 t_kms_series[t] = kms_ser_padded
             except (KeyError, AssertionError, ValueError) as e:
-                # ValueError: duplicate-index reindex (dirty fund data) — skip ticker
-                logger.warning(f"Skipping {t} due to error: {type(e)}: {e}")
-        # Issue #33: impute missing key metrics so symbols without coverage stay in train
-        if t_kms_series and stock_price_series:
-            template = next(iter(t_kms_series.values()))
-            for t, prices in stock_price_series.items():
-                if t not in t_kms_series:
+                logger.warning(
+                    f"No key metrics for {t} ({type(e)}: {e}); will zero-fill"
+                )
+        # Issue #33 / fund-thin (ETF, IPO): impute missing key metrics so dim matches
+        if stock_price_series:
+            template = next(iter(t_kms_series.values()), None)
+            if template is None:
+                cols = self._key_metrics_template_columns()
+                if cols:
                     logger.info(
-                        f"Zero-filling key metrics for {t} "
-                        f"({len(template.components)} columns)"
+                        f"No key metrics in batch; zero-filling {len(cols)} columns "
+                        "for all requested symbols"
                     )
-                    t_kms_series[t] = self._zero_cov_like(template, prices)
-        # logger.info("t_kms_series:", t_kms_series)
+                    for t, prices in stock_price_series.items():
+                        t_kms_series[t] = self._zero_cov_from_columns(
+                            cols, prices, fillna_value=-1
+                        )
+                else:
+                    logger.warning(
+                        "No key-metrics template available; stack will omit this block"
+                    )
+            else:
+                for t, prices in stock_price_series.items():
+                    if t not in t_kms_series:
+                        logger.info(
+                            f"Zero-filling key metrics for {t} "
+                            f"({len(template.components)} columns)"
+                        )
+                        t_kms_series[t] = self._zero_cov_like(template, prices)
         return t_kms_series
+
+    def _key_metrics_template_columns(self) -> list[str]:
+        """Column names for key-metrics past covs when the batch has no rows."""
+        src = getattr(self, "kms_loaded_df", None)
+        if src is not None and not src.empty:
+            return list(src.columns)
+        # Load a covered template symbol (batch filter left the frame empty)
+        df = self._read_template_symbol_frame("keymetrics_history.parquet")
+        if df is not None and not df.empty:
+            return list(df.columns)
+        return []
 
     def _price_covariate_series_from_df(self, df: pd.DataFrame, train_date_start=None):
         """Build multi-asset market price covariates (broad/sectors/industry funds).
@@ -733,57 +841,118 @@ class Covariates:
         """
         logger.info(f"preparing future covariates: analyst estimates[{period}]")
         assert period in fiscal_periods
+        stock_price_series = stock_price_series or {}
         t_est_series = {}
-        for t, prices in stock_price_series.items():
-            # logger.info(f'ticker {t}')
-            try:
-                est_df = all_est_df.loc[[t]].copy()
-                est_df = est_df.droplevel("Symbol")
-                est_df.index = pd.to_datetime(est_df.index)
-                assert not est_df.index.duplicated().any()
-                # expand series with estimates from future periods
-                est_df = self.est_add_future_periods(
-                    est_df=est_df, n_future_periods=n_future_periods, period=period
-                )
-                # logger.info(f'{t} estimates columns: \n{est_df.columns}')
-                # align dates to business days
-                est_df = self.df_index_to_biz_days(est_df)
-                # there should be no duplicate rows
-                est_df = est_df[~est_df.index.duplicated(keep="first")]
-                assert not est_df.index.duplicated().any()
-                # expand date index to match target price series dates and pad data
-                est_series_tmp = TimeSeries.from_dataframe(
-                    est_df, freq="B", fill_missing_dates=True
-                )
-                # logger.info(f'est_series_tmp start time, end time: {est_series_tmp.start_time()}, {est_series_tmp.end_time()}')
-                est_df = est_series_tmp.pd_dataframe()
-                # Make current annual/quarter period estimates available on all business days through end of the period
-                est_df.ffill(inplace=True)
-                est_ser = TimeSeries.from_dataframe(est_df, freq="B", fillna_value=-1)
-                est_padded = self.pad_covs(
-                    cov_series=est_ser, price_series=prices, fillna_value=-1
-                )
-                assert (
-                    len(est_padded.gaps()) == 0
-                ), f"found gaps in series: \n{est_padded.gaps()}"
-                t_est_series[t] = est_padded
-
-            except (KeyError, AssertionError, ValueError) as e:
-                logger.info(
-                    f"No analyst estimates[{period}] for {t} ({type(e)}: {e}); "
-                    "will zero-fill if template exists"
-                )
-        # Issue #33: impute missing analyst estimates so IPOs stay in train/forecast
-        if t_est_series and stock_price_series:
-            template = next(iter(t_est_series.values()))
+        empty_frame = (
+            all_est_df is None
+            or (hasattr(all_est_df, "empty") and all_est_df.empty)
+        )
+        if not empty_frame:
             for t, prices in stock_price_series.items():
-                if t not in t_est_series:
-                    logger.info(
-                        f"Zero-filling analyst estimates[{period}] for {t} "
-                        f"({len(template.components)} columns)"
+                # logger.info(f'ticker {t}')
+                try:
+                    est_df = all_est_df.loc[[t]].copy()
+                    est_df = est_df.droplevel("Symbol")
+                    est_df.index = pd.to_datetime(est_df.index)
+                    assert not est_df.index.duplicated().any()
+                    # expand series with estimates from future periods
+                    est_df = self.est_add_future_periods(
+                        est_df=est_df,
+                        n_future_periods=n_future_periods,
+                        period=period,
                     )
-                    t_est_series[t] = self._zero_cov_like(template, prices)
+                    # align dates to business days
+                    est_df = self.df_index_to_biz_days(est_df)
+                    est_df = est_df[~est_df.index.duplicated(keep="first")]
+                    assert not est_df.index.duplicated().any()
+                    est_series_tmp = TimeSeries.from_dataframe(
+                        est_df, freq="B", fill_missing_dates=True
+                    )
+                    est_df = est_series_tmp.pd_dataframe()
+                    # Make current period estimates available through end of period
+                    est_df.ffill(inplace=True)
+                    est_ser = TimeSeries.from_dataframe(
+                        est_df, freq="B", fillna_value=-1
+                    )
+                    est_padded = self.pad_covs(
+                        cov_series=est_ser, price_series=prices, fillna_value=-1
+                    )
+                    assert (
+                        len(est_padded.gaps()) == 0
+                    ), f"found gaps in series: \n{est_padded.gaps()}"
+                    t_est_series[t] = est_padded
+
+                except (KeyError, AssertionError, ValueError) as e:
+                    logger.info(
+                        f"No analyst estimates[{period}] for {t} ({type(e)}: {e}); "
+                        "will zero-fill"
+                    )
+        # Issue #33 / fund-thin (ETF, IPO): impute so future_cov dim matches train
+        if stock_price_series:
+            template = next(iter(t_est_series.values()), None)
+            if template is None:
+                logger.info(
+                    f"No analyst estimates[{period}] in batch "
+                    "(common for ETFs / fund-thin names); loading disk template"
+                )
+                template = self._build_est_template_from_disk(
+                    period=period,
+                    n_future_periods=n_future_periods,
+                    price_like=next(iter(stock_price_series.values())),
+                )
+            if template is not None:
+                for t, prices in stock_price_series.items():
+                    if t not in t_est_series:
+                        logger.info(
+                            f"Zero-filling analyst estimates[{period}] for {t} "
+                            f"({len(template.components)} columns)"
+                        )
+                        t_est_series[t] = self._zero_cov_like(template, prices)
+            else:
+                logger.warning(
+                    f"No analyst estimates[{period}] template; "
+                    "stack may omit this block (dim risk)"
+                )
         return t_est_series
+
+    def _build_est_template_from_disk(
+        self,
+        *,
+        period: str,
+        n_future_periods: int,
+        price_like: TimeSeries,
+    ) -> Optional[TimeSeries]:
+        """Build expanded estimate column template from a covered symbol on disk."""
+        df = self._read_template_symbol_frame(
+            f"analyst_estimates_{period}.parquet"
+        )
+        if df is None or df.empty:
+            # Fall back to already-loaded (possibly empty) frame's structure — fail
+            loaded = (getattr(self, "est_loaded_df", None) or {}).get(period)
+            if loaded is None or loaded.empty:
+                return None
+            df = loaded
+        try:
+            # Use first available template symbol
+            sym = df.index.get_level_values(0)[0]
+            est_df = df.loc[[sym]].copy()
+            est_df = est_df.droplevel("Symbol")
+            est_df.index = pd.to_datetime(est_df.index)
+            est_df = est_df[~est_df.index.duplicated(keep="last")]
+            if est_df.empty:
+                return None
+            est_df = self.est_add_future_periods(
+                est_df=est_df,
+                n_future_periods=n_future_periods,
+                period=period,
+            )
+            cols = list(est_df.columns)
+            return self._zero_cov_from_columns(cols, price_like, fillna_value=-1)
+        except Exception as e:
+            logger.warning(
+                f"Could not build estimates[{period}] template from disk: {e}"
+            )
+            return None
 
     def prepare_analyst_estimates(self, stock_price_series=None):
         logger.info("preparing future covariates: analyst estimates")

--- a/src/canswim/dashboard/run_tab.py
+++ b/src/canswim/dashboard/run_tab.py
@@ -352,20 +352,57 @@ def _refresh_summary(result: dict) -> str:
         return "\n\n".join(lines)
 
     if not result.get("ok") and not forecast.get("forecasted"):
-        g_part = _gather_summary(gather) if gather else ""
         head = f"❌ **{btn} could not finish.**"
         if incomplete and not ready:
             head = (
                 f"❌ **{btn} stopped** — no symbols ready for forecast yet."
             )
-        return (
-            f"{head}\n\n"
-            f"{result.get('error') or ''}\n\n"
-            f"{g_part}\n\n"
-            "**What you can do next**\n\n"
-            "1. **Recommended:** Drop short-history / IPO names and try again.\n\n"
-            "2. Open **Technical log** for details."
+        err = (result.get("error") or forecast.get("error") or "").strip()
+        err_l = err.lower()
+        is_cov = bool(
+            forecast.get("need_covariates")
+            or result.get("fail_reason") == "covariates"
+            or "dimensionality" in err_l
+            or "feature mismatch" in err_l
+            or "fund-thin" in err_l
+            or "past_covariates" in err_l
         )
+        is_hist = bool(incomplete and not ready and not is_cov)
+
+        lines = [head]
+        if err:
+            lines.append(err)
+        # Only restate gather hard-fail; skip green gather success + IPO advice
+        # when market data was fine and forecast covariates failed.
+        if incomplete and not ready:
+            g_part = _gather_summary(gather) if gather else ""
+            if g_part:
+                lines.append(g_part)
+        elif ready:
+            lines.append(
+                f"Market data looked ready for: {_fmt_syms(ready)}. "
+                "The forecast step could not finish."
+            )
+
+        lines.append("**What you can do next**")
+        if is_cov:
+            lines.append(
+                "1. **Recommended:** Try again after **Update market data** "
+                "(fundamentals). ETFs and other fund-thin names use zero-filled "
+                "fund inputs like IPOs—if it still fails, open **Technical log**."
+            )
+            lines.append(
+                "2. Or forecast a regular stock (e.g. LLY) to confirm the model path."
+            )
+        elif is_hist:
+            lines.append(
+                "1. **Recommended:** Drop short-history / IPO names and try again."
+            )
+            lines.append("2. Open **Technical log** for details.")
+        else:
+            lines.append("1. Open **Technical log** for details.")
+            lines.append("2. Retry, or try fewer symbols.")
+        return "\n\n".join(lines)
 
     n_orig = len(forecast.get("origins") or [])
     new_fc = _norm_syms(forecast.get("forecasted") or [])

--- a/src/canswim/run_triggers.py
+++ b/src/canswim/run_triggers.py
@@ -104,7 +104,16 @@ COVARIATE_FAIL_MSG = (
     "Could not build a forecast for: {symbols}. "
     "Prices may be fine, but model inputs (ownership, estimates, or other fundamentals) "
     "are missing or could not be aligned. "
-    "Try Update market data again (includes fundamentals), then re-run the forecast."
+    "Try Update market data again (includes fundamentals), then re-run the forecast. "
+    "ETFs and other fund-thin names use zero-filled fund covariates (like IPOs); "
+    "if this still fails, see Technical log for a feature-dimension mismatch."
+)
+
+DIMENSIONALITY_FAIL_MSG = (
+    "Model feature mismatch for: {symbols}. "
+    "Local market inputs did not match the trained model’s expected columns "
+    "(common for ETFs or incomplete fund data). "
+    "Retry after Update market data; if it persists, report via GitHub issues."
 )
 
 STALE_PRICE_START_MSG = (
@@ -1034,9 +1043,15 @@ def forecast_for_tickers(
         return out
     except Exception as e:
         logger.exception("forecast_for_tickers failed")
+        err = str(e)
+        # Map Darts dim errors to consumer language (ETFs / fund-thin often hit this)
+        if "dimensionality" in err.lower() or "past_covariates" in err.lower():
+            err = DIMENSIONALITY_FAIL_MSG.format(
+                symbols=", ".join(tickers) if tickers else "requested symbols"
+            )
         return {
             "ok": False,
-            "error": str(e),
+            "error": err,
             "mode": mode,
             "tickers": tickers,
             "resolved_start": start_info,
@@ -1046,6 +1061,7 @@ def forecast_for_tickers(
             "skipped": skipped_all,
             "messages": messages,
             "model_loaded": model_loaded,
+            "fail_reason": "covariates",
         }
     finally:
         if prev_list is None:

--- a/tests/canswim/test_cov_imputation.py
+++ b/tests/canswim/test_cov_imputation.py
@@ -125,3 +125,56 @@ def test_prepare_key_metrics_zero_fills_missing():
     out = c.prepare_key_metrics(stock_price_series=prices)
     assert "HAS" in out and "IPO" in out
     assert len(out["IPO"].components) == len(out["HAS"].components)
+
+
+def test_fund_thin_empty_batch_zero_fills_earn_like_etf():
+    """ETF-style batch: no earnings rows at all still gets train-shaped columns."""
+    from canswim.covariates import _EARN_FEATURE_COLS
+
+    c = Covariates()
+    c.earnings_loaded_df = pd.DataFrame()  # empty load (XLF-only filter)
+    prices = {"XLF": _price_ts()}
+    out = c.prepare_earn_series(stock_price_series=prices)
+    assert "XLF" in out
+    assert list(out["XLF"].components) == list(_EARN_FEATURE_COLS)
+
+
+def test_fund_thin_empty_batch_zero_fills_key_metrics():
+    c = Covariates()
+    c.kms_loaded_df = pd.DataFrame()
+    # Provide columns via mock of disk template path
+    c._key_metrics_template_columns = lambda: [  # type: ignore[method-assign]
+        "period",
+        "revenuePerShare",
+        "netIncomePerShare",
+    ]
+    prices = {"XLF": _price_ts()}
+    out = c.prepare_key_metrics(stock_price_series=prices)
+    assert "XLF" in out
+    assert list(out["XLF"].components) == [
+        "period",
+        "revenuePerShare",
+        "netIncomePerShare",
+    ]
+
+
+def test_fund_thin_empty_batch_zero_fills_estimates():
+    c = Covariates()
+    prices = {"XLF": _price_ts(n=60, start="2023-06-01")}
+    # Disk template via stub
+    tmpl = c._zero_cov_from_columns(
+        ["estimatedEpsAvg_p_annual_1", "estimatedEpsAvg_p_annual_2"],
+        prices["XLF"],
+        fillna_value=-1,
+    )
+    c._build_est_template_from_disk = (  # type: ignore[method-assign]
+        lambda **kwargs: tmpl
+    )
+    out = c.prepare_est_series(
+        all_est_df=pd.DataFrame(),
+        n_future_periods=2,
+        period="annual",
+        stock_price_series=prices,
+    )
+    assert "XLF" in out
+    assert len(out["XLF"].components) == 2


### PR DESCRIPTION
## Summary

- **XLF / ETF-only refresh** failed: no earnings/key-metrics/estimates in the batch → past cov 763 vs train 833 → Darts dimensionality error.
- Same **fund-thin zero-fill** policy as IPOs (#33), extended to empty batches (no peer template): fixed earn schema + disk templates for kms/estimates.
- Run-tab: stop showing green “market data ready” + IPO next-steps when the gather was fine and forecast covariates failed.
- Docs: fund-thin section covers ETFs.

## Test plan

- [x] Local CI 176 passed
- [x] XLF single-origin forecast end-to-end SUCCESS after fix
- [x] New unit tests for empty-batch earn/kms/estimates
- [ ] GitHub Actions green