### PR TITLE
feat: gentle remote API error messages for GUI and MCP

### DIFF
--- a/docs/run_triggers.md
+++ b/docs/run_triggers.md
@@ -29,6 +29,28 @@ For scoped runs (`--tickers` / dashboard / MCP):
 - If history is complete but stale, download only a **short tail** refresh.
 - **Train** mode (`gatherdata` without `--tickers`) still uses full `train_date_start` history.
 
+### When remote APIs fail (network / key / plan)
+
+Gather and **Refresh data & forecasts** (GUI · MCP · CLI) classify provider failures
+via `canswim.remote_api_errors` and return a **gentle checklist** instead of a raw
+stack trace:
+
+| Kind | Typical cause |
+|------|----------------|
+| `network` | Offline, DNS, firewall, VPN, provider outage |
+| `auth` | Invalid / rotated / revoked API key |
+| `subscription` | Plan expired, tier too low for endpoint |
+| `rate_limit` | Too many calls (429) |
+| `timeout` | Slow link or overloaded provider |
+| `missing_key` | `FMP_API_KEY` not set in this process |
+
+**MCP:** failed write tools include `error` (human text) plus structured
+`remote_api` (`kind`, `checklist`, `provider`, `detail`).  
+**GUI:** Run tab status shows the same checklist; Technical log keeps full JSON.
+
+Operators should verify internet access, that **FMP_API_KEY** (or other tokens)
+are loaded after restart, and that the data plan is active.
+
 ### Fundamentals (covariates), not only OHLCV
 
 Unless `--no_covariates` / GUI equivalent, scoped gather also refreshes model inputs such as:

--- a/src/canswim/dashboard/run_tab.py
+++ b/src/canswim/dashboard/run_tab.py
@@ -90,14 +90,50 @@ def _gather_summary(result: dict) -> str:
     # ---- hard failure (nothing forecast-ready) ----
     if not result.get("ok"):
         err = (result.get("error") or "").strip()
+        remote = result.get("remote_api") or {}
+        is_remote = bool(
+            remote
+            or result.get("fail_reason") == "remote_api"
+            or "market-data" in err.lower()
+            or "api key" in err.lower()
+            or "could not reach" in err.lower()
+        )
         is_hist = bool(
-            short
-            or no_hist
-            or "IPO" in err
-            or "trading history" in err.lower()
-            or "not enough" in err.lower()
+            not is_remote
+            and (
+                short
+                or no_hist
+                or "IPO" in err
+                or "trading history" in err.lower()
+                or "not enough" in err.lower()
+            )
         )
         lines: list[str] = []
+        if is_remote:
+            lines.append("❌ **Could not update market data from the remote provider.**")
+            if err:
+                # Gentle multi-line message already includes checklist
+                lines.append(err)
+            else:
+                lines.append(
+                    "Check internet access, API key, and subscription status "
+                    "(see checklist below)."
+                )
+            if not err or "Please check:" not in err:
+                lines.append("")
+                lines.append("**What you can do next**")
+                lines.append(
+                    "1. **Recommended:** Confirm **internet access** and that "
+                    "**FMP_API_KEY** (or your data provider token) is valid and active."
+                )
+                lines.append(
+                    "2. If your plan expired or the key was rotated, update `.env` "
+                    "and **restart** the dashboard, then retry."
+                )
+                lines.append(
+                    "3. Open **Technical log** for the raw provider error."
+                )
+            return "\n\n".join(lines)
         if is_hist:
             lines.append(
                 f"❌ **None of these symbols are ready for forecasts yet** "
@@ -359,17 +395,53 @@ def _refresh_summary(result: dict) -> str:
             )
         err = (result.get("error") or forecast.get("error") or "").strip()
         err_l = err.lower()
-        is_cov = bool(
-            forecast.get("need_covariates")
-            or result.get("fail_reason") == "covariates"
-            or "dimensionality" in err_l
-            or "feature mismatch" in err_l
-            or "fund-thin" in err_l
-            or "past_covariates" in err_l
+        remote = (
+            result.get("remote_api")
+            or gather.get("remote_api")
+            or forecast.get("remote_api")
+            or {}
         )
-        is_hist = bool(incomplete and not ready and not is_cov)
+        is_remote = bool(
+            remote
+            or result.get("fail_reason") == "remote_api"
+            or gather.get("fail_reason") == "remote_api"
+            or "market-data" in err_l
+            or "api key" in err_l
+            or "could not reach" in err_l
+            or "subscription" in err_l
+        )
+        is_cov = bool(
+            not is_remote
+            and (
+                forecast.get("need_covariates")
+                or result.get("fail_reason") == "covariates"
+                or "dimensionality" in err_l
+                or "feature mismatch" in err_l
+                or "fund-thin" in err_l
+                or "past_covariates" in err_l
+            )
+        )
+        is_hist = bool(incomplete and not ready and not is_cov and not is_remote)
 
         lines = [head]
+        if is_remote:
+            lines.append(
+                "Market data could not be refreshed from the remote provider."
+            )
+            if err:
+                lines.append(err)
+            if not err or "Please check:" not in err:
+                lines.append("**What you can do next**")
+                lines.append(
+                    "1. **Recommended:** Check **internet**, **FMP_API_KEY** "
+                    "(valid / not revoked), and that your **data plan is active**."
+                )
+                lines.append(
+                    "2. Restart the dashboard after updating keys, then retry."
+                )
+                lines.append("3. Open **Technical log** for the provider detail.")
+            return "\n\n".join(lines)
+
         if err:
             lines.append(err)
         # Only restate gather hard-fail; skip green gather success + IPO advice

--- a/src/canswim/mcp/tools/runs.py
+++ b/src/canswim/mcp/tools/runs.py
@@ -70,7 +70,13 @@ def gather_tickers_impl(
             pass
     if result.get("ok"):
         return ok_result(result)
-    return err_result(result.get("error") or "gather failed", data=result)
+    # Surface structured remote_api (network / key / plan) for MCP clients
+    return err_result(
+        result.get("error") or "gather failed",
+        data=result,
+        remote_api=result.get("remote_api"),
+        fail_reason=result.get("fail_reason"),
+    )
 
 
 def forecast_tickers_impl(
@@ -96,7 +102,12 @@ def forecast_tickers_impl(
     )
     if result.get("ok"):
         return ok_result(result)
-    return err_result(result.get("error") or "forecast failed", data=result)
+    return err_result(
+        result.get("error") or "forecast failed",
+        data=result,
+        remote_api=result.get("remote_api"),
+        fail_reason=result.get("fail_reason"),
+    )
 
 
 def refresh_tickers_impl(
@@ -127,7 +138,17 @@ def refresh_tickers_impl(
     )
     if result.get("ok"):
         return ok_result(result)
-    return err_result(result.get("error") or "refresh failed", data=result)
+    # Propagate gather remote_api if present under nested gather
+    remote = result.get("remote_api") or (result.get("gather") or {}).get(
+        "remote_api"
+    )
+    return err_result(
+        result.get("error") or "refresh failed",
+        data=result,
+        remote_api=remote,
+        fail_reason=result.get("fail_reason")
+        or (result.get("gather") or {}).get("fail_reason"),
+    )
 
 
 def runs_enabled() -> bool:

--- a/src/canswim/remote_api_errors.py
+++ b/src/canswim/remote_api_errors.py
@@ -1,0 +1,466 @@
+"""Classify remote market-data API failures for consumer-facing GUI / MCP / CLI.
+
+Maps network, auth, subscription, rate-limit, and missing-key failures from FMP,
+yfinance, and generic HTTP into a short message plus a practical checklist.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any, Optional, Sequence, Union
+
+
+# Stable kinds for tests / MCP structured output
+KIND_NETWORK = "network"
+KIND_TIMEOUT = "timeout"
+KIND_AUTH = "auth"
+KIND_SUBSCRIPTION = "subscription"
+KIND_RATE_LIMIT = "rate_limit"
+KIND_MISSING_KEY = "missing_key"
+KIND_HTTP = "http"
+KIND_UNKNOWN = "unknown"
+
+
+@dataclass
+class RemoteApiIssue:
+    """Structured remote API failure for operators and clients."""
+
+    kind: str
+    message: str
+    checklist: list[str] = field(default_factory=list)
+    provider: Optional[str] = None
+    detail: str = ""
+    http_status: Optional[int] = None
+
+    def as_dict(self) -> dict[str, Any]:
+        d = asdict(self)
+        return d
+
+    def user_text(self, *, include_checklist: bool = True) -> str:
+        """Plain-language block suitable for GUI markdown or MCP error strings."""
+        parts = [self.message.strip()]
+        if include_checklist and self.checklist:
+            parts.append("")
+            parts.append("Please check:")
+            for i, item in enumerate(self.checklist, 1):
+                parts.append(f"{i}. {item}")
+        if self.provider:
+            parts.append("")
+            parts.append(f"(Data provider: {self.provider})")
+        return "\n".join(parts).strip()
+
+
+_DEFAULT_CHECKLIST = [
+    "Internet connectivity (can you open financial sites in a browser?).",
+    "API key is set in the environment (e.g. FMP_API_KEY) and has not been rotated or revoked.",
+    "Your market-data plan is active (subscription not expired; tier covers this endpoint).",
+    "Service status for the provider (FMP, Yahoo, etc.) if many users report outages.",
+    "Retry later if you hit rate limits—wait a few minutes or reduce the symbol list.",
+]
+
+
+def _text_blob(err: Union[BaseException, str, None], extra: Sequence[str] = ()) -> str:
+    parts: list[str] = []
+    if err is not None:
+        if isinstance(err, BaseException):
+            parts.append(type(err).__name__)
+            parts.append(str(err))
+            # Chain
+            cause = err.__cause__ or getattr(err, "__context__", None)
+            if cause is not None:
+                parts.append(str(cause))
+        else:
+            parts.append(str(err))
+    parts.extend(str(x) for x in (extra or []) if x)
+    return " ".join(parts).lower()
+
+
+def _infer_provider(text: str, provider: Optional[str]) -> Optional[str]:
+    if provider:
+        return provider
+    if "fmp" in text or "financialmodelingprep" in text or "fmpsdk" in text:
+        return "FMP (Financial Modeling Prep)"
+    if "yfinance" in text or "yahoo" in text:
+        return "Yahoo Finance (yfinance)"
+    if "huggingface" in text or "hf hub" in text or "hf_token" in text:
+        return "Hugging Face"
+    return None
+
+
+def _http_status_from_exc(err: Union[BaseException, str, None]) -> Optional[int]:
+    if not isinstance(err, BaseException):
+        return None
+    for attr in ("status_code", "code", "errno"):
+        v = getattr(err, attr, None)
+        if isinstance(v, int) and 100 <= v < 600:
+            return v
+    resp = getattr(err, "response", None)
+    if resp is not None:
+        sc = getattr(resp, "status_code", None)
+        if isinstance(sc, int):
+            return sc
+    # Parse "401 Client Error" style
+    s = str(err)
+    for code in (401, 403, 402, 429, 500, 502, 503, 504):
+        if str(code) in s:
+            return code
+    return None
+
+
+def classify_remote_error(
+    err: Union[BaseException, str, None] = None,
+    *,
+    provider: Optional[str] = None,
+    extra_messages: Sequence[str] = (),
+    http_status: Optional[int] = None,
+) -> RemoteApiIssue:
+    """Classify a remote failure into a gentle, actionable RemoteApiIssue."""
+    text = _text_blob(err, extra_messages)
+    prov = _infer_provider(text, provider)
+    status = http_status if http_status is not None else _http_status_from_exc(err)
+    detail = str(err) if err is not None else " ".join(str(x) for x in extra_messages)
+
+    # --- missing key ---
+    if (
+        "fmp_api_key" in text
+        and ("missing" in text or "not set" in text or "none" in text or "found: false" in text)
+    ) or (
+        "api key" in text
+        and ("missing" in text or "not set" in text or "required" in text or "not found" in text)
+    ) or ("no api key" in text or "apikey is invalid" in text and "empty" in text):
+        return RemoteApiIssue(
+            kind=KIND_MISSING_KEY,
+            provider=prov or "FMP (Financial Modeling Prep)",
+            message=(
+                "Market data could not be downloaded because an API key is missing "
+                "or not visible to this process."
+            ),
+            checklist=[
+                "Set FMP_API_KEY in your environment or `.env` (same shell that starts the dashboard / MCP).",
+                "Restart the dashboard or MCP server after changing keys so the new value is loaded.",
+                "Confirm the key is not blank and has no extra quotes/spaces.",
+            ],
+            detail=detail,
+            http_status=status,
+        )
+
+    # --- auth / revoked ---
+    auth_markers = (
+        "invalid api key",
+        "invalid apikey",
+        "api key not valid",
+        "unauthorized",
+        "authentication",
+        "not authenticated",
+        "token revoked",
+        "revoked",
+        "forbidden",
+        "access denied",
+        "permission denied",
+        "401",
+        "403",
+    )
+    if status in (401, 403) or any(m in text for m in auth_markers):
+        # Prefer subscription wording when plan language is also present
+        if any(
+            m in text
+            for m in (
+                "premium",
+                "subscribe",
+                "subscription",
+                "upgrade",
+                "plan",
+                "legacy endpoint",
+                "available exclusively",
+            )
+        ):
+            pass  # fall through to subscription below after re-check
+        else:
+            return RemoteApiIssue(
+                kind=KIND_AUTH,
+                provider=prov,
+                message=(
+                    "The market-data provider rejected this request "
+                    "(invalid, expired, or revoked API credentials)."
+                ),
+                checklist=[
+                    "Verify FMP_API_KEY (or the relevant provider token) is current.",
+                    "If you rotated keys, update `.env` and restart the app / MCP server.",
+                    "Confirm the key was not revoked in the provider’s dashboard.",
+                    "Check that this process is using the same environment as your working CLI tests.",
+                ],
+                detail=detail,
+                http_status=status,
+            )
+
+    # --- subscription / premium ---
+    sub_markers = (
+        "premium",
+        "subscription",
+        "subscribe",
+        "upgrade your plan",
+        "legacy endpoint",
+        "exclusive",
+        "paid plan",
+        "not available under",
+        "limit of your plan",
+        "402",
+    )
+    if status == 402 or any(m in text for m in sub_markers):
+        return RemoteApiIssue(
+            kind=KIND_SUBSCRIPTION,
+            provider=prov or "FMP (Financial Modeling Prep)",
+            message=(
+                "The market-data provider reports this endpoint or usage is not "
+                "available on the current plan (subscription expired, tier too low, "
+                "or feature not included)."
+            ),
+            checklist=[
+                "Log into the provider account and confirm the subscription is active.",
+                "Check whether the plan includes historical prices / fundamentals you need.",
+                "If the trial or billing period ended, renew or upgrade, then retry.",
+                "After plan changes, wait a few minutes and restart the dashboard / MCP.",
+            ],
+            detail=detail,
+            http_status=status,
+        )
+
+    # --- rate limit ---
+    if status == 429 or any(
+        m in text
+        for m in (
+            "rate limit",
+            "too many requests",
+            "429",
+            "throttle",
+            "quota exceeded",
+        )
+    ):
+        return RemoteApiIssue(
+            kind=KIND_RATE_LIMIT,
+            provider=prov,
+            message=(
+                "The market-data provider rate-limited this request "
+                "(too many calls in a short time)."
+            ),
+            checklist=[
+                "Wait a few minutes, then retry with a shorter symbol list.",
+                "Avoid running multiple gathers/refreshes at once.",
+                "If this happens often, check your plan’s rate limits or spread work over time.",
+            ],
+            detail=detail,
+            http_status=status,
+        )
+
+    # --- timeout ---
+    if any(
+        m in text
+        for m in (
+            "timeout",
+            "timed out",
+            "read timed out",
+            "connect timeout",
+            "deadline exceeded",
+        )
+    ):
+        return RemoteApiIssue(
+            kind=KIND_TIMEOUT,
+            provider=prov,
+            message=(
+                "A market-data request timed out before a response arrived "
+                "(slow network or overloaded provider)."
+            ),
+            checklist=[
+                "Check your internet connection stability.",
+                "Retry with fewer symbols.",
+                "Try again later if the provider is slow or degraded.",
+            ],
+            detail=detail,
+            http_status=status,
+        )
+
+    # --- network / DNS / connection ---
+    network_markers = (
+        "nameresolutionerror",
+        "getaddrinfo",
+        "nodename nor servname",
+        "failed to resolve",
+        "connection error",
+        "connection refused",
+        "connection reset",
+        "connection aborted",
+        "network is unreachable",
+        "temporary failure in name resolution",
+        "max retries exceeded",
+        "newconnectionerror",
+        "connecterror",
+        "sslerror",
+        "certificate verify",
+        "proxyerror",
+        "offline",
+        "no route to host",
+    )
+    network_exc = isinstance(err, (ConnectionError, TimeoutError)) or (
+        isinstance(err, OSError)
+        and any(m in text for m in ("connect", "network", "resolve", "unreachable", "refused", "reset"))
+    )
+    if network_exc or any(m in text for m in network_markers):
+        return RemoteApiIssue(
+            kind=KIND_NETWORK,
+            provider=prov,
+            message=(
+                "Could not reach the market-data service "
+                "(network, DNS, firewall, or provider outage)."
+            ),
+            checklist=[
+                "Confirm this machine has working internet access.",
+                "If you use VPN/proxy/firewall, allow HTTPS to the data provider.",
+                "Check provider status pages if the outage looks widespread.",
+                "Retry once connectivity is restored.",
+            ],
+            detail=detail,
+            http_status=status,
+        )
+
+    # --- generic HTTP 5xx ---
+    if status is not None and status >= 500:
+        return RemoteApiIssue(
+            kind=KIND_HTTP,
+            provider=prov,
+            message=(
+                f"The market-data service returned an error (HTTP {status}). "
+                "This is often temporary on the provider side."
+            ),
+            checklist=[
+                "Retry in a few minutes.",
+                "Check the provider’s status page for an outage.",
+                "If it persists, open Technical log / MCP details for the raw error.",
+            ],
+            detail=detail,
+            http_status=status,
+        )
+
+    # --- unknown but looks remote ---
+    if any(
+        m in text
+        for m in (
+            "http",
+            "https",
+            "api",
+            "request",
+            "remote",
+            "endpoint",
+            "fmpsdk",
+            "yfinance",
+            "download",
+        )
+    ):
+        return RemoteApiIssue(
+            kind=KIND_UNKNOWN,
+            provider=prov,
+            message=(
+                "Market data could not be downloaded from the remote provider. "
+                "This is often network access, an expired/revoked API key, "
+                "or a subscription/plan limit."
+            ),
+            checklist=list(_DEFAULT_CHECKLIST),
+            detail=detail,
+            http_status=status,
+        )
+
+    return RemoteApiIssue(
+        kind=KIND_UNKNOWN,
+        provider=prov,
+        message=(
+            "Something went wrong while updating market data from a remote source. "
+            "If downloads keep failing, check network access and your API credentials."
+        ),
+        checklist=list(_DEFAULT_CHECKLIST),
+        detail=detail,
+        http_status=status,
+    )
+
+
+def looks_like_remote_failure(
+    err: Union[BaseException, str, None] = None,
+    *,
+    extra_messages: Sequence[str] = (),
+) -> bool:
+    """Heuristic: is this likely a remote API / network issue vs local data policy?"""
+    text = _text_blob(err, extra_messages)
+    if not text.strip():
+        return False
+    # Local policy failures — not remote
+    local_markers = (
+        "not enough trading history",
+        "short history",
+        "incomplete",
+        "ipo",
+        "invalid tickers",
+        "no symbols",
+        "mcp_allow_runs",
+        "runs are disabled",
+        "dimensionality",
+        "past_covariates",
+        "already on file",
+    )
+    if any(m in text for m in local_markers) and not any(
+        m in text
+        for m in ("http", "api key", "fmp", "connection", "timeout", "401", "403", "429")
+    ):
+        return False
+    issue = classify_remote_error(err, extra_messages=extra_messages)
+    return issue.kind != KIND_UNKNOWN or any(
+        m in text
+        for m in (
+            "fmp",
+            "yfinance",
+            "api key",
+            "connection",
+            "timeout",
+            "rate limit",
+            "unauthorized",
+            "premium",
+            "subscription",
+        )
+    )
+
+
+def enrich_result_with_remote_issue(
+    result: dict[str, Any],
+    err: Union[BaseException, str, None] = None,
+    *,
+    provider: Optional[str] = None,
+    extra_messages: Sequence[str] = (),
+    force_error_message: bool = True,
+) -> dict[str, Any]:
+    """Attach ``remote_api`` and prefer a gentle ``error`` string when remote.
+
+    When ``result['ok']`` is True, only attaches advisory ``remote_api`` (does not
+    flip ok or invent a hard error) unless ``force_error_message`` and ok is False.
+    """
+    extras = list(extra_messages)
+    if result.get("messages"):
+        extras.extend(str(m) for m in result["messages"])
+    if err is None and result.get("error"):
+        err = result.get("error")
+    if not looks_like_remote_failure(err, extra_messages=extras):
+        return result
+    issue = classify_remote_error(
+        err, provider=provider, extra_messages=extras
+    )
+    result = dict(result)
+    result["remote_api"] = issue.as_dict()
+    if result.get("ok") is True:
+        # Soft note only — e.g. one fund endpoint failed but prices succeeded
+        note = issue.user_text(include_checklist=False)
+        msgs = list(result.get("messages") or [])
+        if note and note not in msgs:
+            msgs.append(f"Remote data note: {note}")
+        result["messages"] = msgs
+        return result
+    result["fail_reason"] = result.get("fail_reason") or "remote_api"
+    if force_error_message:
+        # Prefer gentle message as primary error (raw detail in remote_api.detail)
+        result["error"] = issue.user_text(include_checklist=True)
+    return result

--- a/src/canswim/remote_api_errors.py
+++ b/src/canswim/remote_api_errors.py
@@ -387,41 +387,71 @@ def looks_like_remote_failure(
     extra_messages: Sequence[str] = (),
 ) -> bool:
     """Heuristic: is this likely a remote API / network issue vs local data policy?"""
-    text = _text_blob(err, extra_messages)
-    if not text.strip():
-        return False
-    # Local policy failures — not remote
+    # Primary error wins: history / IPO policy must not be overridden by soft
+    # notes like "FMP_API_KEY not set" that we always append when key is absent.
+    primary = _text_blob(err)
     local_markers = (
         "not enough trading history",
         "short history",
-        "incomplete",
-        "ipo",
+        "trading history yet",
+        "recent ipos",
         "invalid tickers",
         "no symbols",
         "mcp_allow_runs",
         "runs are disabled",
         "dimensionality",
         "past_covariates",
+        "feature mismatch",
         "already on file",
+        "week-aligned",
+        "could not resolve",
     )
-    if any(m in text for m in local_markers) and not any(
-        m in text
-        for m in ("http", "api key", "fmp", "connection", "timeout", "401", "403", "429")
-    ):
+    if primary.strip() and any(m in primary for m in local_markers):
+        # Still remote if primary itself is clearly an API failure
+        if not any(
+            m in primary
+            for m in (
+                "http",
+                "unauthorized",
+                "connection",
+                "timeout",
+                "rate limit",
+                "invalid api",
+                "subscription",
+                "premium",
+            )
+        ):
+            return False
+
+    text = _text_blob(err, extra_messages)
+    if not text.strip():
         return False
+
     issue = classify_remote_error(err, extra_messages=extra_messages)
-    return issue.kind != KIND_UNKNOWN or any(
+    if issue.kind in (
+        KIND_NETWORK,
+        KIND_TIMEOUT,
+        KIND_AUTH,
+        KIND_SUBSCRIPTION,
+        KIND_RATE_LIMIT,
+        KIND_MISSING_KEY,
+        KIND_HTTP,
+    ):
+        # Missing-key soft notes alone should not reclassify a local failure
+        if issue.kind == KIND_MISSING_KEY and primary.strip():
+            if any(m in primary for m in local_markers):
+                return False
+        return True
+    return any(
         m in text
         for m in (
-            "fmp",
-            "yfinance",
-            "api key",
-            "connection",
-            "timeout",
+            "connection refused",
+            "name resolution",
             "rate limit",
             "unauthorized",
             "premium",
-            "subscription",
+            "subscription expired",
+            "invalid api key",
         )
     )
 

--- a/src/canswim/run_triggers.py
+++ b/src/canswim/run_triggers.py
@@ -32,6 +32,10 @@ from loguru import logger
 from canswim.calendar_weeks import list_monthly_catchup_origins, resolve_forecast_start
 from canswim.eligibility import is_valid_ticker_symbol
 from canswim.hfhub import _env_bool
+from canswim.remote_api_errors import (
+    enrich_result_with_remote_issue,
+    looks_like_remote_failure,
+)
 
 # Soft cap so accidental pastes do not launch huge jobs
 DEFAULT_MAX_TICKERS = 50
@@ -433,6 +437,12 @@ def gather_for_tickers(
         # Scoped user runs: ~2y missing-only (not multi-decade train history)
         g.gather_mode = "forecast"
 
+        if not getattr(g, "FMP_API_KEY", None):
+            messages.append(
+                "FMP_API_KEY not set — will try yfinance for prices; "
+                "fundamentals (ownership, estimates, profiles) need FMP."
+            )
+
         # Broad market / sectors: reuse local files on small scopes
         try:
             g.gather_broad_market_data()
@@ -491,7 +501,7 @@ def gather_for_tickers(
             friendly = ""
 
         if still_incomplete and not ready:
-            return {
+            out_inc: dict[str, Any] = {
                 "ok": False,
                 "error": friendly
                 or INCOMPLETE_DATA_MSG.format(symbols=", ".join(still_incomplete)),
@@ -507,6 +517,18 @@ def gather_for_tickers(
                 "ready": [],
                 "need_gather": True,
             }
+            # Remote download planned but nothing usable → often API/network
+            if planned_fetch and planned_but_empty:
+                out_inc = enrich_result_with_remote_issue(
+                    out_inc,
+                    extra_messages=messages
+                    + [
+                        "No usable download after remote market-data request.",
+                        "FMP or yfinance may be unreachable or rejecting the API key.",
+                    ],
+                    provider="FMP / yfinance",
+                )
+            return out_inc
 
         if still_incomplete and ready:
             messages.append(friendly)
@@ -585,7 +607,7 @@ def gather_for_tickers(
         except Exception as e:
             messages.append(f"Charts list sync note: {e}")
 
-        return {
+        out_ok: dict[str, Any] = {
             "ok": True,
             "partial": bool(still_incomplete),
             "tickers": tickers,
@@ -601,10 +623,20 @@ def gather_for_tickers(
             "ready": ready,
             "db_sync": db_sync,
         }
+        # Soft remote notes (e.g. fund endpoint failed) → attach structured hint
+        if any(
+            looks_like_remote_failure(m) for m in messages if isinstance(m, str)
+        ):
+            out_ok = enrich_result_with_remote_issue(
+                out_ok, extra_messages=[str(m) for m in messages]
+            )
+            # success path keeps ok=True; remote_api is advisory for UI
+            out_ok["ok"] = True
+        return out_ok
     except Exception as e:
         logger.exception("gather_for_tickers failed")
         err = str(e)
-        return {
+        out_fail: dict[str, Any] = {
             "ok": False,
             "error": err,
             "tickers": tickers,
@@ -612,6 +644,9 @@ def gather_for_tickers(
             "messages": messages,
             "need_gather": True,
         }
+        return enrich_result_with_remote_issue(
+            out_fail, e, extra_messages=[str(m) for m in messages]
+        )
 
 
 def _ensure_symbols_on_list(tickers: Sequence[str]) -> Path:
@@ -1129,6 +1164,11 @@ def refresh_symbols(
         )
         out["ok"] = False
         out["need_gather"] = True
+        if gather.get("remote_api"):
+            out["remote_api"] = gather["remote_api"]
+            out["fail_reason"] = gather.get("fail_reason") or "remote_api"
+        elif looks_like_remote_failure(out.get("error"), extra_messages=messages):
+            out = enrich_result_with_remote_issue(out, out.get("error"))
         _report_progress(progress_cb, 1.0, "Stopped — no forecast-ready symbols.")
         return out
 

--- a/src/canswim/run_triggers.py
+++ b/src/canswim/run_triggers.py
@@ -644,9 +644,13 @@ def gather_for_tickers(
             "messages": messages,
             "need_gather": True,
         }
-        return enrich_result_with_remote_issue(
-            out_fail, e, extra_messages=[str(m) for m in messages]
-        )
+        # Classify from the exception first; soft FMP notes must not hide
+        # local short-history / IPO readiness failures.
+        if looks_like_remote_failure(e):
+            return enrich_result_with_remote_issue(
+                out_fail, e, extra_messages=[str(m) for m in messages]
+            )
+        return out_fail
 
 
 def _ensure_symbols_on_list(tickers: Sequence[str]) -> Path:

--- a/tests/canswim/test_remote_api_errors.py
+++ b/tests/canswim/test_remote_api_errors.py
@@ -1,0 +1,122 @@
+"""Remote market-data API failure classification (GUI / MCP messaging)."""
+
+from __future__ import annotations
+
+import pytest
+
+from canswim.remote_api_errors import (
+    KIND_AUTH,
+    KIND_MISSING_KEY,
+    KIND_NETWORK,
+    KIND_RATE_LIMIT,
+    KIND_SUBSCRIPTION,
+    KIND_TIMEOUT,
+    classify_remote_error,
+    enrich_result_with_remote_issue,
+    looks_like_remote_failure,
+)
+
+
+def test_classify_network_dns():
+    issue = classify_remote_error(
+        "HTTPSConnectionPool: Max retries exceeded "
+        "(Caused by NameResolutionError: Failed to resolve "
+        "'financialmodelingprep.com')"
+    )
+    assert issue.kind == KIND_NETWORK
+    assert "reach" in issue.message.lower() or "network" in issue.message.lower()
+    assert any("internet" in c.lower() for c in issue.checklist)
+    assert issue.provider and "FMP" in issue.provider
+
+
+def test_classify_auth_401():
+    issue = classify_remote_error("401 Client Error: Unauthorized for url")
+    assert issue.kind == KIND_AUTH
+    assert "revoked" in issue.message.lower() or "invalid" in issue.message.lower()
+
+
+def test_classify_subscription():
+    issue = classify_remote_error(
+        "Legacy endpoint is available exclusively for Legacy Premium subscribers"
+    )
+    assert issue.kind == KIND_SUBSCRIPTION
+    assert any("subscription" in c.lower() or "plan" in c.lower() for c in issue.checklist)
+
+
+def test_classify_rate_limit():
+    issue = classify_remote_error("429 Too Many Requests — rate limit exceeded")
+    assert issue.kind == KIND_RATE_LIMIT
+
+
+def test_classify_timeout():
+    issue = classify_remote_error("Read timed out after 30s")
+    assert issue.kind == KIND_TIMEOUT
+
+
+def test_classify_missing_key():
+    issue = classify_remote_error("FMP_API_KEY missing; cannot fallback stock prices")
+    assert issue.kind == KIND_MISSING_KEY
+    text = issue.user_text()
+    assert "FMP_API_KEY" in text
+    assert "Please check:" in text
+
+
+def test_looks_like_remote_vs_local_history():
+    assert looks_like_remote_failure("Connection refused to api.example.com")
+    assert not looks_like_remote_failure(
+        "Not enough trading history yet for: BOT. Recent IPOs usually cannot."
+    )
+
+
+def test_enrich_failure_rewrites_error():
+    r = enrich_result_with_remote_issue(
+        {"ok": False, "error": "raw", "messages": []},
+        ConnectionError("Failed to resolve 'financialmodelingprep.com'"),
+    )
+    assert r["ok"] is False
+    assert r.get("remote_api", {}).get("kind") == KIND_NETWORK
+    assert "Please check:" in r["error"]
+    assert r["fail_reason"] == "remote_api"
+
+
+def test_enrich_success_is_advisory_only():
+    r = enrich_result_with_remote_issue(
+        {
+            "ok": True,
+            "messages": ["earnings note: 401 Unauthorized from FMP"],
+            "ready": ["AAPL"],
+        },
+        extra_messages=["earnings note: 401 Unauthorized from FMP"],
+    )
+    assert r["ok"] is True
+    assert "remote_api" in r
+    assert any("Remote data note" in m for m in r["messages"])
+
+
+def test_gather_summary_mentions_remote(monkeypatch):
+    from canswim.dashboard.run_tab import _gather_summary
+
+    s = _gather_summary(
+        {
+            "ok": False,
+            "error": classify_remote_error(
+                "Invalid API KEY"
+            ).user_text(include_checklist=True),
+            "remote_api": classify_remote_error("Invalid API KEY").as_dict(),
+            "fail_reason": "remote_api",
+            "tickers": ["AAPL"],
+            "ready": [],
+            "incomplete": ["AAPL"],
+        }
+    )
+    assert "remote provider" in s.lower() or "api" in s.lower()
+    assert "AAPL" in s or "check" in s.lower()
+
+
+def test_mcp_err_result_includes_remote_api():
+    from canswim.mcp.tools._common import err_result
+
+    issue = classify_remote_error("subscription expired").as_dict()
+    out = err_result("gentle", data={"ok": False}, remote_api=issue)
+    assert out["ok"] is False
+    assert out["remote_api"]["kind"] == KIND_SUBSCRIPTION


### PR DESCRIPTION
## Summary

- New `canswim.remote_api_errors`: classify FMP/yfinance failures into **network / auth / subscription / rate_limit / missing_key / timeout**
- Gentle checklist copy for operators (internet, key revoked, plan expired, restart after `.env` change)
- Wired through **gather / refresh** → Run tab status + MCP `err_result.remote_api`
- Docs: `docs/run_triggers.md` section

## Test plan

- [x] Local CI 187 passed
- [x] Unit tests for classifier + UX/MCP payload
- [ ] GitHub Actions green → merge