### PR TITLE
fix: portable torch load + canonical ~/.canswim home layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,13 +15,17 @@ Operator UX and data-refresh wave on top of 0.0.20260713 (Run tab, catch-up fore
 - **MCP** — `get_db_schema` + hardened read-only `run_select`; **live progress streaming** (`notifications/progress` + info logs) on `refresh_tickers` / `forecast_tickers` / `gather_tickers`
 - **Cross-tab Gradio fix** — Run handlers no longer depend on Charts-tab inputs (fixes hard Error toast on refresh)
 - **Gather status UX** — multi-bucket ready / short-history / IPO messaging
+- **Torch ≥2.6 checkpoint load** — `darts_torch_load_compat()` around trusted Darts full-model pickles (`weights_only=False`); CPU and any CUDA GPU; no host/arch hardcoding
+- **Portable GPU use** — still `torch.cuda.is_available()` / Lightning `accelerator="auto"`; install a torch wheel that matches the machine (see pytorch.org)
+- **Deploy home layout** — canonical per-user state is **`~/.canswim/`** (`data/`, optional `service/` for user-systemd wrappers); not a separate `~/.canswim-dashboard` tree
 
 ### Requirements for end users
 
 - Python ≥ 3.10
 - Optional but typical: **FMP API key** for fundamentals, ownership, estimates, and company profiles
 - Default model checkpoint on **Hugging Face** (public; swappable)
-- Local disk for parquet + DuckDB under `data/`
+- Local disk for parquet + DuckDB under `data/` (or `~/.canswim/data` when using the prod home layout)
+- Optional CUDA: any GPU supported by your installed PyTorch build
 
 **NOT FINANCIAL OR INVESTMENT ADVICE. USE AT YOUR OWN RISK.**
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ pip install -e ".[dev]"
 conda activate canswim
 ```
 
+**CPU and GPU:** forecasts run on CPU by default. If the active environment has a working CUDA build of PyTorch, GPU is used automatically — no canswim-specific device flag. Install torch from [pytorch.org](https://pytorch.org) for your OS/GPU when you want acceleration (RTX 30/40-class, data-center GPUs, etc.). The same source tree and PyPI package are meant to work on contributor laptops and production hosts without host-specific code paths.
+
 See [CHANGELOG.md](CHANGELOG.md) for release notes. Docs: [https://ivelin.github.io/canswim/](https://ivelin.github.io/canswim/).
 
 ## Local-first market data
@@ -95,6 +97,7 @@ For a **user-level** long-running install:
 |---------|----------|-----|
 | **Dashboard** | Private (e.g. Tailscale only) | `canswim-dashboard.service` → Gradio `:7860` — **not** on public Funnel |
 | **MCP** | Public via reverse proxy | `canswim-mcp.service` → `python -m canswim mcp --http --host 127.0.0.1 --port 3472`; edge gateway requires `CANSWIM_MCP_KEY` (`?apikey=`) |
+| **Local state** | Per-user | Canonical **`~/.canswim/`** (`data/`, optional `service/` for unit wrappers) — not a separate `~/.canswim-dashboard` tree |
 
 Basics above; full unit templates, env, Funnel/Caddy apikey matrix, and data population: **[docs/deploy_service.md](docs/deploy_service.md)**. MCP flags: **[docs/mcp.md](docs/mcp.md)**.
 

--- a/docs/deploy_service.md
+++ b/docs/deploy_service.md
@@ -31,9 +31,18 @@ Do **not** put the Gradio UI on the public Funnel. Do **not** expose the MCP bin
 ## Prerequisites
 
 - Linux user account with **systemd --user** (and preferably `loginctl enable-linger $USER` so services survive logout).
-- Checkout of canswim (or `pip install canswim`) and a Python env with dependencies (torch/darts for forecast, Gradio for UI, `mcp` for FastMCP).
-- Shared data directory (example: `~/.canswim/data`) with `data-3rd-party/` parquet + `forecast/` partitions.
-- Model checkpoint available for forecast (`canswim_model.pt` in the process cwd, or HF download when `hfhub_sync=True`).
+- Checkout of canswim (or `pip install canswim`) and a Python env with dependencies (torch/darts for forecast, Gradio for UI, `mcp` for FastMCP). **CPU works.** When CUDA is available, canswim uses it automatically (`torch.cuda.is_available()` / Lightning `accelerator="auto"`). No host-specific paths are required in application code.
+- **PyTorch must match the machine** (same as any torch app): install a wheel that supports your GPU (or CPU-only). Common cases — Ampere/Ada (e.g. RTX 3090/4090) with current CUDA 12.x wheels; very new archs may need a newer torch/CUDA build from [pytorch.org](https://pytorch.org). If `cuda.is_available()` is true but `predict` fails with *no kernel image is available for execution on the device*, the installed torch was built without kernels for that GPU — fix the **env’s torch**, not canswim flags. Point wrappers at the interpreter you verified: `Environment=PYTHON=/path/to/venv/bin/python`.
+- Shared **CANSWIM_HOME** (canonical: `~/.canswim/`) for local config and data — not a second `~/.canswim-dashboard` tree:
+
+  | Path | Role |
+  |------|------|
+  | `~/.canswim/data/` | Parquet (`data-3rd-party/`), `forecast/`, DuckDB |
+  | `~/.canswim/backups/` | Optional snapshots |
+  | `~/.canswim/service/` | User-systemd wrappers + unit templates + operator notes |
+
+  Secrets stay in `~/.env`. Application code (`CANSWIM_DIR` checkout or site-packages) is separate from home state.
+- Model checkpoint available for forecast (`canswim_model.pt` in the process cwd, or HF download when `hfhub_sync=True`). Under torch ≥2.6, Darts full-model pickles need `weights_only=False`; canswim applies that only around trusted checkpoint loads.
 - Secrets in **`~/.env`** (not committed): e.g. `FMP_API_KEY`, `CANSWIM_MCP_KEY`, optional `HF_TOKEN` / dashboard password.
 - Optional public MCP: reverse proxy (Caddy recommended) and a single Tailscale Funnel (or TLS terminator) to the proxy port.
 
@@ -41,13 +50,14 @@ Do **not** put the Gradio UI on the public Funnel. Do **not** expose the MCP bin
 
 ```bash
 # Example paths — adjust to your host
-export CANSWIM_DIR=~/canswim          # git checkout
-export CANSWIM_HOME=~/.canswim
+export CANSWIM_DIR=~/canswim          # git checkout (or wherever you install from source)
+export CANSWIM_HOME=~/.canswim        # canonical local config + data
 export data_dir=$CANSWIM_HOME/data
 export db_file=canswim_local.duckdb
 export hfhub_sync=False
 
-mkdir -p "$data_dir/data-3rd-party" "$data_dir/forecast"
+mkdir -p "$data_dir/data-3rd-party" "$data_dir/forecast" \
+  "$CANSWIM_HOME/service" "$CANSWIM_HOME/backups"
 # optional: symlink checkout data/ → shared data so relative paths resolve
 # ln -sfn "$data_dir" "$CANSWIM_DIR/data"
 ```
@@ -69,7 +79,7 @@ export FMP_API_KEY="${FMP_API_KEY:-${FMP_API_Key:-}}"
 
 ## 2. Dashboard unit (private GUI)
 
-**Wrapper** `~/.canswim-dashboard/run.sh` (illustrative):
+**Wrapper** `~/.canswim/service/run.sh` (illustrative):
 
 ```bash
 #!/usr/bin/env bash
@@ -80,6 +90,7 @@ export FMP_API_KEY="${FMP_API_KEY:-${FMP_API_Key:-}}"
 : "${CANSWIM_HOME:=$HOME/.canswim}"
 : "${CANSWIM_DASHBOARD_HOST:=0.0.0.0}"
 : "${CANSWIM_DASHBOARD_PORT:=7860}"
+: "${PYTHON:=${CANSWIM_PYTHON:-$(command -v python3)}}"
 cd "$CANSWIM_DIR"
 export PYTHONPATH="${CANSWIM_DIR}/src${PYTHONPATH:+:$PYTHONPATH}"
 export GRADIO_SERVER_NAME="$CANSWIM_DASHBOARD_HOST"
@@ -87,12 +98,11 @@ export GRADIO_SERVER_PORT="$CANSWIM_DASHBOARD_PORT"
 export data_dir="${CANSWIM_HOME}/data"
 export db_file=canswim_local.duckdb
 export hfhub_sync=False
-# Conservative threads on shared hosts
 export OMP_NUM_THREADS=2 TORCH_NUM_THREADS=2
-exec env data-3rd-party=data-3rd-party python -m canswim dashboard --same_data True
+exec env data-3rd-party=data-3rd-party "$PYTHON" -m canswim dashboard --same_data True
 ```
 
-**Unit** `~/.config/systemd/user/canswim-dashboard.service`:
+**Unit** `~/.config/systemd/user/canswim-dashboard.service` (template also kept under `~/.canswim/service/`):
 
 ```ini
 [Unit]
@@ -103,9 +113,10 @@ After=network-online.target
 Type=simple
 WorkingDirectory=%h/canswim
 EnvironmentFile=-%h/.env
+Environment=CANSWIM_HOME=%h/.canswim
 Environment=CANSWIM_DASHBOARD_HOST=0.0.0.0
 Environment=CANSWIM_DASHBOARD_PORT=7860
-ExecStart=%h/.canswim-dashboard/run.sh
+ExecStart=%h/.canswim/service/run.sh
 Restart=always
 RestartSec=10
 MemoryMax=4G
@@ -117,7 +128,8 @@ WantedBy=default.target
 ```
 
 ```bash
-chmod +x ~/.canswim-dashboard/run.sh
+chmod +x ~/.canswim/service/run.sh
+cp ~/.canswim/service/canswim-dashboard.service ~/.config/systemd/user/
 systemctl --user daemon-reload
 systemctl --user enable --now canswim-dashboard
 systemctl --user status canswim-dashboard --no-pager
@@ -138,7 +150,7 @@ Confirm the UI is **not** listed on public Funnel routes. Prefer binding only th
 python -m canswim mcp --http --host 127.0.0.1 --port 3472
 ```
 
-**Wrapper** `~/.canswim-dashboard/run-mcp.sh` (illustrative):
+**Wrapper** `~/.canswim/service/run-mcp.sh` (illustrative):
 
 ```bash
 #!/usr/bin/env bash
@@ -149,13 +161,14 @@ export FMP_API_KEY="${FMP_API_KEY:-${FMP_API_Key:-}}"
 : "${CANSWIM_HOME:=$HOME/.canswim}"
 : "${CANSWIM_MCP_HOST:=127.0.0.1}"
 : "${CANSWIM_MCP_PORT:=3472}"
+: "${PYTHON:=${CANSWIM_PYTHON:-$(command -v python3)}}"
 cd "$CANSWIM_DIR"
 export PYTHONPATH="${CANSWIM_DIR}/src${PYTHONPATH:+:$PYTHONPATH}"
 export data_dir="${CANSWIM_HOME}/data"
 export db_file=canswim_local.duckdb
 export hfhub_sync=False
 # Leave MCP_ALLOW_RUNS unset for read-only public tools
-exec env data-3rd-party=data-3rd-party python -m canswim mcp \
+exec env data-3rd-party=data-3rd-party "$PYTHON" -m canswim mcp \
   --http --host "$CANSWIM_MCP_HOST" --port "$CANSWIM_MCP_PORT"
 ```
 
@@ -172,7 +185,7 @@ WorkingDirectory=%h/canswim
 EnvironmentFile=-%h/.env
 Environment=CANSWIM_MCP_HOST=127.0.0.1
 Environment=CANSWIM_MCP_PORT=3472
-ExecStart=%h/.canswim-dashboard/run-mcp.sh
+ExecStart=%h/.canswim/service/run-mcp.sh
 Restart=always
 RestartSec=5
 MemoryMax=2G

--- a/src/canswim/hfhub.py
+++ b/src/canswim/hfhub.py
@@ -13,6 +13,7 @@ import os.path
 from pathlib import Path
 
 from canswim.paths import symbol_lists_dir
+from canswim.torch_compat import darts_torch_load_compat
 
 
 def _env_bool(name: str, default: bool = False) -> bool:
@@ -91,9 +92,12 @@ class HFHub:
                 repo_id=repo_id, local_dir=tmpdirname, token=self.HF_TOKEN
             )
             logger.info(f"dir file list:\n {os.listdir(tmpdirname)}")
-            model = model_class.load(
-                path=f"{tmpdirname}/{model_name}", map_location=map_location, **kwargs
-            )
+            with darts_torch_load_compat():
+                model = model_class.load(
+                    path=f"{tmpdirname}/{model_name}",
+                    map_location=map_location,
+                    **kwargs,
+                )
             logger.info("Downloaded model from:", repo_id)
             logger.info("Model name:", model.model_name)
             logger.info("Model params:", model.model_params)

--- a/src/canswim/model.py
+++ b/src/canswim/model.py
@@ -24,6 +24,7 @@ import gc
 from loguru import logger
 from canswim import constants
 import yaml
+from canswim.torch_compat import darts_torch_load_compat
 
 
 def election_year_offset(idx):
@@ -89,12 +90,22 @@ class CanswimModel:
         self.target_column = "Close"
         self.covariates = Covariates()
         self.hfhub = HFHub()
-        # use GPU if available
+        # Use GPU when the *installed* torch can run on this device; else CPU.
+        # Portable: no host/arch hardcoding — RTX 3090, newer GPUs, or CPU-only.
         if torch.cuda.is_available():
-            logger.info("Configuring CUDA GPU")
+            try:
+                name = torch.cuda.get_device_name(0)
+                major, minor = torch.cuda.get_device_capability(0)
+                logger.info(
+                    f"Configuring CUDA GPU: {name} (compute capability {major}.{minor})"
+                )
+            except Exception:
+                logger.info("Configuring CUDA GPU")
             # utilize CUDA tensor cores with bfloat16
             # https://pytorch.org/docs/stable/generated/torch.set_float32_matmul_precision.html#torch.set_float32_matmul_precision
             torch.set_float32_matmul_precision("high")  #  | 'medium'
+        else:
+            logger.info("CUDA not available; using CPU")
 
         self.__load_config()
 
@@ -487,9 +498,10 @@ class CanswimModel:
             map_location = "cpu"
         try:
             logger.info(f"Loading saved model name: {self.model_name}")
-            self.torch_model = TiDEModel.load(
-                path=self.model_name, map_location=map_location
-            )
+            with darts_torch_load_compat():
+                self.torch_model = TiDEModel.load(
+                    path=self.model_name, map_location=map_location
+                )
             logger.info(
                 f"Loaded saved model name: {self.model_name}, \nmodel parameters: \n{self.torch_model}"
             )
@@ -507,9 +519,10 @@ class CanswimModel:
             map_location = "cpu"
         try:
             logger.info(f"Loading saved model name: {self.model_name}")
-            self.torch_model = self.torch_model.load_weights(
-                path=self.model_name, map_location=map_location
-            )
+            with darts_torch_load_compat():
+                self.torch_model = self.torch_model.load_weights(
+                    path=self.model_name, map_location=map_location
+                )
             logger.info(
                 f"Loaded saved model name: {self.model_name}, \nmodel parameters: \n{self.torch_model}"
             )

--- a/src/canswim/torch_compat.py
+++ b/src/canswim/torch_compat.py
@@ -1,0 +1,36 @@
+"""PyTorch compatibility helpers for Darts checkpoints (CPU and all GPUs)."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+import torch
+
+
+@contextmanager
+def darts_torch_load_compat():
+    """Allow Darts full-model pickles under torch>=2.6 (any device).
+
+    Darts ``TiDEModel.load`` calls ``torch.load`` without ``weights_only=``.
+    Torch 2.6+ defaults ``weights_only=True``, which rejects pickled model
+    classes. Local/HF checkpoints are trusted operator artifacts. This is
+    independent of GPU arch (works on CPU, Ampere, Ada, etc.).
+    """
+    orig = torch.load
+
+    def _load(*args, **kwargs):
+        kwargs.setdefault("weights_only", False)
+        try:
+            return orig(*args, **kwargs)
+        except TypeError as e:
+            # Older torch without weights_only kwarg
+            if "weights_only" not in str(e):
+                raise
+            kwargs.pop("weights_only", None)
+            return orig(*args, **kwargs)
+
+    torch.load = _load  # type: ignore[assignment]
+    try:
+        yield
+    finally:
+        torch.load = orig

--- a/tests/canswim/test_docs_sync.py
+++ b/tests/canswim/test_docs_sync.py
@@ -83,10 +83,18 @@ def test_deploy_service_doc_covers_gui_and_mcp_split():
         "--http",
         "dashboard",
         "127.0.0.1",
+        # Canonical per-user home (not a second ~/.canswim-dashboard tree)
+        "CANSWIM_HOME",
+        "~/.canswim/service",
+        "~/.canswim/data",
     ):
         assert needle in text, f"docs/deploy_service.md missing {needle!r}"
+    # Legacy deploy path must not reappear as the documented primary layout
+    assert "~/.canswim-dashboard/run" not in text
+    assert "ExecStart=%h/.canswim-dashboard/" not in text
     readme = _read("README.md")
     assert "deploy_service.md" in readme
     assert "CANSWIM_MCP_KEY" in readme or "apikey" in readme
+    assert "~/.canswim/" in readme
     mkdocs = _read("mkdocs.yml")
     assert "deploy_service.md" in mkdocs

--- a/tests/canswim/test_torch_compat.py
+++ b/tests/canswim/test_torch_compat.py
@@ -1,0 +1,122 @@
+"""Tests for torch/Darts load compatibility helpers."""
+
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from canswim.torch_compat import darts_torch_load_compat
+
+
+def test_darts_torch_load_compat_sets_weights_only_false():
+    """Darts full pickles need weights_only=False under torch>=2.6."""
+    captured = {}
+
+    def fake_load(*args, **kwargs):
+        captured.update(kwargs)
+        return "ok"
+
+    with patch.object(torch, "load", fake_load):
+        with darts_torch_load_compat():
+            result = torch.load("checkpoint.pt", map_location="cpu")
+        # restored after context
+        assert torch.load is fake_load
+
+    assert result == "ok"
+    assert captured.get("weights_only") is False
+    assert captured.get("map_location") == "cpu"
+
+
+def test_darts_torch_load_compat_restores_original_on_error():
+    orig = torch.load
+    try:
+        with darts_torch_load_compat():
+            raise RuntimeError("boom")
+    except RuntimeError:
+        pass
+    assert torch.load is orig
+
+
+def test_darts_torch_load_compat_preserves_explicit_weights_only():
+    captured = {}
+
+    def fake_load(*args, **kwargs):
+        captured.update(kwargs)
+        return None
+
+    with patch.object(torch, "load", fake_load):
+        with darts_torch_load_compat():
+            torch.load("x.pt", weights_only=True)
+
+    assert captured.get("weights_only") is True
+
+
+def test_load_model_uses_darts_torch_load_compat():
+    """CanswimModel.load_model must load under the weights_only compat context."""
+    from canswim.model import CanswimModel
+
+    entered = {"n": 0}
+
+    @contextmanager
+    def tracking_compat():
+        entered["n"] += 1
+        yield
+
+    fake_model = MagicMock(name="TiDEModel")
+    with (
+        patch("canswim.model.darts_torch_load_compat", tracking_compat),
+        patch("canswim.model.TiDEModel.load", return_value=fake_model) as load,
+        patch("canswim.model.torch.cuda.is_available", return_value=False),
+        patch.object(CanswimModel, "__init__", lambda self, *a, **k: None),
+    ):
+        m = CanswimModel.__new__(CanswimModel)
+        m.model_name = "canswim_model.pt"
+        m.torch_model = None
+        ok = m.load_model()
+
+    assert ok is True
+    assert entered["n"] == 1
+    load.assert_called_once_with(path="canswim_model.pt", map_location="cpu")
+    assert m.torch_model is fake_model
+
+
+def test_hfhub_download_model_uses_darts_torch_load_compat():
+    """HF model load path also wraps TiDEModel.load for torch>=2.6."""
+    from canswim.hfhub import HFHub
+
+    entered = {"n": 0}
+
+    @contextmanager
+    def tracking_compat():
+        entered["n"] += 1
+        yield
+
+    fake_cls = MagicMock()
+    fake_cls.load.return_value = MagicMock(
+        model_name="canswim_model.pt",
+        model_params={},
+        model_created=True,
+    )
+
+    hub = HFHub.__new__(HFHub)
+    hub.hfhub_sync = True
+    hub.HF_TOKEN = "x"
+    hub.repo_id = "ivelin/canswim"
+
+    with (
+        patch("canswim.hfhub.darts_torch_load_compat", tracking_compat),
+        patch("canswim.hfhub.snapshot_download"),
+        patch("canswim.hfhub.tempfile.TemporaryDirectory") as td,
+        patch("canswim.hfhub.os.listdir", return_value=["canswim_model.pt"]),
+        patch("canswim.hfhub.torch.cuda.is_available", return_value=False),
+    ):
+        td.return_value.__enter__.return_value = "/tmp/fake-hf"
+        td.return_value.__exit__.return_value = None
+        out = hub.download_model(
+            model_name="canswim_model.pt",
+            model_class=fake_cls,
+        )
+
+    assert entered["n"] == 1
+    fake_cls.load.assert_called_once()
+    assert out is fake_cls.load.return_value


### PR DESCRIPTION
## Summary

- Load Darts full-model checkpoints under **torch ≥2.6** via `darts_torch_load_compat()` (`weights_only=False` for trusted local/HF pickles). Works on **CPU and any CUDA GPU**; no host/arch hardcoding in application code.
- Document portable GPU use (install a matching torch wheel; canswim uses `torch.cuda.is_available()` / Lightning `accelerator="auto"`).
- Document canonical per-user home **`~/.canswim/`** (`data/`, optional `service/` for user-systemd wrappers) instead of a separate `~/.canswim-dashboard` tree.
- Lock deploy paths and load call sites with unit tests; CHANGELOG notes for 0.0.20260714.

Host-only prod pin (e.g. `Environment=PYTHON=…` for a CUDA-capable venv on GB10) stays outside the package.

## Test plan

- [x] `./scripts/ci-local.sh` — 205 passed
- [x] `tests/canswim/test_torch_compat.py` — helper + `load_model` / HF download wrappers
- [x] `tests/canswim/test_docs_sync.py` — `CANSWIM_HOME`, `~/.canswim/service`, no legacy ExecStart path
- [x] Prod host smoke (separate): services under `~/.canswim/service/`, dashboard 200, NVDA forecast with CUDA when venv matches GPU