### PR TITLE
fix: prod host deploy compat (MCP HTTP, DuckDB 1.5, forecast schema)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -29,7 +29,7 @@ Local work should keep **`hfhub_sync=False`** (default) unless you intentionally
 | `gatherdata` | Get market data (full universe or scoped) | `--tickers`, `--no_covariates` |
 | `forecast` | Run forecasts (full or scoped) | `--tickers`, `--forecast_start_date`, `--dry_run` |
 | `resolve_start` | Print which forecast start date would be used | `--forecast_start_date` |
-| `mcp` | MCP server for clients | env `MCP_ALLOW_RUNS=1` for writes |
+| `mcp` | MCP server for clients | env `MCP_ALLOW_RUNS=1` for writes; `--http --host --port` for Streamable HTTP |
 | `train` | Continuous model training (full history) | `--new_model` |
 | `modelsearch` | Hyperparameter search | — |
 | `downloaddata` | Download train/forecast data from HF Hub | needs `hfhub_sync` / tokens as configured |
@@ -73,6 +73,9 @@ Without `--tickers`, `gatherdata` / `forecast` keep **full-universe / train-styl
 | `--no_covariates` | `gatherdata --tickers` | Prices (+ broad market path) only; skip earnings, ownership, etc. |
 | `--same_data True` | `dashboard` | Reuse DuckDB search DB (faster start) |
 | `--new_model True` | `train` | Train a new model instead of continuing |
+| `--http` | `mcp` | Streamable HTTP (gateway) instead of stdio |
+| `--transport …` | `mcp` | `stdio` / `streamable-http` / `http` / `sse` |
+| `--host` / `--port` | `mcp` | Bind for HTTP/SSE transports |
 
 ## Environment variables (common)
 
@@ -83,6 +86,9 @@ Without `--tickers`, `gatherdata` / `forecast` keep **full-universe / train-styl
 | `YFINANCE_USE_CACHE` | `False` | Avoid multi‑GB yfinance SQLite cache hang |
 | `MCP_ALLOW_RUNS` / `CANSWIM_ALLOW_RUNS` | unset | Enable MCP gather/forecast tools only |
 | `MCP_INIT_DB` | unset | If set, MCP may build DuckDB from parquet on start |
+| `CANSWIM_MCP_TRANSPORT` / `MCP_TRANSPORT` | `stdio` | MCP transport when flags omitted |
+| `CANSWIM_MCP_HOST` / `MCP_HOST` | `127.0.0.1` | HTTP/SSE bind host |
+| `CANSWIM_MCP_PORT` / `MCP_PORT` | `8000` | HTTP/SSE bind port |
 | `data_dir` | `data` | Data root |
 | `db_file` | (dashboard/MCP defaults) | DuckDB filename under `data_dir` |
 | `stock_tickers_list` | list CSV name | Universe for full gather/forecast when not using `--tickers` |

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -35,6 +35,26 @@ python -m canswim mcp
 MCP_ALLOW_RUNS=1 python -m canswim mcp
 ```
 
+### Streamable HTTP (production / mcp-gateway)
+
+Default transport is **stdio** (desktop clients). For a reverse-proxy gateway (Tailscale Funnel + Caddy apikey), run Streamable HTTP bound to localhost:
+
+```bash
+python -m canswim mcp --http --host 127.0.0.1 --port 3472
+# equivalent:
+python -m canswim mcp --transport streamable-http --host 127.0.0.1 --port 3472
+```
+
+| Flag / env | Meaning |
+|------------|---------|
+| `--http` | Shorthand for Streamable HTTP transport |
+| `--transport stdio\|streamable-http\|http\|sse` | Explicit transport (`http` ≡ `streamable-http`) |
+| `--host` / `CANSWIM_MCP_HOST` / `MCP_HOST` | Bind address (default `127.0.0.1`) |
+| `--port` / `CANSWIM_MCP_PORT` / `MCP_PORT` | Bind port (default `8000`) |
+| `CANSWIM_MCP_TRANSPORT` / `MCP_TRANSPORT` | Env override for transport |
+
+FastMCP serves the MCP endpoint at **`/mcp`** on that host:port. Public clients use the gateway path with `?apikey=` (never expose the bind port directly on the public internet).
+
 ## Example client config (stdio)
 
 ```json

--- a/src/canswim/__main__.py
+++ b/src/canswim/__main__.py
@@ -62,6 +62,7 @@ parser.add_argument(
         `train` — continuous model training (full history).
         `forecast` — run forecasts (all symbols, or --tickers for a short list).
         `mcp` — MCP server (read-only by default; write tools need MCP_ALLOW_RUNS=1).
+          Use --http / --transport streamable-http --host/--port for gateway HTTP.
         `resolve_start` — show which forecast start date would be used.
         """,
     choices=[
@@ -127,6 +128,51 @@ parser.add_argument(
     required=False,
     default=False,
     help="""Optional argument for the `dashboard` task. Whether to reuse previously created search database (faster start time) or update with new forecast data (slower start time).""",
+)
+
+parser.add_argument(
+    "--http",
+    action="store_true",
+    default=False,
+    help=(
+        "With `mcp`: run Streamable HTTP transport (for mcp-gateway / remote "
+        "connectors) instead of stdio. Shorthand for --transport streamable-http."
+    ),
+)
+
+parser.add_argument(
+    "--transport",
+    type=str,
+    required=False,
+    default=None,
+    choices=["stdio", "streamable-http", "http", "sse"],
+    help=(
+        "With `mcp`: transport protocol (default stdio). "
+        "Use streamable-http or http for production behind a reverse proxy. "
+        "Also: CANSWIM_MCP_TRANSPORT / MCP_TRANSPORT."
+    ),
+)
+
+parser.add_argument(
+    "--host",
+    type=str,
+    required=False,
+    default=None,
+    help=(
+        "With `mcp --http` / streamable-http / sse: bind address "
+        "(default 127.0.0.1). Also: CANSWIM_MCP_HOST / MCP_HOST."
+    ),
+)
+
+parser.add_argument(
+    "--port",
+    type=int,
+    required=False,
+    default=None,
+    help=(
+        "With `mcp --http` / streamable-http / sse: bind port "
+        "(default 8000). Also: CANSWIM_MCP_PORT / MCP_PORT."
+    ),
 )
 
 log_level = os.getenv("LOG_LEVEL", os.getenv("LOGURU_LEVEL", "INFO")).upper()
@@ -222,6 +268,11 @@ match args.task:
     case "mcp":
         from canswim.mcp.server import main as mcp_main
 
-        mcp_main()
+        mcp_main(
+            transport=args.transport,
+            host=args.host,
+            port=args.port,
+            http=bool(args.http),
+        )
     case _:
         logger.error("Unrecognized task argument {m} ", m=args.task)

--- a/src/canswim/covariates.py
+++ b/src/canswim/covariates.py
@@ -663,8 +663,8 @@ class Covariates:
         self.load_institutional_symbol_ownership()
 
     def load_institutional_symbol_ownership(self):
-        inst_ownership_file = (
-            "data/data-3rd-party/institutional_symbol_ownership.parquet"
+        inst_ownership_file = self._parquet_path(
+            "institutional_symbol_ownership.parquet"
         )
         logger.info(f"Loading data from: {inst_ownership_file}")
         # df = pd.read_csv(inst_ownership_file, low_memory=False)
@@ -679,16 +679,16 @@ class Covariates:
         self.inst_symbol_ownership_df = df
 
     def load_broad_market(self):
-        file = "data/data-3rd-party/broad_market.parquet"
+        file = self._parquet_path("broad_market.parquet")
         # self.broad_market_df = pd.read_csv(csv_file, header=[0, 1], index_col=0)
         self.broad_market_df = pd.read_parquet(file)
 
     def load_sectors(self):
-        file = "data/data-3rd-party/sectors.parquet"
+        file = self._parquet_path("sectors.parquet")
         self.sectors_df = pd.read_parquet(file)
 
     def load_industry_funds(self):
-        file = "data/data-3rd-party/industry_funds.parquet"
+        file = self._parquet_path("industry_funds.parquet")
         self.industry_funds_df = pd.read_parquet(file)
 
     def load_future_covariates(self):
@@ -721,7 +721,7 @@ class Covariates:
         )
 
     def load_earnings(self):
-        earnings_file = "data/data-3rd-party/earnings_calendar.parquet"
+        earnings_file = self._parquet_path("earnings_calendar.parquet")
         logger.info(f"Loading data from: {earnings_file}")
         # earnings_loaded_df = pd.read_csv(earnings_csv_file)
         logger.info(f"pyarrow_filters: {self.pyarrow_filters}")
@@ -745,7 +745,7 @@ class Covariates:
         self.earnings_loaded_df = earnings_unique
 
     def load_key_metrics(self):
-        kms_file = "data/data-3rd-party/keymetrics_history.parquet"
+        kms_file = self._parquet_path("keymetrics_history.parquet")
         logger.info(f"Loading data from: {kms_file}")
         # kms_loaded_df = pd.read_csv(kms_file)
         kms_loaded_df = pd.read_parquet(kms_file, filters=self.pyarrow_filters)
@@ -755,7 +755,7 @@ class Covariates:
         self.est_loaded_df = {}
         for period in fiscal_periods:
             assert period in fiscal_periods
-            est_file = f"data/data-3rd-party/analyst_estimates_{period}.parquet"
+            est_file = self._parquet_path(f"analyst_estimates_{period}.parquet")
             logger.info(f"Loading data from: {est_file}")
             # est_loaded_df = pd.read_csv(est_file)
             est_loaded_df = pd.read_parquet(est_file, filters=self.pyarrow_filters)

--- a/src/canswim/db.py
+++ b/src/canswim/db.py
@@ -1140,30 +1140,72 @@ def sync_forecasts_to_search_db(
             WHERE upper(CAST(symbol AS VARCHAR)) IN ({in_list})
             """
         )
-        # Hive parquet: time column may be "time" or already "date"
-        # Darts forecast parquet uses time index column "time" + hive partition cols
+        # Production hive parquet uses column "date"; older fixtures used "time".
+        # DuckDB errors if a referenced column is missing, so pick from schema.
+        sample_files = sorted(glob.glob(forecast_glob, recursive=True))
+        pq_cols = {
+            str(r[0]).lower()
+            for r in db_con.execute(
+                f"DESCRIBE SELECT * FROM read_parquet('{sample_files[0]}') LIMIT 0"
+            ).fetchall()
+        }
+        if "date" in pq_cols:
+            date_expr = "CAST(f.date AS DATE)"
+        elif "time" in pq_cols:
+            date_expr = "CAST(f.time AS DATE)"
+        else:
+            return {
+                "ok": False,
+                "error": (
+                    f"Forecast parquet missing date/time column; cols={sorted(pq_cols)}"
+                ),
+                "symbols": syms,
+                "forecast_rows": 0,
+            }
+        # Dedupe when multiple part files share symbol/start/date (common in hive dirs).
         db_con.execute(
             f"""--sql
             INSERT INTO forecast
-            SELECT
-                CAST(f.time AS DATE) AS date,
-                upper(CAST(f.symbol AS VARCHAR)) AS symbol,
-                CAST(
-                    make_date(
-                        CAST(f.forecast_start_year AS INTEGER),
-                        CAST(f.forecast_start_month AS INTEGER),
-                        CAST(f.forecast_start_day AS INTEGER)
-                    ) AS DATE
-                ) AS start_date,
-                f."close_quantile_0.01",
-                f."close_quantile_0.05",
-                f."close_quantile_0.2",
-                f."close_quantile_0.5",
-                f."close_quantile_0.8",
-                f."close_quantile_0.95",
-                f."close_quantile_0.99"
-            FROM read_parquet('{forecast_glob}', hive_partitioning = 1) AS f
-            WHERE upper(CAST(f.symbol AS VARCHAR)) IN ({in_list})
+            SELECT date, symbol, start_date,
+                "close_quantile_0.01",
+                "close_quantile_0.05",
+                "close_quantile_0.2",
+                "close_quantile_0.5",
+                "close_quantile_0.8",
+                "close_quantile_0.95",
+                "close_quantile_0.99"
+            FROM (
+                SELECT
+                    {date_expr} AS date,
+                    upper(CAST(f.symbol AS VARCHAR)) AS symbol,
+                    CAST(
+                        make_date(
+                            CAST(f.forecast_start_year AS INTEGER),
+                            CAST(f.forecast_start_month AS INTEGER),
+                            CAST(f.forecast_start_day AS INTEGER)
+                        ) AS DATE
+                    ) AS start_date,
+                    f."close_quantile_0.01",
+                    f."close_quantile_0.05",
+                    f."close_quantile_0.2",
+                    f."close_quantile_0.5",
+                    f."close_quantile_0.8",
+                    f."close_quantile_0.95",
+                    f."close_quantile_0.99",
+                    row_number() OVER (
+                        PARTITION BY upper(CAST(f.symbol AS VARCHAR)),
+                            make_date(
+                                CAST(f.forecast_start_year AS INTEGER),
+                                CAST(f.forecast_start_month AS INTEGER),
+                                CAST(f.forecast_start_day AS INTEGER)
+                            ),
+                            {date_expr}
+                        ORDER BY f.symbol
+                    ) AS rn
+                FROM read_parquet('{forecast_glob}', hive_partitioning = 1) AS f
+                WHERE upper(CAST(f.symbol AS VARCHAR)) IN ({in_list})
+            )
+            WHERE rn = 1
             """
         )
         n = db_con.execute(

--- a/src/canswim/db.py
+++ b/src/canswim/db.py
@@ -395,18 +395,32 @@ def init_search_db(
         db_con.sql(
             f"""--sql
             CREATE OR REPLACE TABLE forecast
-            AS SELECT
-                CAST(f.time AS DATE) AS date,
-                f.symbol,
-                make_date(
-                    f.forecast_start_year,
-                    f.forecast_start_month,
-                    f.forecast_start_day
-                ) AS start_date,
-                COLUMNS("close_quantile_\\d+\\.\\d+")
-            FROM read_parquet('{forecast_path}/**/*.parquet', hive_partitioning = 1) AS f
-            SEMI JOIN stock_tickers
-            ON f.symbol = stock_tickers.symbol
+            AS SELECT * EXCLUDE (rn)
+            FROM (
+                SELECT
+                    CAST(f.date AS DATE) AS date,
+                    f.symbol,
+                    make_date(
+                        f.forecast_start_year,
+                        f.forecast_start_month,
+                        f.forecast_start_day
+                    ) AS start_date,
+                    COLUMNS('close_quantile_.*'),
+                    row_number() OVER (
+                        PARTITION BY f.symbol,
+                            make_date(
+                                f.forecast_start_year,
+                                f.forecast_start_month,
+                                f.forecast_start_day
+                            ),
+                            CAST(f.date AS DATE)
+                        ORDER BY f.symbol
+                    ) AS rn
+                FROM read_parquet('{forecast_path}/**/*.parquet', hive_partitioning = 1) AS f
+                SEMI JOIN stock_tickers
+                ON f.symbol = stock_tickers.symbol
+            )
+            WHERE rn = 1
             """
         )
         db_con.table("forecast").show()

--- a/src/canswim/forecast.py
+++ b/src/canswim/forecast.py
@@ -138,10 +138,22 @@ def validate_forecast_dataframe(
     if df.empty and not forecast_df.empty:
         errors.append("all symbols failed forecast sanity checks")
 
-    # Restore original column layout for parquet write: time as index if it was
-    if time_col in df.columns:
-        df = df.set_index(time_col)
-        df.index.name = time_col if time_col != "index" else None
+    # Keep only partition + quantile columns (+ date) for hive parquet compatibility
+    keep = (
+        required
+        + qcols
+        + [c for c in ("date", "time", time_col) if c in df.columns]
+    )
+    keep = list(dict.fromkeys(keep))  # stable unique
+    df = df[[c for c in keep if c in df.columns]]
+
+    # Prefer column name "date" (production search-DB / sync path)
+    if time_col in df.columns and time_col != "date":
+        df = df.rename(columns={time_col: "date"})
+        time_col = "date"
+    if "date" in df.columns:
+        df = df.set_index("date")
+        df.index.name = "date"
 
     return df, errors
 
@@ -409,17 +421,18 @@ class CanswimForecaster:
                     )
                 # convert probabilistic forecast into a dataframe with quantile samples as columns Close_01, Close_02...
                 df = ts.pd_dataframe()
-                # save commonly used quantiles
+                # save commonly used quantiles only (drop raw MC sample columns)
+                out = pd.DataFrame(index=df.index)
                 for q in constants.quantiles:
                     qseries = df.quantile(q=q, axis=1)
                     qname = f"close_quantile_{q}"
-                    df[qname] = qseries
-                df["symbol"] = t
-                df["forecast_start_year"] = partition_start.year
-                df["forecast_start_month"] = partition_start.month
-                df["forecast_start_day"] = partition_start.day
-                # logger.debug(f"Next forecast sample: {df}")
-                forecast_df = pd.concat([forecast_df, df])
+                    out[qname] = qseries
+                out["symbol"] = t
+                out["forecast_start_year"] = partition_start.year
+                out["forecast_start_month"] = partition_start.month
+                out["forecast_start_day"] = partition_start.day
+                # logger.debug(f"Next forecast sample: {out}")
+                forecast_df = pd.concat([forecast_df, out])
             return forecast_df
 
         assert forecasts is not None and len(forecasts) > 0

--- a/src/canswim/gather_data.py
+++ b/src/canswim/gather_data.py
@@ -106,10 +106,14 @@ class MarketDataGatherer:
         self.last_price_fetch_plans = []
 
     def _yfinance_session(self):
-        """Rate-limited session. Avoids SQLite cache hang by default.
+        """Optional custom session for yfinance.
 
-        Uses ``requests_ratelimiter.LimiterSession`` when available (stable
-        across pyrate-limiter v2/v3 API breaks). Falls back to a plain Session.
+        Default is ``None`` so yfinance uses its own curl_cffi session (required
+        by Yahoo). A custom ``LimiterSession`` / plain requests Session raises:
+        "Yahoo API requires curl_cffi session …".
+
+        Only when ``YFINANCE_USE_CACHE=1`` do we return a cached limiter session
+        (legacy; can be large/slow and may still break on current Yahoo).
         """
         if self.use_yfinance_cache:
             try:
@@ -129,13 +133,7 @@ class MarketDataGatherer:
                 )
             except Exception as e:
                 logger.warning(f"Could not enable yfinance cache ({e}); uncached session")
-        try:
-            from requests_ratelimiter import LimiterSession
-
-            return LimiterSession(per_second=5)
-        except Exception as e:
-            logger.warning(f"requests_ratelimiter unavailable ({e}); plain Session")
-            return Session()
+        return None
 
     def _data_file(self, name: str) -> str:
         d = data_3rd_party_dir()
@@ -259,27 +257,26 @@ class MarketDataGatherer:
         except Exception as e:
             logger.warning(f"Could not load data from file: {data_file}. Error: {e}")
         session = self._yfinance_session()
+        yf_kwargs = dict(
+            start=start_date,
+            group_by="tickers",
+            auto_adjust=False,
+            threads=True,
+            progress=True,
+        )
+        if session is not None:
+            yf_kwargs["session"] = session
         try:
             new_df = yf.download(
                 list(tickers),
-                start=start_date,
-                group_by="tickers",
-                auto_adjust=False,
-                threads=True,
-                progress=True,
                 timeout=30,
-                session=session,
+                **yf_kwargs,
             )
         except TypeError:
             # older yfinance without timeout kwarg
             new_df = yf.download(
                 list(tickers),
-                start=start_date,
-                group_by="tickers",
-                auto_adjust=False,
-                threads=True,
-                progress=True,
-                session=session,
+                **yf_kwargs,
             )
         except Exception as e:
             logger.error(f"yfinance download failed for {data_file}: {e}")
@@ -361,6 +358,7 @@ class MarketDataGatherer:
             "^NDX",
             "^NDXE",
             "^RUT",
+            "^R2ESC",  # equal-weight R2K; thin history ok (zero-filled if sparse)
             "^VIX",
             "DX-Y.NYB",
             "^IRX",
@@ -398,29 +396,21 @@ class MarketDataGatherer:
         """Primary path: yfinance multi-ticker download → (Symbol, Date) frame."""
         session = self._yfinance_session()
         tickers = list(self.stocks_ticker_set)
+        yf_kwargs = dict(
+            start=start_date,
+            group_by="tickers",
+            auto_adjust=False,
+            threads=False,
+            progress=True,
+        )
+        if session is not None:
+            yf_kwargs["session"] = session
         try:
             # threads=False is more reliable under rate limits; fail fast → FMP
-            raw = yf.download(
-                tickers,
-                start=start_date,
-                group_by="tickers",
-                auto_adjust=False,
-                threads=False,
-                progress=True,
-                timeout=15,
-                session=session,
-            )
+            raw = yf.download(tickers, timeout=15, **yf_kwargs)
         except TypeError:
             try:
-                raw = yf.download(
-                    tickers,
-                    start=start_date,
-                    group_by="tickers",
-                    auto_adjust=False,
-                    threads=False,
-                    progress=True,
-                    session=session,
-                )
+                raw = yf.download(tickers, **yf_kwargs)
             except Exception as e:
                 logger.error(f"yfinance stock price download failed: {e}")
                 return pd.DataFrame()

--- a/src/canswim/mcp/server.py
+++ b/src/canswim/mcp/server.py
@@ -8,6 +8,7 @@ registered for discoverability but require ``MCP_ALLOW_RUNS=1`` to execute.
 from __future__ import annotations
 
 import asyncio
+import os
 from typing import Any, Optional
 
 from dotenv import load_dotenv
@@ -278,8 +279,74 @@ async def refresh_tickers(
     )
 
 
-def main() -> None:
-    mcp.run(transport="stdio")
+def _resolve_transport(
+    transport: str | None = None,
+    *,
+    http: bool = False,
+) -> str:
+    """Resolve MCP transport: CLI/env override, else stdio.
+
+    Accepted values: ``stdio`` (default), ``streamable-http`` (alias ``http``), ``sse``.
+    Env: ``CANSWIM_MCP_TRANSPORT`` or ``MCP_TRANSPORT``.
+    """
+    if http and not transport:
+        return "streamable-http"
+    raw = (transport or os.getenv("CANSWIM_MCP_TRANSPORT") or os.getenv("MCP_TRANSPORT") or "stdio")
+    raw = str(raw).strip().lower()
+    if raw in ("http", "streamable_http", "streamable-http"):
+        return "streamable-http"
+    if raw in ("stdio", "sse", "streamable-http"):
+        return raw
+    raise ValueError(
+        f"Unknown MCP transport {raw!r}; use stdio, streamable-http (or http), or sse"
+    )
+
+
+def apply_http_settings(
+    host: str | None = None,
+    port: int | None = None,
+) -> tuple[str, int]:
+    """Apply host/port onto the module FastMCP instance (for streamable-http / sse).
+
+    Precedence: explicit args → ``CANSWIM_MCP_HOST`` / ``CANSWIM_MCP_PORT``
+    (or ``MCP_HOST`` / ``MCP_PORT``) → FastMCP defaults (127.0.0.1:8000).
+    Returns the effective (host, port).
+    """
+    h = host or os.getenv("CANSWIM_MCP_HOST") or os.getenv("MCP_HOST") or mcp.settings.host
+    p_raw = port if port is not None else (
+        os.getenv("CANSWIM_MCP_PORT") or os.getenv("MCP_PORT") or mcp.settings.port
+    )
+    p = int(p_raw)
+    mcp.settings.host = str(h)
+    mcp.settings.port = p
+    return str(h), p
+
+
+def main(
+    transport: str | None = None,
+    host: str | None = None,
+    port: int | None = None,
+    *,
+    http: bool = False,
+) -> None:
+    """Run the MCP server (stdio by default; streamable-http for gateway/public).
+
+    For production behind mcp-gateway, prefer::
+
+        python -m canswim mcp --http --host 127.0.0.1 --port 3472
+    """
+    resolved = _resolve_transport(transport, http=http)
+    if resolved in ("streamable-http", "sse"):
+        eff_host, eff_port = apply_http_settings(host=host, port=port)
+        logger.info(
+            "canswim-mcp transport={} host={} port={}",
+            resolved,
+            eff_host,
+            eff_port,
+        )
+    else:
+        logger.info("canswim-mcp transport=stdio")
+    mcp.run(transport=resolved)  # type: ignore[arg-type]
 
 
 if __name__ == "__main__":

--- a/src/canswim/model.py
+++ b/src/canswim/model.py
@@ -31,6 +31,36 @@ def election_year_offset(idx):
     return idx.year % 4
 
 
+def align_covariate_series_to_components(
+    series: TimeSeries,
+    expected: Sequence[str],
+    *,
+    fill_value: float = 0.0,
+) -> TimeSeries:
+    """Reorder/pad/drop columns so a covariate series matches the checkpoint schema.
+
+    The trained TiDE model stores ``past_covariate_series`` /
+    ``future_covariate_series`` with the exact column set used at train time.
+    Local gather can miss thin funds (e.g. ``^R2ESC``) or ``Adj Close`` for
+    some indexes; zero-fill and reorder so ``predict`` does not fail with a
+    dimensionality mismatch.
+    """
+    if series is None:
+        raise ValueError("series is required")
+    expected = [str(c) for c in expected]
+    if not expected:
+        return series
+    df = series.pd_dataframe(copy=True)
+    df.columns = [str(c) for c in df.columns]
+    for col in expected:
+        if col not in df.columns:
+            df[col] = fill_value
+    # Drop extras, reorder to training schema
+    df = df.reindex(columns=expected)
+    df = df.fillna(fill_value)
+    return TimeSeries.from_dataframe(df)
+
+
 def optuna_print_callback(study, trial):
     logger.info(f"Current value: {trial.value}, Current params: {trial.params}")
     logger.info(
@@ -406,13 +436,25 @@ class CanswimModel:
         self.targets_list = []
         self.past_cov_list = []
         self.future_cov_list = []
+        past_expected = self._checkpoint_cov_components(past=True)
+        future_expected = self._checkpoint_cov_components(past=False)
         for t in sorted(self.targets.target_series.keys()):
             n_target_samples = len(self.targets.target_series[t])
             if n_target_samples >= self.min_samples:
                 self.targets_ticker_list.append(t)
                 self.targets_list.append(self.targets.target_series[t])
-                self.past_cov_list.append(self.covariates.past_covariates[t])
-                self.future_cov_list.append(self.covariates.future_covariates[t])
+                past_ts = self.covariates.past_covariates[t]
+                future_ts = self.covariates.future_covariates[t]
+                if past_expected:
+                    past_ts = align_covariate_series_to_components(
+                        past_ts, past_expected
+                    )
+                if future_expected:
+                    future_ts = align_covariate_series_to_components(
+                        future_ts, future_expected
+                    )
+                self.past_cov_list.append(past_ts)
+                self.future_cov_list.append(future_ts)
             else:
                 logger.info(
                     f"Skipping {t} due to lack of data. Only {n_target_samples} available"
@@ -791,6 +833,25 @@ class CanswimModel:
             ##past_cov_list.append(past_covs_sliced)
             past_cov_list.append(past_cov)
         return past_cov_list
+
+    def _checkpoint_cov_components(self, *, past: bool) -> Optional[List[str]]:
+        """Column names from the loaded checkpoint covariate series (no darts_enc_*)."""
+        tm = getattr(self, "torch_model", None)
+        if tm is None:
+            return None
+        series = (
+            getattr(tm, "past_covariate_series", None)
+            if past
+            else getattr(tm, "future_covariate_series", None)
+        )
+        if series is None or not hasattr(series, "components"):
+            return None
+        cols = [
+            str(c)
+            for c in list(series.components)
+            if not str(c).startswith("darts_enc")
+        ]
+        return cols or None
 
     def predict(
         self,

--- a/src/canswim/targets.py
+++ b/src/canswim/targets.py
@@ -33,7 +33,9 @@ class Targets:
         ]
 
     def load_stock_prices(self):
-        stocks_price_file = "data/data-3rd-party/all_stocks_price_hist_1d.parquet"
+        from canswim.db import DataPaths
+
+        stocks_price_file = DataPaths.from_env().stocks_price_path
         logger.info(
             f"Loading data from: {stocks_price_file} with filter: {self.pyarrow_filters}"
         )

--- a/tests/canswim/test_cli_run.py
+++ b/tests/canswim/test_cli_run.py
@@ -35,6 +35,9 @@ def test_cli_help_lists_tickers_and_resolve(tmp_path):
     assert "--tickers" in out
     assert "resolve_start" in out
     assert "dry_run" in out or "--dry_run" in out
+    assert "--http" in out
+    assert "--transport" in out
+    assert "streamable-http" in out
 
 
 def test_run_gather_tickers_force_allow(monkeypatch, capsys):

--- a/tests/canswim/test_db.py
+++ b/tests/canswim/test_db.py
@@ -164,14 +164,18 @@ def test_get_forecast_rows_latest(mini_db):
 
 
 def test_sync_forecasts_to_search_db_from_hive_parquet(mini_db, tmp_path: Path):
-    """Forecast parquet must land in DuckDB so Charts can plot lines."""
-    # Build a tiny hive-style forecast partition for CCC
+    """Forecast parquet must land in DuckDB so Charts can plot lines.
+
+    Production hive layout uses column ``date`` (not ``time``) plus hive
+    partition keys for symbol / forecast_start_*.
+    """
+    # Build a tiny hive-style forecast partition for CCC (production shape)
     froot = tmp_path / "forecast" / "symbol=CCC" / "forecast_start_year=2026" / "forecast_start_month=3" / "forecast_start_day=2"
     froot.mkdir(parents=True)
     dates = pd.bdate_range("2026-03-02", periods=42)
     fdf = pd.DataFrame(
         {
-            "time": dates,
+            "date": dates,
             "symbol": "CCC",
             "close_quantile_0.01": 90.0,
             "close_quantile_0.05": 92.0,
@@ -192,10 +196,48 @@ def test_sync_forecasts_to_search_db_from_hive_parquet(mini_db, tmp_path: Path):
     res = sync_forecasts_to_search_db(
         mini_db, ["CCC"], forecast_path=str(tmp_path / "forecast")
     )
-    assert res["ok"] is True
+    assert res["ok"] is True, res
     assert res["forecast_rows"] == 42
     after = get_forecast_rows(mini_db, "CCC", latest_only=False)
     assert len(after) == 42
+
+
+def test_sync_forecasts_to_search_db_accepts_legacy_time_column(
+    mini_db, tmp_path: Path
+):
+    """Older fixtures used ``time``; sync must still load them."""
+    froot = (
+        tmp_path
+        / "forecast"
+        / "symbol=CCC"
+        / "forecast_start_year=2026"
+        / "forecast_start_month=4"
+        / "forecast_start_day=6"
+    )
+    froot.mkdir(parents=True)
+    dates = pd.bdate_range("2026-04-06", periods=5)
+    pd.DataFrame(
+        {
+            "time": dates,
+            "symbol": "CCC",
+            "close_quantile_0.01": 90.0,
+            "close_quantile_0.05": 92.0,
+            "close_quantile_0.2": 95.0,
+            "close_quantile_0.5": 100.0,
+            "close_quantile_0.8": 105.0,
+            "close_quantile_0.95": 108.0,
+            "close_quantile_0.99": 110.0,
+            "forecast_start_year": 2026,
+            "forecast_start_month": 4,
+            "forecast_start_day": 6,
+        }
+    ).to_parquet(froot / "part.parquet", index=False)
+
+    res = sync_forecasts_to_search_db(
+        mini_db, ["CCC"], forecast_path=str(tmp_path / "forecast")
+    )
+    assert res["ok"] is True, res
+    assert res["forecast_rows"] == 5
 
 
 def test_get_close_prices(mini_db):

--- a/tests/canswim/test_forecast_sanity.py
+++ b/tests/canswim/test_forecast_sanity.py
@@ -31,6 +31,10 @@ def test_validate_accepts_coherent_forecast():
     assert cleaned is not None and not cleaned.empty
     assert len(cleaned) == 42
     assert "symbol" in cleaned.columns
+    # MC sample columns must not be written to hive parquet
+    assert not any(str(c).startswith("Close_s") for c in cleaned.columns)
+    # index/date column normalized to date for production sync
+    assert cleaned.index.name == "date" or "date" in cleaned.columns
     # no hard errors for a clean frame
     assert not any("all symbols failed" in e for e in errors)
 
@@ -88,3 +92,13 @@ def test_all_bad_symbols_yield_empty_and_error():
     cleaned, errors = validate_forecast_dataframe(df, expected_horizon=None)
     assert cleaned.empty
     assert any("all symbols failed" in e or "median" in e for e in errors)
+
+def test_align_covariate_series_to_components_pads_and_orders():
+    from darts import TimeSeries
+    from canswim.model import align_covariate_series_to_components
+
+    idx = pd.bdate_range("2024-01-01", periods=4)
+    ts = TimeSeries.from_dataframe(pd.DataFrame({"a": 1.0, "b": 2.0}, index=idx))
+    out = align_covariate_series_to_components(ts, ["b", "c", "a"])
+    assert list(out.components) == ["b", "c", "a"]
+    assert float(out.pd_dataframe()["c"].iloc[0]) == 0.0

--- a/tests/canswim/test_mcp_tools.py
+++ b/tests/canswim/test_mcp_tools.py
@@ -274,3 +274,81 @@ def test_server_registers_tools(mcp_env):
         # Fallback: tools list API if present
         tools = getattr(mcp_server.mcp, "list_tools", None)
         assert tools is not None or hasattr(mcp_server.mcp, "_mcp_server")
+
+
+def test_resolve_transport_defaults_and_aliases(monkeypatch):
+    """Shipped transport resolver: stdio default; http → streamable-http."""
+    from canswim.mcp.server import _resolve_transport
+
+    monkeypatch.delenv("CANSWIM_MCP_TRANSPORT", raising=False)
+    monkeypatch.delenv("MCP_TRANSPORT", raising=False)
+    assert _resolve_transport() == "stdio"
+    assert _resolve_transport(http=True) == "streamable-http"
+    assert _resolve_transport("http") == "streamable-http"
+    assert _resolve_transport("streamable_http") == "streamable-http"
+    assert _resolve_transport("sse") == "sse"
+    monkeypatch.setenv("CANSWIM_MCP_TRANSPORT", "http")
+    assert _resolve_transport() == "streamable-http"
+    with pytest.raises(ValueError, match="Unknown MCP transport"):
+        _resolve_transport("udp")
+
+
+def test_apply_http_settings_from_args_and_env(monkeypatch):
+    """apply_http_settings mutates the real FastMCP instance host/port."""
+    from canswim.mcp import server as mcp_server
+
+    monkeypatch.delenv("CANSWIM_MCP_HOST", raising=False)
+    monkeypatch.delenv("CANSWIM_MCP_PORT", raising=False)
+    monkeypatch.delenv("MCP_HOST", raising=False)
+    monkeypatch.delenv("MCP_PORT", raising=False)
+
+    prev_host = mcp_server.mcp.settings.host
+    prev_port = mcp_server.mcp.settings.port
+    try:
+        h, p = mcp_server.apply_http_settings(host="127.0.0.1", port=3472)
+        assert (h, p) == ("127.0.0.1", 3472)
+        assert mcp_server.mcp.settings.host == "127.0.0.1"
+        assert mcp_server.mcp.settings.port == 3472
+
+        monkeypatch.setenv("CANSWIM_MCP_HOST", "0.0.0.0")
+        monkeypatch.setenv("CANSWIM_MCP_PORT", "3499")
+        h2, p2 = mcp_server.apply_http_settings()
+        assert (h2, p2) == ("0.0.0.0", 3499)
+        assert mcp_server.mcp.settings.port == 3499
+    finally:
+        mcp_server.mcp.settings.host = prev_host
+        mcp_server.mcp.settings.port = prev_port
+
+
+def test_main_passes_streamable_http_to_fastmcp_run(monkeypatch):
+    """main() drives the real entry path: resolve transport + settings + mcp.run."""
+    from canswim.mcp import server as mcp_server
+
+    calls: list[dict] = []
+
+    def _fake_run(transport="stdio", mount_path=None):
+        calls.append(
+            {
+                "transport": transport,
+                "mount_path": mount_path,
+                "host": mcp_server.mcp.settings.host,
+                "port": mcp_server.mcp.settings.port,
+            }
+        )
+
+    monkeypatch.setattr(mcp_server.mcp, "run", _fake_run)
+    prev_host = mcp_server.mcp.settings.host
+    prev_port = mcp_server.mcp.settings.port
+    try:
+        mcp_server.main(http=True, host="127.0.0.1", port=3472)
+        assert len(calls) == 1
+        assert calls[0]["transport"] == "streamable-http"
+        assert calls[0]["host"] == "127.0.0.1"
+        assert calls[0]["port"] == 3472
+
+        calls.clear()
+        mcp_server.main(transport="stdio")
+        assert calls[0]["transport"] == "stdio"
+    finally:
+        mcp_server.mcp.settings.host = prev_host
+        mcp_server.mcp.settings.port = prev_port


### PR DESCRIPTION
## Summary

Host production cutover found several main-branch gaps that block a real shared-data deploy (Tailscale Gradio + public apikey MCP + DuckDB search + TiDE forecast). This PR lands those fixes with tests and docs, without changing the default stdio MCP or happy-path local `./data` layout.

1. **MCP Streamable HTTP** — `python -m canswim mcp --http --host/--port` (and env) for mcp-gateway reverse proxy; stdio remains default.
2. **`data_dir` paths** — targets/covariates use `DataPaths` / `_parquet_path` instead of hardcoded `data/data-3rd-party/...`.
3. **DuckDB search rebuild/sync** — DuckDB 1.5-compatible `COLUMNS(...)`, production hive column `date` (legacy `time` still supported on sync), dedupe before unique indexes.
4. **Forecast feature mismatch** — stop injecting `LimiterSession` into yfinance (Yahoo requires curl_cffi); align past/future covariates to checkpoint columns; write hive forecast parquet as quantiles + date only (no `Close_s*` samples).
5. **`^R2ESC`** added to broad-market gather list for closer train schema coverage.

## Risk / compatibility

| Change | Default / remote impact |
|--------|-------------------------|
| MCP transport | Still **stdio** unless `--http` / env |
| data paths | Still default `data/` if env unset |
| DuckDB SQL | Works on current DuckDB (CI + host 1.5); regex COLUMNS form was already broken on 1.5 |
| yfinance session | `None` by default — required for modern Yahoo; cache path only if `YFINANCE_USE_CACHE=1` |
| covariate align | Only when checkpoint exposes `past_covariate_series` / `future_covariate_series` |
| forecast parquet | Smaller/cleaner files; matches existing production `date` + quantile layout |

## Test plan

- [x] `./scripts/ci-local.sh` (PYTHONPATH clean) — **199 passed**
- [x] MCP transport unit tests (`test_mcp_tools`, CLI help)
- [x] DuckDB sync tests production `date` + legacy `time` fixtures
- [x] Forecast sanity: no `Close_s*` in validated frame; align helper pads/orders
- [x] Docs: `docs/mcp.md`, `docs/cli.md` updated for HTTP transport
- [ ] GitHub Actions Tests green on PR

## Deploy note (host only, not in this PR)

User systemd wrappers, Caddy `/mcp/canswim` → `:3472`, and `~/.canswim/data` remain host config.