### PR TITLE
feat: versioned DuckDB search schema migrations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ User-facing docs live under `docs/` and the root `README.md`. **Update them in t
 | `docs/cli.md` | CLI recipes / env / workflows |
 | `docs/run_triggers.md` | Gather/forecast policy (CLI · GUI · MCP) |
 | `docs/mcp.md` | MCP tools + opt-in writes |
-| `docs/data_store.md` | Parquet vs DuckDB |
+| `docs/data_store.md` | Parquet vs DuckDB **and schema migrations** |
 | `README.md` | Landing links + short tables |
 | `docs/images/{charts,scans,run}.png` | Dashboard screenshots |
 
@@ -47,6 +47,28 @@ User-facing docs live under `docs/` and the root `README.md`. **Update them in t
 | MCP tools add/rename/remove | `docs/mcp.md` tool table (+ README link only if needed) |
 | Charts / Scans / Run layout or primary copy | Replace affected `docs/images/*.png` in the same PR |
 | Data paths / DuckDB vs parquet semantics | `docs/data_store.md` |
+| **Search DB / DuckDB schema** | See **Schema migrations** below |
+
+## Schema migrations (required between app versions)
+
+**Every change that affects the DuckDB search schema must ship with documented, coded, and tested migration steps.** Do not rely on “just rebuild” alone without a versioned path for operators who reuse local DBs.
+
+| Requirement | Where |
+|-------------|--------|
+| Schema version constant + migration functions | `src/canswim/db_migrations.py` (`CURRENT_SCHEMA_VERSION`, `MIGRATIONS`) |
+| Apply on reuse; stamp on full rebuild | `init_search_db` in `src/canswim/db.py` |
+| Operator upgrade steps + migration log | `docs/data_store.md` |
+| Automated tests for upgrade path | `tests/canswim/test_db_migrations.py` |
+
+**Checklist for a schema-changing PR:**
+
+1. Bump `CURRENT_SCHEMA_VERSION` and add a `Migration` (name + description + `upgrade`).
+2. Append a row to the **Migration log** in `docs/data_store.md`.
+3. Add/extend tests: old version (or legacy pre-meta DB) → new version.
+4. Prefer **additive** migrations; if a full rebuild is required, document that explicitly as the operator step.
+5. Run `./scripts/ci-local.sh` before push/merge.
+
+Parquet under `data/` remains the system of record; migrations evolve the **search cache**. Full rebuild (`--same_data False` / Rebuild Charts database) remains the escape hatch and must stamp the current schema version.
 
 Do **not** maintain a separate design-doc tree that diverges from `docs/run_triggers.md`. Prefer tests that lock consumer strings (`tests/canswim/test_ux_split_labels.py`) and MCP tool registration checks (`tests/canswim/test_docs_sync.py`) over stale prose.
 

--- a/docs/data_store.md
+++ b/docs/data_store.md
@@ -9,36 +9,125 @@
 | **Parquet (system of record)** | `data/data-3rd-party/*.parquet`, `data/forecast/` | Ground-truth prices, fundamentals, model forecasts. Written by gather/forecast/train pipelines. |
 | **DuckDB (search / UI cache)** | `data/<db_file>` e.g. `canswim_local.duckdb` | Charts dropdown, Scans, Advanced SQL, MCP reads. **Derived** from parquet. |
 
-If the UI or MCP looks stale or missing a symbol, the usual fix is: ensure parquet is updated, then **rebuild or sync** the search DB—not invent rows in DuckDB alone.
+If the UI or MCP looks stale or missing a symbol, the usual fix is: ensure parquet is updated, then **rebuild or migrate** the search DB—not invent rows in DuckDB alone.
 
 ## What each is used for
 
 - **Gather** writes/merges parquet (prices, earnings, ownership, estimates, company profiles, …).
 - **Forecast** writes forecast partitions under `data/forecast/` (and may sync rows into DuckDB).
-- **Dashboard** builds or reuses DuckDB (`--same_data True` reuses; first open / rebuild loads from parquet).
+- **Dashboard** builds or reuses DuckDB (`--same_data True` reuses + **runs migrations**; first open / rebuild loads from parquet).
 - **MCP** reads DuckDB; optional `MCP_INIT_DB=1` can build it on start.
 
 Scoped gather/forecast also **sync** symbols, forecast rows, and **company profiles** into DuckDB so Charts/Scans pick up new tickers and name/sector/industry without a full rebuild.
 
-| Parquet file | DuckDB table | Used by |
-|--------------|--------------|---------|
-| `data-3rd-party/company_profile.parquet` | `company_profile` | Charts company blurb; Scans `company_name` / `sector` / `industry` columns |
+## Search DB schema (DuckDB)
 
-`company_profile` is optional for `--same_data True` reuse (core scan tables can exist without it); gather/sync or a full rebuild populates it when the parquet is present.
+**Code:** `canswim.db` (tables), `canswim.db_migrations` (version + upgrades).  
+**Runtime export:** MCP `get_db_schema` / `describe_search_schema()` (live columns, types, indexes, `schema_version`).  
+**Current schema version:** `CURRENT_SCHEMA_VERSION` in `src/canswim/db_migrations.py` (v**1** as of this doc).
+
+### Core tables (required for reuse)
+
+| Table | Role | Typical keys / columns |
+|-------|------|-------------------------|
+| `stock_tickers` | Charts/Scans symbol universe | `symbol` (or `Symbol`) |
+| `forecast` | Quantile paths | `symbol`, `start_date` (origin), `date` (horizon day), `close_quantile_*` |
+| `latest_forecast` | Per-symbol latest origin | `symbol`, `date` (= max start_date) |
+| `close_price` | Historical closes | `Date`, `Symbol`/`symbol`, `Close` |
+| `backtest_error` | Mean abs log-error of median vs close | `symbol`, `start_date`, `mal_error` |
+
+### Optional tables
+
+| Table | Role |
+|-------|------|
+| `company_profile` | Name, sector, industry, exchange, mkt_cap, website, description (one row per symbol) |
+| `canswim_schema_meta` | Key/value meta: **`schema_version`**, migration stamps |
+
+### Parquet → DuckDB map
+
+| Parquet / path | DuckDB table | Notes |
+|----------------|--------------|--------|
+| `symbol_lists/*.csv` ∪ price ∪ forecast hive | `stock_tickers` | Union on rebuild; expand on reuse |
+| `data/forecast/**/*.parquet` (hive) | `forecast`, `latest_forecast` | Rebuild from hive partitions |
+| `data-3rd-party/all_stocks_price_hist_1d.parquet` | `close_price` | Target column (default Close) |
+| (derived from forecast + close) | `backtest_error` | Computed on rebuild / refreshed on forecast sync |
+| `data-3rd-party/company_profile.parquet` | `company_profile` | Optional; lazy repair on reuse |
+
+### Indexes (created on full rebuild)
+
+- `forecast_symd_idx` on `forecast (symbol, start_date, date)`
+- `latest_forecast_symd_idx` on `latest_forecast (symbol, date)`
+- `close_price_symd_idx` on `close_price (symbol, date)`
+- `backtest_error_sym_start_idx` on `backtest_error (symbol, start_date)`
+
+Column casing may vary (`Symbol` vs `symbol`); prefer `upper(symbol)` joins in custom SQL.
+
+---
+
+## Upgrading between app versions (required path)
+
+**Going forward, every schema-affecting change must ship with:**
+
+1. **Code** — a new entry in `MIGRATIONS` + bump `CURRENT_SCHEMA_VERSION` (`db_migrations.py`)
+2. **Docs** — a row in the **Migration log** below (this file)
+3. **Tests** — coverage in `tests/canswim/test_db_migrations.py`
+
+### Operator upgrade steps
+
+1. **Install** the new `canswim` package (pip/conda).
+2. **Keep** local `data/data-3rd-party/` and `data/forecast/` (parquet SoT).
+3. **Start dashboard or rebuild:**
+   - Prefer: `python -m canswim dashboard --same_data True`  
+     → reuses DuckDB and **applies pending migrations automatically**.
+   - Or full rebuild: Run tab **Rebuild Charts database**, or  
+     `python -m canswim dashboard --same_data False`  
+     → recreates tables from parquet and **stamps current schema version**.
+4. **Confirm** (optional): MCP `get_db_schema` / health — `schema_version` should equal app `schema_version_current`.
+5. If migrations fail or the DB looks corrupt: **full rebuild** from parquet (step 3, `--same_data False`). Parquet is never rewritten by search migrations.
+
+### Escape hatch
+
+| Situation | Action |
+|-----------|--------|
+| Migration error / unknown old file | Rebuild: `--same_data False` or **Rebuild Charts database** |
+| Charts empty but parquet full | Rebuild search DB |
+| Only missing `company_profile` | Reuse path repairs it; or re-gather profiles |
+
+---
+
+## Migration log
+
+| Version | Name | App note | What the migration does |
+|---------|------|----------|-------------------------|
+| **1** | `baseline_search_v1` | Introduced with schema versioning | Ensures `canswim_schema_meta`; ensures optional `company_profile`; stamps `schema_version=1`. Legacy DBs with core tables but no meta are treated as v0 → v1. |
+
+*When adding v2+: append a row here in the same PR as the code migration.*
+
+### Developer checklist (new schema change)
+
+```text
+[ ] Bump CURRENT_SCHEMA_VERSION
+[ ] Add Migration(version=N, name=..., upgrade=...)
+[ ] Document in Migration log (this file)
+[ ] Test: apply_migrations from N-1 → N (and legacy → N if needed)
+[ ] Prefer additive changes; destructive changes require rebuild docs + test
+```
+
+---
 
 ## Operator tips
 
 ```bash
-# Reuse existing search DB (fast)
+# Reuse existing search DB (fast) + run migrations
 python -m canswim dashboard --same_data True
 
-# Rebuild search tables from local parquet (slower; use after major data changes)
+# Rebuild search tables from local parquet (slower; stamps current schema version)
 python -m canswim dashboard --same_data False
 ```
 
 - The dashboard shows a **search DB status** banner (path, reuse vs rebuild, row counts, whether parquet sources exist).
 - On the **Run** tab under More options, **Rebuild Charts database** rebuilds DuckDB without restarting (same as `--same_data False`).
-- With `--same_data True`, optional tables such as `company_profile` are **repaired lazily** if missing (no full wipe).
+- With `--same_data True`, optional tables such as `company_profile` are **repaired lazily** if missing (no full wipe); **schema migrations** run first.
 - Prefer **`hfhub_sync=False`** for local work so gather does not pull the full HF dataset snapshot.
 - Do not commit gitignored `data/` artifacts or slimmed local-only symbol lists used for experiments (see `AGENTS.md`).
 

--- a/src/canswim/db.py
+++ b/src/canswim/db.py
@@ -136,6 +136,8 @@ def search_db_status(db_path: Optional[str] = None) -> dict[str, Any]:
         except Exception:
             forecast_files = 0
 
+    from canswim.db_migrations import CURRENT_SCHEMA_VERSION, get_schema_version
+
     out: dict[str, Any] = {
         "db_path": path,
         "db_exists": Path(path).is_file(),
@@ -143,6 +145,9 @@ def search_db_status(db_path: Optional[str] = None) -> dict[str, Any]:
         "counts": {},
         "missing_core": list(CORE_SEARCH_TABLES),
         "missing_optional": ["company_profile"],
+        "schema_version": None,
+        "schema_version_current": CURRENT_SCHEMA_VERSION,
+        "schema_needs_migration": False,
         "parquet": {
             "prices": Path(paths.stocks_price_path).is_file(),
             "prices_path": paths.stocks_price_path,
@@ -174,6 +179,11 @@ def search_db_status(db_path: Optional[str] = None) -> dict[str, Any]:
                 t for t in ("company_profile",) if t not in existing
             ]
             out["ok"] = len(out["missing_core"]) == 0
+        ver = get_schema_version(path)
+        out["schema_version"] = ver
+        out["schema_needs_migration"] = (
+            ver is None or int(ver) < CURRENT_SCHEMA_VERSION
+        )
     except Exception as e:
         logger.warning(f"search_db_status({path}): {e}")
         out["error"] = str(e)
@@ -329,6 +339,12 @@ def init_search_db(
 
     if _should_reuse_db(db_path, same_data):
         logger.info("Reusing search database")
+        # Versioned migrations before optional repairs (see db_migrations.py)
+        from canswim.db_migrations import apply_migrations
+
+        migration = apply_migrations(db_path, paths=paths)
+        if not migration.get("ok"):
+            logger.warning(f"Search DB migration issue: {migration.get('error')}")
         repair = ensure_optional_search_tables(db_path, paths=paths)
         # Grow Charts list from local prices/forecasts without a full rebuild
         # (CSV-only stock_tickers used to hide gathered portfolio symbols).
@@ -348,6 +364,7 @@ def init_search_db(
             "rebuilt": False,
             "reused": True,
             "repair": repair,
+            "migration": migration,
             "status": status,
         }
 
@@ -466,11 +483,16 @@ def init_search_db(
             """
         )
         _create_or_load_company_profile_table(db_con, paths)
+    # Stamp schema version after full rebuild (escape hatch for any prior version)
+    from canswim.db_migrations import stamp_current_schema_version
+
+    migration = stamp_current_schema_version(db_path)
     status = search_db_status(db_path)
     return {
         "rebuilt": True,
         "reused": False,
         "repair": {"ok": True, "repaired": [], "notes": []},
+        "migration": migration,
         "status": status,
     }
 
@@ -1668,6 +1690,11 @@ SEARCH_TABLE_DOCS: dict[str, str] = {
         "Optional company metadata: name, sector, industry, country, "
         "exchange, mkt_cap, website, description. One row per symbol."
     ),
+    "canswim_schema_meta": (
+        "Search-DB schema versioning (key/value). "
+        "schema_version tracks migrations in canswim.db_migrations; "
+        "see docs/data_store.md Migration log."
+    ),
 }
 
 
@@ -1746,11 +1773,20 @@ def describe_search_schema(
     Includes tables, columns (name/type/nullable), indexes, optional row
     counts, and short purpose notes. Read-only connection only.
     """
+    from canswim.db_migrations import (
+        CURRENT_SCHEMA_VERSION,
+        get_schema_version,
+        list_migrations,
+    )
+
     path = db_path or get_db_path()
     out: dict[str, Any] = {
         "db_path": path,
         "db_exists": Path(path).is_file(),
         "read_only": True,
+        "schema_version": None,
+        "schema_version_current": CURRENT_SCHEMA_VERSION,
+        "migrations": list_migrations(),
         "sql_policy": (
             "Custom SQL via run_select: single SELECT or WITH…SELECT only; "
             "enforced + DuckDB read-only connection. "
@@ -1765,11 +1801,14 @@ def describe_search_schema(
             "search/UI cache (Charts, Scans, MCP).",
             "forecast.start_date = forecast origin; forecast.date = horizon day.",
             "Join company_profile on upper(symbol) for sector/industry filters.",
+            "Schema version is stored in canswim_schema_meta; "
+            "see docs/data_store.md for migration steps between app versions.",
         ],
     }
     if not out["db_exists"]:
         out["error"] = f"Database file not found: {path}"
         return out
+    out["schema_version"] = get_schema_version(path)
 
     try:
         with connect_readonly(path) as con:

--- a/src/canswim/db_migrations.py
+++ b/src/canswim/db_migrations.py
@@ -1,0 +1,263 @@
+"""Versioned DuckDB search-DB migrations (documented, coded, tested).
+
+Every app release that changes the search schema **must**:
+1. Bump ``CURRENT_SCHEMA_VERSION``
+2. Add a migration function in ``MIGRATIONS``
+3. Document it in ``docs/data_store.md`` (Migration log)
+4. Add/extend tests in ``tests/canswim/test_db_migrations.py``
+
+Parquet remains system of record; DuckDB is derived. Migrations evolve the
+cache in place when possible. Full rebuild (``init_search_db(same_data=False)``)
+is always a valid escape hatch and stamps the current version.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Callable, Optional
+
+from loguru import logger
+
+# ---------------------------------------------------------------------------
+# Schema contract (search DuckDB)
+# ---------------------------------------------------------------------------
+
+# Bump when search-DB layout changes. Keep MIGRATIONS in sync.
+CURRENT_SCHEMA_VERSION = 1
+
+META_TABLE = "canswim_schema_meta"
+
+# Documented core tables for v1 (see docs/data_store.md)
+SCHEMA_V1_CORE_TABLES = (
+    "stock_tickers",
+    "forecast",
+    "latest_forecast",
+    "close_price",
+    "backtest_error",
+)
+SCHEMA_V1_OPTIONAL_TABLES = ("company_profile",)
+
+
+@dataclass(frozen=True)
+class Migration:
+    """One discrete schema step: from (version-1) → version."""
+
+    version: int
+    name: str
+    description: str
+    upgrade: Callable[[Any, Optional[Any]], None]  # (db_con, paths) -> None
+
+
+def _ensure_meta_table(db_con) -> None:
+    db_con.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {META_TABLE} (
+            key VARCHAR PRIMARY KEY,
+            value VARCHAR,
+            updated_at TIMESTAMP
+        )
+        """
+    )
+
+
+def get_schema_version(db_path: str) -> Optional[int]:
+    """Return applied schema version, or None if meta missing / unreadable."""
+    from canswim.db import connect_readonly, db_file_exists
+
+    if not db_file_exists(db_path):
+        return None
+    try:
+        with connect_readonly(db_path) as con:
+            tables = {
+                r[0]
+                for r in con.execute(
+                    "SELECT table_name FROM information_schema.tables "
+                    "WHERE table_schema = 'main'"
+                ).fetchall()
+            }
+            if META_TABLE not in tables:
+                return None
+            row = con.execute(
+                f"SELECT value FROM {META_TABLE} WHERE key = 'schema_version'"
+            ).fetchone()
+            if not row or row[0] is None:
+                return None
+            return int(row[0])
+    except Exception as e:
+        logger.debug(f"get_schema_version: {e}")
+        return None
+
+
+def _set_schema_version(db_con, version: int) -> None:
+    _ensure_meta_table(db_con)
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    db_con.execute(
+        f"""
+        INSERT OR REPLACE INTO {META_TABLE} (key, value, updated_at)
+        VALUES ('schema_version', ?, ?)
+        """,
+        [str(int(version)), now],
+    )
+    db_con.execute(
+        f"""
+        INSERT OR REPLACE INTO {META_TABLE} (key, value, updated_at)
+        VALUES ('schema_version_name', ?, ?)
+        """,
+        [f"v{int(version)}", now],
+    )
+
+
+def stamp_current_schema_version(db_path: str) -> dict[str, Any]:
+    """Write CURRENT_SCHEMA_VERSION after a full rebuild."""
+    from canswim.db import connect_readwrite
+
+    with connect_readwrite(db_path) as con:
+        _set_schema_version(con, CURRENT_SCHEMA_VERSION)
+    return {
+        "ok": True,
+        "schema_version": CURRENT_SCHEMA_VERSION,
+        "stamped": True,
+    }
+
+
+def _migrate_to_v1(db_con, paths=None) -> None:
+    """v1 baseline: meta table + optional company_profile present.
+
+    Pre-version installs (core tables, no meta) are stamped v1 after optional
+    table repair. Does not rebuild forecast/close from parquet.
+    """
+    from canswim.db import _create_or_load_company_profile_table, _list_main_tables
+
+    _ensure_meta_table(db_con)
+    existing = _list_main_tables(db_con)
+    if "company_profile" not in existing:
+        logger.info("Migration v1: ensuring company_profile table")
+        _create_or_load_company_profile_table(db_con, paths)
+    # Record migration name for operators
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    db_con.execute(
+        f"""
+        INSERT OR REPLACE INTO {META_TABLE} (key, value, updated_at)
+        VALUES ('migration_1', ?, ?)
+        """,
+        ["baseline_search_v1", now],
+    )
+
+
+MIGRATIONS: list[Migration] = [
+    Migration(
+        version=1,
+        name="baseline_search_v1",
+        description=(
+            "Baseline search cache: core tables "
+            f"{', '.join(SCHEMA_V1_CORE_TABLES)}; optional "
+            f"{', '.join(SCHEMA_V1_OPTIONAL_TABLES)}; "
+            f"{META_TABLE} tracks schema_version."
+        ),
+        upgrade=_migrate_to_v1,
+    ),
+]
+
+
+def list_migrations() -> list[dict[str, Any]]:
+    """Public inventory for docs/tests (version, name, description)."""
+    return [
+        {
+            "version": m.version,
+            "name": m.name,
+            "description": m.description,
+        }
+        for m in sorted(MIGRATIONS, key=lambda x: x.version)
+    ]
+
+
+def apply_migrations(
+    db_path: str,
+    *,
+    paths: Optional[Any] = None,
+    target_version: Optional[int] = None,
+) -> dict[str, Any]:
+    """Apply pending migrations up to ``target_version`` (default: current).
+
+    Returns a structured report for GUI/MCP/logs.
+    """
+    from canswim.db import connect_readwrite, db_file_exists
+
+    target = int(target_version or CURRENT_SCHEMA_VERSION)
+    if target > CURRENT_SCHEMA_VERSION:
+        return {
+            "ok": False,
+            "error": (
+                f"target_version {target} > CURRENT_SCHEMA_VERSION "
+                f"{CURRENT_SCHEMA_VERSION}"
+            ),
+            "from_version": None,
+            "to_version": None,
+            "applied": [],
+        }
+    if not db_file_exists(db_path):
+        return {
+            "ok": False,
+            "error": f"No database file at {db_path}",
+            "from_version": None,
+            "to_version": None,
+            "applied": [],
+        }
+
+    from_ver = get_schema_version(db_path)
+    # Legacy DB without meta but with core tables → treat as 0 (needs v1 stamp)
+    if from_ver is None:
+        from_ver = 0
+
+    applied: list[dict[str, Any]] = []
+    if from_ver >= target:
+        return {
+            "ok": True,
+            "from_version": from_ver,
+            "to_version": from_ver,
+            "applied": [],
+            "current": CURRENT_SCHEMA_VERSION,
+            "message": "Search DB schema already up to date.",
+        }
+
+    try:
+        with connect_readwrite(db_path) as db_con:
+            for mig in sorted(MIGRATIONS, key=lambda m: m.version):
+                if mig.version <= from_ver or mig.version > target:
+                    continue
+                logger.info(
+                    f"Applying search DB migration v{mig.version}: {mig.name}"
+                )
+                mig.upgrade(db_con, paths)
+                _set_schema_version(db_con, mig.version)
+                applied.append(
+                    {
+                        "version": mig.version,
+                        "name": mig.name,
+                        "description": mig.description,
+                    }
+                )
+        to_ver = get_schema_version(db_path)
+        return {
+            "ok": True,
+            "from_version": from_ver,
+            "to_version": to_ver,
+            "applied": applied,
+            "current": CURRENT_SCHEMA_VERSION,
+            "message": (
+                f"Migrated search DB schema {from_ver} → {to_ver}."
+                if applied
+                else "No migrations applied."
+            ),
+        }
+    except Exception as e:
+        logger.exception("apply_migrations failed")
+        return {
+            "ok": False,
+            "error": str(e),
+            "from_version": from_ver,
+            "to_version": get_schema_version(db_path),
+            "applied": applied,
+            "current": CURRENT_SCHEMA_VERSION,
+        }

--- a/tests/canswim/test_db_migrations.py
+++ b/tests/canswim/test_db_migrations.py
@@ -1,0 +1,153 @@
+"""Search DB schema versioning and migrations (documented upgrade path)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import duckdb
+import pytest
+
+from canswim.db import (
+    CORE_SEARCH_TABLES,
+    connect_readwrite,
+    init_search_db,
+    search_db_status,
+)
+from canswim.db_migrations import (
+    CURRENT_SCHEMA_VERSION,
+    META_TABLE,
+    MIGRATIONS,
+    apply_migrations,
+    get_schema_version,
+    list_migrations,
+    stamp_current_schema_version,
+)
+
+
+def _legacy_core_db(path: Path) -> None:
+    """Pre-versioning install: core tables only, no meta."""
+    con = duckdb.connect(str(path))
+    con.execute(
+        "CREATE TABLE stock_tickers AS SELECT * FROM (VALUES ('AAPL')) t(symbol)"
+    )
+    con.execute(
+        """
+        CREATE TABLE forecast AS SELECT * FROM (
+          VALUES (DATE '2025-01-06', 'AAPL', DATE '2025-01-06', 100.0)
+        ) t(date, symbol, start_date, "close_quantile_0.5")
+        """
+    )
+    con.execute(
+        "CREATE TABLE latest_forecast AS SELECT * FROM (VALUES ('AAPL', DATE '2025-01-06')) t(symbol, date)"
+    )
+    con.execute(
+        """
+        CREATE TABLE close_price AS SELECT * FROM (
+          VALUES (DATE '2025-01-02', 'AAPL', 99.0)
+        ) t(Date, Symbol, Close)
+        """
+    )
+    con.execute(
+        """
+        CREATE TABLE backtest_error AS SELECT * FROM (
+          VALUES ('AAPL', DATE '2025-01-06', 0.01)
+        ) t(symbol, start_date, mal_error)
+        """
+    )
+    con.close()
+
+
+def test_current_version_matches_latest_migration():
+    assert MIGRATIONS, "at least one migration required"
+    assert max(m.version for m in MIGRATIONS) == CURRENT_SCHEMA_VERSION
+    versions = [m.version for m in MIGRATIONS]
+    assert versions == sorted(versions)
+    assert versions == list(range(1, CURRENT_SCHEMA_VERSION + 1))
+
+
+def test_list_migrations_public_inventory():
+    inv = list_migrations()
+    assert inv[0]["version"] == 1
+    assert inv[0]["name"] == "baseline_search_v1"
+    assert "description" in inv[0]
+
+
+def test_legacy_db_migrates_to_v1(tmp_path: Path):
+    db = tmp_path / "legacy.duckdb"
+    _legacy_core_db(db)
+    assert get_schema_version(str(db)) is None
+
+    report = apply_migrations(str(db))
+    assert report["ok"] is True
+    assert report["from_version"] == 0
+    assert report["to_version"] == 1
+    assert any(a["version"] == 1 for a in report["applied"])
+    assert get_schema_version(str(db)) == 1
+
+    # company_profile created by v1
+    with duckdb.connect(str(db), read_only=True) as con:
+        tables = {
+            r[0]
+            for r in con.execute(
+                "SELECT table_name FROM information_schema.tables "
+                "WHERE table_schema = 'main'"
+            ).fetchall()
+        }
+    assert META_TABLE in tables
+    assert "company_profile" in tables
+
+    # Idempotent
+    report2 = apply_migrations(str(db))
+    assert report2["ok"] is True
+    assert report2["applied"] == []
+    assert report2["to_version"] == 1
+
+
+def test_stamp_after_conceptual_rebuild(tmp_path: Path):
+    db = tmp_path / "stamp.duckdb"
+    _legacy_core_db(db)
+    r = stamp_current_schema_version(str(db))
+    assert r["ok"] is True
+    assert get_schema_version(str(db)) == CURRENT_SCHEMA_VERSION
+
+
+def test_init_search_db_reuse_runs_migration(tmp_path: Path, monkeypatch):
+    """--same_data True path applies migrations to legacy files."""
+    data = tmp_path / "data"
+    third = data / "data-3rd-party"
+    third.mkdir(parents=True)
+    db = data / "test.duckdb"
+    _legacy_core_db(db)
+
+    monkeypatch.setenv("data_dir", str(data))
+    monkeypatch.setenv("db_file", "test.duckdb")
+    # Avoid expand needing missing parquet paths hard-failing
+    monkeypatch.setenv("price_data", "missing_prices.parquet")
+    monkeypatch.setenv("stock_tickers_list", "missing.csv")
+
+    result = init_search_db(str(db), same_data=True)
+    assert result.get("reused") is True
+    assert result.get("migration", {}).get("ok") is True
+    assert get_schema_version(str(db)) == CURRENT_SCHEMA_VERSION
+    st = search_db_status(str(db))
+    assert st.get("schema_version") == CURRENT_SCHEMA_VERSION
+    assert st.get("schema_needs_migration") is False
+
+
+def test_docs_mention_migration_log_and_version():
+    root = Path(__file__).resolve().parents[2]
+    doc = (root / "docs" / "data_store.md").read_text(encoding="utf-8")
+    assert "Migration log" in doc
+    assert "baseline_search_v1" in doc
+    assert "CURRENT_SCHEMA_VERSION" in doc or "schema_version" in doc
+    assert "Upgrading between app versions" in doc
+    agents = (root / "AGENTS.md").read_text(encoding="utf-8")
+    assert "Schema migrations" in agents
+    assert "db_migrations.py" in agents
+
+
+def test_docs_migration_log_covers_all_coded_migrations():
+    root = Path(__file__).resolve().parents[2]
+    doc = (root / "docs" / "data_store.md").read_text(encoding="utf-8")
+    for m in MIGRATIONS:
+        assert m.name in doc, f"docs/data_store.md missing migration {m.name}"


### PR DESCRIPTION
## Summary

- **Going forward:** schema changes require **documented + coded + tested** migrations (`AGENTS.md`)
- `canswim.db_migrations`: `CURRENT_SCHEMA_VERSION`, `MIGRATIONS`, `apply_migrations`, meta table
- `init_search_db`: migrate on reuse; stamp version after full rebuild
- `docs/data_store.md`: full table map, upgrade steps, migration log (v1 baseline)
- Tests: legacy DB → v1, idempotent apply, docs/code inventory sync

## Operator upgrade path

1. Install new package  
2. Keep parquet under `data/`  
3. `dashboard --same_data True` (auto-migrate) or rebuild (`--same_data False`)  
4. Confirm `schema_version` via status / `get_db_schema`

## Test plan

- [x] Local CI 194 passed  
- [ ] GitHub Actions green → merge  