### PR TITLE
fix: DuckDB forecast skip-scan + torch≥2.6 model load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,13 +15,17 @@ Operator UX and data-refresh wave on top of 0.0.20260713 (Run tab, catch-up fore
 - **MCP** — `get_db_schema` + hardened read-only `run_select`; **live progress streaming** (`notifications/progress` + info logs) on `refresh_tickers` / `forecast_tickers` / `gather_tickers`
 - **Cross-tab Gradio fix** — Run handlers no longer depend on Charts-tab inputs (fixes hard Error toast on refresh)
 - **Gather status UX** — multi-bucket ready / short-history / IPO messaging
+- **Torch ≥2.6 checkpoint load** — `darts_torch_load_compat()` around trusted Darts full-model pickles (`weights_only=False`); CPU and any CUDA GPU; no host/arch hardcoding
+- **Portable GPU use** — still `torch.cuda.is_available()` / Lightning `accelerator="auto"`; install a torch wheel that matches the machine (see pytorch.org)
+- **Deploy home layout** — canonical per-user state is **`~/.canswim/`** (`data/`, optional `service/` for user-systemd wrappers); not a separate `~/.canswim-dashboard` tree
 
 ### Requirements for end users
 
 - Python ≥ 3.10
 - Optional but typical: **FMP API key** for fundamentals, ownership, estimates, and company profiles
 - Default model checkpoint on **Hugging Face** (public; swappable)
-- Local disk for parquet + DuckDB under `data/`
+- Local disk for parquet + DuckDB under `data/` (or `~/.canswim/data` when using the prod home layout)
+- Optional CUDA: any GPU supported by your installed PyTorch build
 
 **NOT FINANCIAL OR INVESTMENT ADVICE. USE AT YOUR OWN RISK.**
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ pip install -e ".[dev]"
 conda activate canswim
 ```
 
+**CPU and GPU:** forecasts run on CPU by default. If the active environment has a working CUDA build of PyTorch, GPU is used automatically — no canswim-specific device flag. Install torch from [pytorch.org](https://pytorch.org) for your OS/GPU when you want acceleration (RTX 30/40-class, data-center GPUs, etc.). The same source tree and PyPI package are meant to work on contributor laptops and production hosts without host-specific code paths.
+
 See [CHANGELOG.md](CHANGELOG.md) for release notes. Docs: [https://ivelin.github.io/canswim/](https://ivelin.github.io/canswim/).
 
 ## Local-first market data
@@ -95,6 +97,7 @@ For a **user-level** long-running install:
 |---------|----------|-----|
 | **Dashboard** | Private (e.g. Tailscale only) | `canswim-dashboard.service` → Gradio `:7860` — **not** on public Funnel |
 | **MCP** | Public via reverse proxy | `canswim-mcp.service` → `python -m canswim mcp --http --host 127.0.0.1 --port 3472`; edge gateway requires `CANSWIM_MCP_KEY` (`?apikey=`) |
+| **Local state** | Per-user | Canonical **`~/.canswim/`** (`data/`, optional `service/` for unit wrappers) — not a separate `~/.canswim-dashboard` tree |
 
 Basics above; full unit templates, env, Funnel/Caddy apikey matrix, and data population: **[docs/deploy_service.md](docs/deploy_service.md)**. MCP flags: **[docs/mcp.md](docs/mcp.md)**.
 

--- a/docs/deploy_service.md
+++ b/docs/deploy_service.md
@@ -31,9 +31,18 @@ Do **not** put the Gradio UI on the public Funnel. Do **not** expose the MCP bin
 ## Prerequisites
 
 - Linux user account with **systemd --user** (and preferably `loginctl enable-linger $USER` so services survive logout).
-- Checkout of canswim (or `pip install canswim`) and a Python env with dependencies (torch/darts for forecast, Gradio for UI, `mcp` for FastMCP).
-- Shared data directory (example: `~/.canswim/data`) with `data-3rd-party/` parquet + `forecast/` partitions.
-- Model checkpoint available for forecast (`canswim_model.pt` in the process cwd, or HF download when `hfhub_sync=True`).
+- Checkout of canswim (or `pip install canswim`) and a Python env with dependencies (torch/darts for forecast, Gradio for UI, `mcp` for FastMCP). **CPU works.** When CUDA is available, canswim uses it automatically (`torch.cuda.is_available()` / Lightning `accelerator="auto"`). No host-specific paths are required in application code.
+- **PyTorch must match the machine** (same as any torch app): install a wheel that supports your GPU (or CPU-only). Common cases — Ampere/Ada (e.g. RTX 3090/4090) with current CUDA 12.x wheels; very new archs may need a newer torch/CUDA build from [pytorch.org](https://pytorch.org). If `cuda.is_available()` is true but `predict` fails with *no kernel image is available for execution on the device*, the installed torch was built without kernels for that GPU — fix the **env’s torch**, not canswim flags. Point wrappers at the interpreter you verified: `Environment=PYTHON=/path/to/venv/bin/python`.
+- Shared **CANSWIM_HOME** (canonical: `~/.canswim/`) for local config and data — not a second `~/.canswim-dashboard` tree:
+
+  | Path | Role |
+  |------|------|
+  | `~/.canswim/data/` | Parquet (`data-3rd-party/`), `forecast/`, DuckDB |
+  | `~/.canswim/backups/` | Optional snapshots |
+  | `~/.canswim/service/` | User-systemd wrappers + unit templates + operator notes |
+
+  Secrets stay in `~/.env`. Application code (`CANSWIM_DIR` checkout or site-packages) is separate from home state.
+- Model checkpoint available for forecast (`canswim_model.pt` in the process cwd, or HF download when `hfhub_sync=True`). Under torch ≥2.6, Darts full-model pickles need `weights_only=False`; canswim applies that only around trusted checkpoint loads.
 - Secrets in **`~/.env`** (not committed): e.g. `FMP_API_KEY`, `CANSWIM_MCP_KEY`, optional `HF_TOKEN` / dashboard password.
 - Optional public MCP: reverse proxy (Caddy recommended) and a single Tailscale Funnel (or TLS terminator) to the proxy port.
 
@@ -41,13 +50,14 @@ Do **not** put the Gradio UI on the public Funnel. Do **not** expose the MCP bin
 
 ```bash
 # Example paths — adjust to your host
-export CANSWIM_DIR=~/canswim          # git checkout
-export CANSWIM_HOME=~/.canswim
+export CANSWIM_DIR=~/canswim          # git checkout (or wherever you install from source)
+export CANSWIM_HOME=~/.canswim        # canonical local config + data
 export data_dir=$CANSWIM_HOME/data
 export db_file=canswim_local.duckdb
 export hfhub_sync=False
 
-mkdir -p "$data_dir/data-3rd-party" "$data_dir/forecast"
+mkdir -p "$data_dir/data-3rd-party" "$data_dir/forecast" \
+  "$CANSWIM_HOME/service" "$CANSWIM_HOME/backups"
 # optional: symlink checkout data/ → shared data so relative paths resolve
 # ln -sfn "$data_dir" "$CANSWIM_DIR/data"
 ```
@@ -69,7 +79,7 @@ export FMP_API_KEY="${FMP_API_KEY:-${FMP_API_Key:-}}"
 
 ## 2. Dashboard unit (private GUI)
 
-**Wrapper** `~/.canswim-dashboard/run.sh` (illustrative):
+**Wrapper** `~/.canswim/service/run.sh` (illustrative):
 
 ```bash
 #!/usr/bin/env bash
@@ -80,6 +90,7 @@ export FMP_API_KEY="${FMP_API_KEY:-${FMP_API_Key:-}}"
 : "${CANSWIM_HOME:=$HOME/.canswim}"
 : "${CANSWIM_DASHBOARD_HOST:=0.0.0.0}"
 : "${CANSWIM_DASHBOARD_PORT:=7860}"
+: "${PYTHON:=${CANSWIM_PYTHON:-$(command -v python3)}}"
 cd "$CANSWIM_DIR"
 export PYTHONPATH="${CANSWIM_DIR}/src${PYTHONPATH:+:$PYTHONPATH}"
 export GRADIO_SERVER_NAME="$CANSWIM_DASHBOARD_HOST"
@@ -87,12 +98,11 @@ export GRADIO_SERVER_PORT="$CANSWIM_DASHBOARD_PORT"
 export data_dir="${CANSWIM_HOME}/data"
 export db_file=canswim_local.duckdb
 export hfhub_sync=False
-# Conservative threads on shared hosts
 export OMP_NUM_THREADS=2 TORCH_NUM_THREADS=2
-exec env data-3rd-party=data-3rd-party python -m canswim dashboard --same_data True
+exec env data-3rd-party=data-3rd-party "$PYTHON" -m canswim dashboard --same_data True
 ```
 
-**Unit** `~/.config/systemd/user/canswim-dashboard.service`:
+**Unit** `~/.config/systemd/user/canswim-dashboard.service` (template also kept under `~/.canswim/service/`):
 
 ```ini
 [Unit]
@@ -103,9 +113,10 @@ After=network-online.target
 Type=simple
 WorkingDirectory=%h/canswim
 EnvironmentFile=-%h/.env
+Environment=CANSWIM_HOME=%h/.canswim
 Environment=CANSWIM_DASHBOARD_HOST=0.0.0.0
 Environment=CANSWIM_DASHBOARD_PORT=7860
-ExecStart=%h/.canswim-dashboard/run.sh
+ExecStart=%h/.canswim/service/run.sh
 Restart=always
 RestartSec=10
 MemoryMax=4G
@@ -117,7 +128,8 @@ WantedBy=default.target
 ```
 
 ```bash
-chmod +x ~/.canswim-dashboard/run.sh
+chmod +x ~/.canswim/service/run.sh
+cp ~/.canswim/service/canswim-dashboard.service ~/.config/systemd/user/
 systemctl --user daemon-reload
 systemctl --user enable --now canswim-dashboard
 systemctl --user status canswim-dashboard --no-pager
@@ -138,7 +150,7 @@ Confirm the UI is **not** listed on public Funnel routes. Prefer binding only th
 python -m canswim mcp --http --host 127.0.0.1 --port 3472
 ```
 
-**Wrapper** `~/.canswim-dashboard/run-mcp.sh` (illustrative):
+**Wrapper** `~/.canswim/service/run-mcp.sh` (illustrative):
 
 ```bash
 #!/usr/bin/env bash
@@ -149,13 +161,14 @@ export FMP_API_KEY="${FMP_API_KEY:-${FMP_API_Key:-}}"
 : "${CANSWIM_HOME:=$HOME/.canswim}"
 : "${CANSWIM_MCP_HOST:=127.0.0.1}"
 : "${CANSWIM_MCP_PORT:=3472}"
+: "${PYTHON:=${CANSWIM_PYTHON:-$(command -v python3)}}"
 cd "$CANSWIM_DIR"
 export PYTHONPATH="${CANSWIM_DIR}/src${PYTHONPATH:+:$PYTHONPATH}"
 export data_dir="${CANSWIM_HOME}/data"
 export db_file=canswim_local.duckdb
 export hfhub_sync=False
 # Leave MCP_ALLOW_RUNS unset for read-only public tools
-exec env data-3rd-party=data-3rd-party python -m canswim mcp \
+exec env data-3rd-party=data-3rd-party "$PYTHON" -m canswim mcp \
   --http --host "$CANSWIM_MCP_HOST" --port "$CANSWIM_MCP_PORT"
 ```
 
@@ -172,7 +185,7 @@ WorkingDirectory=%h/canswim
 EnvironmentFile=-%h/.env
 Environment=CANSWIM_MCP_HOST=127.0.0.1
 Environment=CANSWIM_MCP_PORT=3472
-ExecStart=%h/.canswim-dashboard/run-mcp.sh
+ExecStart=%h/.canswim/service/run-mcp.sh
 Restart=always
 RestartSec=5
 MemoryMax=2G

--- a/src/canswim/forecast.py
+++ b/src/canswim/forecast.py
@@ -7,7 +7,6 @@ import os
 from datetime import datetime, timedelta
 from typing import List
 
-import duckdb
 import numpy as np
 import pandas as pd
 import pandas_market_calendars as mcal
@@ -300,59 +299,68 @@ class CanswimForecaster:
             return None
 
     def _get_stocks_without_forecast(self, stocks_df=None, forecast_start_date=None):
+        """Symbols still needing a forecast for ``forecast_start_date``.
+
+        Delegates skip detection to
+        :func:`canswim.run_triggers.list_symbols_with_saved_forecast` (ephemeral
+        DuckDB connection). On any scan failure, treats **all** listed symbols
+        as candidates so refresh/forecast can still run — never abort the whole
+        job solely because the hive skip-scan failed.
+        """
+        if stocks_df is None or len(stocks_df) == 0:
+            return []
+        # Symbol may be a column or the index depending on caller
+        if "Symbol" in getattr(stocks_df, "columns", []):
+            all_syms = [str(s).strip().upper() for s in stocks_df["Symbol"].tolist()]
+        elif "symbol" in getattr(stocks_df, "columns", []):
+            all_syms = [str(s).strip().upper() for s in stocks_df["symbol"].tolist()]
+        else:
+            all_syms = [str(s).strip().upper() for s in stocks_df.index.tolist()]
+        all_syms = sorted({s for s in all_syms if s and s.lower() != "nan"})
+        if not all_syms:
+            return []
+
         if forecast_start_date is not None:
             dt = pd.Timestamp(forecast_start_date)
         else:
             dt = pd.Timestamp.now()
-        # align date to closest business day
-        # leave as is if dt is a business day,
-        # otherwise move forward to next business day
         bd = dt + 0 * BDay()
-        y = bd.year
-        m = bd.month
-        d = bd.day
-        # logger.debug(f"Forecast start date, year, month, day: {bd}, {y}, {m}, {d}")
-        # logger.debug(f"len(stocks_df): {len(stocks_df)}")
-        # logger.debug(f"stocks_df: {stocks_df}")
+        start_s = bd.strftime("%Y-%m-%d")
+
         forecast_glob = f"{self.data_dir}/{self.forecast_subdir}**/*.parquet"
-        # Empty/missing forecast tree: all symbols need a forecast (do not crash DuckDB)
         if not glob.glob(forecast_glob, recursive=True):
             logger.info(
                 f"No existing forecast parquet under {self.data_dir}/{self.forecast_subdir}; "
                 "all listed symbols are candidates."
             )
-            stocks_without_forecast = sorted(list(set(stocks_df["Symbol"])))
-            return stocks_without_forecast
+            return all_syms
+
         try:
-            df = duckdb.sql(
-                f"""--sql
-                CREATE OR REPLACE TABLE stock_group AS SELECT Symbol from stocks_df;
-                SELECT symbol, count(*), forecast_start_year, forecast_start_month, forecast_start_day
-                FROM read_parquet('{forecast_glob}', hive_partitioning = 1) as f
-                SEMI JOIN stock_group
-                ON f.symbol = stock_group.symbol
-                GROUP BY f.symbol, forecast_start_year, forecast_start_month, forecast_start_day
-                HAVING 
-                    forecast_start_year={y} AND
-                    forecast_start_month={m} AND
-                    forecast_start_day={d} AND
-                    count(*) >= {self.canswim_model.pred_horizon}
-                """
-            ).df()
-        except duckdb.IOException as e:
+            # Lazy import: run_triggers imports CanswimForecaster only inside
+            # functions, so this is safe and keeps one DuckDB scan path (DRY).
+            from canswim.run_triggers import list_symbols_with_saved_forecast
+
+            min_rows = int(getattr(self.canswim_model, "pred_horizon", 42) or 42)
+            have = list_symbols_with_saved_forecast(
+                all_syms,
+                start_s,
+                data_dir=self.data_dir,
+                forecast_subdir=self.forecast_subdir,
+                min_horizon_rows=min_rows,
+            )
+        except Exception as e:
             logger.warning(
                 f"Could not read existing forecasts ({e}); treating all as candidates."
             )
-            return sorted(list(set(stocks_df["Symbol"])))
-        # logger.debug(f"sql result: {df}")
-        stocks_with_saved_forecast = set(df["symbol"])
+            return all_syms
+
+        stocks_with_saved_forecast = {str(s).upper() for s in (have or set())}
         logger.debug(
-            f"""These stocks already have a saved forecast: {stocks_with_saved_forecast}"""
+            f"These stocks already have a saved forecast: {stocks_with_saved_forecast}"
         )
-        stocks_without_forecast = set(stocks_df["Symbol"]) - stocks_with_saved_forecast
-        stocks_without_forecast = sorted(list(stocks_without_forecast))
+        stocks_without_forecast = sorted(set(all_syms) - stocks_with_saved_forecast)
         logger.debug(
-            f"""These stocks do not have a saved forecast yet: {stocks_without_forecast}"""
+            f"These stocks do not have a saved forecast yet: {stocks_without_forecast}"
         )
         return stocks_without_forecast
 

--- a/src/canswim/hfhub.py
+++ b/src/canswim/hfhub.py
@@ -13,6 +13,7 @@ import os.path
 from pathlib import Path
 
 from canswim.paths import symbol_lists_dir
+from canswim.torch_compat import darts_torch_load_compat
 
 
 def _env_bool(name: str, default: bool = False) -> bool:
@@ -91,9 +92,12 @@ class HFHub:
                 repo_id=repo_id, local_dir=tmpdirname, token=self.HF_TOKEN
             )
             logger.info(f"dir file list:\n {os.listdir(tmpdirname)}")
-            model = model_class.load(
-                path=f"{tmpdirname}/{model_name}", map_location=map_location, **kwargs
-            )
+            with darts_torch_load_compat():
+                model = model_class.load(
+                    path=f"{tmpdirname}/{model_name}",
+                    map_location=map_location,
+                    **kwargs,
+                )
             logger.info("Downloaded model from:", repo_id)
             logger.info("Model name:", model.model_name)
             logger.info("Model params:", model.model_params)

--- a/src/canswim/model.py
+++ b/src/canswim/model.py
@@ -24,6 +24,7 @@ import gc
 from loguru import logger
 from canswim import constants
 import yaml
+from canswim.torch_compat import darts_torch_load_compat
 
 
 def election_year_offset(idx):
@@ -89,12 +90,22 @@ class CanswimModel:
         self.target_column = "Close"
         self.covariates = Covariates()
         self.hfhub = HFHub()
-        # use GPU if available
+        # Use GPU when the *installed* torch can run on this device; else CPU.
+        # Portable: no host/arch hardcoding — RTX 3090, newer GPUs, or CPU-only.
         if torch.cuda.is_available():
-            logger.info("Configuring CUDA GPU")
+            try:
+                name = torch.cuda.get_device_name(0)
+                major, minor = torch.cuda.get_device_capability(0)
+                logger.info(
+                    f"Configuring CUDA GPU: {name} (compute capability {major}.{minor})"
+                )
+            except Exception:
+                logger.info("Configuring CUDA GPU")
             # utilize CUDA tensor cores with bfloat16
             # https://pytorch.org/docs/stable/generated/torch.set_float32_matmul_precision.html#torch.set_float32_matmul_precision
             torch.set_float32_matmul_precision("high")  #  | 'medium'
+        else:
+            logger.info("CUDA not available; using CPU")
 
         self.__load_config()
 
@@ -487,9 +498,10 @@ class CanswimModel:
             map_location = "cpu"
         try:
             logger.info(f"Loading saved model name: {self.model_name}")
-            self.torch_model = TiDEModel.load(
-                path=self.model_name, map_location=map_location
-            )
+            with darts_torch_load_compat():
+                self.torch_model = TiDEModel.load(
+                    path=self.model_name, map_location=map_location
+                )
             logger.info(
                 f"Loaded saved model name: {self.model_name}, \nmodel parameters: \n{self.torch_model}"
             )
@@ -507,9 +519,10 @@ class CanswimModel:
             map_location = "cpu"
         try:
             logger.info(f"Loading saved model name: {self.model_name}")
-            self.torch_model = self.torch_model.load_weights(
-                path=self.model_name, map_location=map_location
-            )
+            with darts_torch_load_compat():
+                self.torch_model = self.torch_model.load_weights(
+                    path=self.model_name, map_location=map_location
+                )
             logger.info(
                 f"Loaded saved model name: {self.model_name}, \nmodel parameters: \n{self.torch_model}"
             )

--- a/src/canswim/run_triggers.py
+++ b/src/canswim/run_triggers.py
@@ -211,6 +211,11 @@ def list_symbols_with_saved_forecast(
 
     Lightweight (duckdb + parquet only) — no torch / model load. Used to skip
     expensive re-forecasts for the same origin.
+
+    Uses an **ephemeral** DuckDB connection and a single-statement query so a
+    failed/closed default connection (or multi-statement ``duckdb.sql``) cannot
+    abort the caller with ``InvalidInputException: unsuccessful or closed
+    pending query result``.
     """
     import duckdb
 
@@ -220,27 +225,42 @@ def list_symbols_with_saved_forecast(
     data_dir = data_dir or os.getenv("data_dir", "data")
     forecast_subdir = forecast_subdir or os.getenv("forecast_subdir", "forecast/")
     fsd = pd.Timestamp(start_date).tz_localize(None).normalize()
-    y, m, d = int(fsd.year), int(fsd.month), int(fsd.day)
+    # Align to business day the same way the forecaster does (0 * BDay)
+    from pandas.tseries.offsets import BDay
+
+    bd = fsd + 0 * BDay()
+    y, m, d = int(bd.year), int(bd.month), int(bd.day)
     forecast_glob = f"{data_dir}/{forecast_subdir}**/*.parquet"
     if not glob.glob(forecast_glob, recursive=True):
         return set()
     in_list = ", ".join("'" + s.replace("'", "''") + "'" for s in syms)
+    con = None
     try:
-        df = duckdb.sql(
-            f"""--sql
+        # Isolated connection: never share the process default (avoids "closed
+        # pending query result" after a prior failed duckdb.sql in-process).
+        con = duckdb.connect(database=":memory:")
+        df = con.execute(
+            f"""
             SELECT upper(cast(symbol AS VARCHAR)) AS symbol, count(*) AS n
-            FROM read_parquet('{forecast_glob}', hive_partitioning = 1) AS f
+            FROM read_parquet(?, hive_partitioning = 1, union_by_name = true) AS f
             WHERE upper(cast(f.symbol AS VARCHAR)) IN ({in_list})
-              AND forecast_start_year = {y}
-              AND forecast_start_month = {m}
-              AND forecast_start_day = {d}
+              AND forecast_start_year = ?
+              AND forecast_start_month = ?
+              AND forecast_start_day = ?
             GROUP BY 1
-            HAVING count(*) >= {int(min_horizon_rows)}
-            """
+            HAVING count(*) >= ?
+            """,
+            [forecast_glob, y, m, d, int(min_horizon_rows)],
         ).df()
     except Exception as e:
         logger.warning(f"Could not scan existing forecasts ({e}); will not skip")
         return set()
+    finally:
+        if con is not None:
+            try:
+                con.close()
+            except Exception:
+                pass
     if df is None or df.empty:
         return set()
     col = "symbol" if "symbol" in df.columns else df.columns[0]

--- a/src/canswim/torch_compat.py
+++ b/src/canswim/torch_compat.py
@@ -1,0 +1,36 @@
+"""PyTorch compatibility helpers for Darts checkpoints (CPU and all GPUs)."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+import torch
+
+
+@contextmanager
+def darts_torch_load_compat():
+    """Allow Darts full-model pickles under torch>=2.6 (any device).
+
+    Darts ``TiDEModel.load`` calls ``torch.load`` without ``weights_only=``.
+    Torch 2.6+ defaults ``weights_only=True``, which rejects pickled model
+    classes. Local/HF checkpoints are trusted operator artifacts. This is
+    independent of GPU arch (works on CPU, Ampere, Ada, etc.).
+    """
+    orig = torch.load
+
+    def _load(*args, **kwargs):
+        kwargs.setdefault("weights_only", False)
+        try:
+            return orig(*args, **kwargs)
+        except TypeError as e:
+            # Older torch without weights_only kwarg
+            if "weights_only" not in str(e):
+                raise
+            kwargs.pop("weights_only", None)
+            return orig(*args, **kwargs)
+
+    torch.load = _load  # type: ignore[assignment]
+    try:
+        yield
+    finally:
+        torch.load = orig

--- a/tests/canswim/test_docs_sync.py
+++ b/tests/canswim/test_docs_sync.py
@@ -83,10 +83,18 @@ def test_deploy_service_doc_covers_gui_and_mcp_split():
         "--http",
         "dashboard",
         "127.0.0.1",
+        # Canonical per-user home (not a second ~/.canswim-dashboard tree)
+        "CANSWIM_HOME",
+        "~/.canswim/service",
+        "~/.canswim/data",
     ):
         assert needle in text, f"docs/deploy_service.md missing {needle!r}"
+    # Legacy deploy path must not reappear as the documented primary layout
+    assert "~/.canswim-dashboard/run" not in text
+    assert "ExecStart=%h/.canswim-dashboard/" not in text
     readme = _read("README.md")
     assert "deploy_service.md" in readme
     assert "CANSWIM_MCP_KEY" in readme or "apikey" in readme
+    assert "~/.canswim/" in readme
     mkdocs = _read("mkdocs.yml")
     assert "deploy_service.md" in mkdocs

--- a/tests/canswim/test_forecast_skip_existing.py
+++ b/tests/canswim/test_forecast_skip_existing.py
@@ -21,6 +21,91 @@ def test_list_symbols_with_saved_forecast_empty_tree(tmp_path, monkeypatch):
     assert got == set()
 
 
+def test_list_symbols_with_saved_forecast_reads_hive(tmp_path, monkeypatch):
+    """Ephemeral DuckDB scan finds complete partitions under hive layout."""
+    import pandas as pd
+
+    monkeypatch.setenv("data_dir", str(tmp_path))
+    monkeypatch.setenv("forecast_subdir", "forecast/")
+    part = (
+        tmp_path
+        / "forecast"
+        / "symbol=AAPL"
+        / "forecast_start_year=2026"
+        / "forecast_start_month=3"
+        / "forecast_start_day=2"
+    )
+    part.mkdir(parents=True)
+    # 42 rows = DEFAULT_MIN_FORECAST_ROWS
+    rows = pd.DataFrame(
+        {
+            "Close_s0": range(42),
+            "date": pd.date_range("2026-03-02", periods=42, freq="B"),
+        }
+    )
+    rows.to_parquet(part / "part-0.parquet", index=False)
+
+    have = list_symbols_with_saved_forecast(
+        ["AAPL", "MSFT"], "2026-03-02", min_horizon_rows=42
+    )
+    assert have == {"AAPL"}
+
+
+def test_list_symbols_with_saved_forecast_survives_duckdb_error(monkeypatch):
+    """Scan failure returns empty set (do not raise) so callers can still forecast."""
+    monkeypatch.setenv("data_dir", "/tmp/does-not-need-to-exist-canswim")
+    monkeypatch.setenv("forecast_subdir", "forecast/")
+    with patch("canswim.run_triggers.glob.glob", return_value=["fake.parquet"]):
+        with patch("duckdb.connect", side_effect=RuntimeError("closed pending")):
+            got = list_symbols_with_saved_forecast(["TSLA"], "2026-07-13")
+    assert got == set()
+
+
+def test_get_stocks_without_forecast_treats_scan_fail_as_all_candidates():
+    """Hive skip-scan errors must not abort prep_next_stock_group."""
+    import pandas as pd
+
+    from canswim.forecast import CanswimForecaster
+
+    cf = CanswimForecaster.__new__(CanswimForecaster)
+    cf.data_dir = "/tmp/x"
+    cf.forecast_subdir = "forecast/"
+    cf.canswim_model = MagicMock(pred_horizon=42)
+    stocks = pd.DataFrame({"Symbol": ["TSLA", "AMD"]})
+
+    with patch("canswim.forecast.glob.glob", return_value=["something.parquet"]):
+        with patch(
+            "canswim.run_triggers.list_symbols_with_saved_forecast",
+            side_effect=RuntimeError("closed pending query result"),
+        ):
+            out = cf._get_stocks_without_forecast(
+                stocks_df=stocks, forecast_start_date="2026-07-13"
+            )
+    assert out == ["AMD", "TSLA"]
+
+
+def test_get_stocks_without_forecast_subtracts_already_saved():
+    import pandas as pd
+
+    from canswim.forecast import CanswimForecaster
+
+    cf = CanswimForecaster.__new__(CanswimForecaster)
+    cf.data_dir = "/tmp/x"
+    cf.forecast_subdir = "forecast/"
+    cf.canswim_model = MagicMock(pred_horizon=42)
+    stocks = pd.DataFrame({"Symbol": ["TSLA", "AMD", "META"]})
+
+    with patch("canswim.forecast.glob.glob", return_value=["something.parquet"]):
+        with patch(
+            "canswim.run_triggers.list_symbols_with_saved_forecast",
+            return_value={"TSLA", "META"},
+        ):
+            out = cf._get_stocks_without_forecast(
+                stocks_df=stocks, forecast_start_date="2026-07-13"
+            )
+    assert out == ["AMD"]
+
+
 def test_forecast_skips_model_when_all_already_saved(monkeypatch):
     monkeypatch.setenv("MCP_ALLOW_RUNS", "1")
     with patch(

--- a/tests/canswim/test_torch_compat.py
+++ b/tests/canswim/test_torch_compat.py
@@ -1,0 +1,122 @@
+"""Tests for torch/Darts load compatibility helpers."""
+
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from canswim.torch_compat import darts_torch_load_compat
+
+
+def test_darts_torch_load_compat_sets_weights_only_false():
+    """Darts full pickles need weights_only=False under torch>=2.6."""
+    captured = {}
+
+    def fake_load(*args, **kwargs):
+        captured.update(kwargs)
+        return "ok"
+
+    with patch.object(torch, "load", fake_load):
+        with darts_torch_load_compat():
+            result = torch.load("checkpoint.pt", map_location="cpu")
+        # restored after context
+        assert torch.load is fake_load
+
+    assert result == "ok"
+    assert captured.get("weights_only") is False
+    assert captured.get("map_location") == "cpu"
+
+
+def test_darts_torch_load_compat_restores_original_on_error():
+    orig = torch.load
+    try:
+        with darts_torch_load_compat():
+            raise RuntimeError("boom")
+    except RuntimeError:
+        pass
+    assert torch.load is orig
+
+
+def test_darts_torch_load_compat_preserves_explicit_weights_only():
+    captured = {}
+
+    def fake_load(*args, **kwargs):
+        captured.update(kwargs)
+        return None
+
+    with patch.object(torch, "load", fake_load):
+        with darts_torch_load_compat():
+            torch.load("x.pt", weights_only=True)
+
+    assert captured.get("weights_only") is True
+
+
+def test_load_model_uses_darts_torch_load_compat():
+    """CanswimModel.load_model must load under the weights_only compat context."""
+    from canswim.model import CanswimModel
+
+    entered = {"n": 0}
+
+    @contextmanager
+    def tracking_compat():
+        entered["n"] += 1
+        yield
+
+    fake_model = MagicMock(name="TiDEModel")
+    with (
+        patch("canswim.model.darts_torch_load_compat", tracking_compat),
+        patch("canswim.model.TiDEModel.load", return_value=fake_model) as load,
+        patch("canswim.model.torch.cuda.is_available", return_value=False),
+        patch.object(CanswimModel, "__init__", lambda self, *a, **k: None),
+    ):
+        m = CanswimModel.__new__(CanswimModel)
+        m.model_name = "canswim_model.pt"
+        m.torch_model = None
+        ok = m.load_model()
+
+    assert ok is True
+    assert entered["n"] == 1
+    load.assert_called_once_with(path="canswim_model.pt", map_location="cpu")
+    assert m.torch_model is fake_model
+
+
+def test_hfhub_download_model_uses_darts_torch_load_compat():
+    """HF model load path also wraps TiDEModel.load for torch>=2.6."""
+    from canswim.hfhub import HFHub
+
+    entered = {"n": 0}
+
+    @contextmanager
+    def tracking_compat():
+        entered["n"] += 1
+        yield
+
+    fake_cls = MagicMock()
+    fake_cls.load.return_value = MagicMock(
+        model_name="canswim_model.pt",
+        model_params={},
+        model_created=True,
+    )
+
+    hub = HFHub.__new__(HFHub)
+    hub.hfhub_sync = True
+    hub.HF_TOKEN = "x"
+    hub.repo_id = "ivelin/canswim"
+
+    with (
+        patch("canswim.hfhub.darts_torch_load_compat", tracking_compat),
+        patch("canswim.hfhub.snapshot_download"),
+        patch("canswim.hfhub.tempfile.TemporaryDirectory") as td,
+        patch("canswim.hfhub.os.listdir", return_value=["canswim_model.pt"]),
+        patch("canswim.hfhub.torch.cuda.is_available", return_value=False),
+    ):
+        td.return_value.__enter__.return_value = "/tmp/fake-hf"
+        td.return_value.__exit__.return_value = None
+        out = hub.download_model(
+            model_name="canswim_model.pt",
+            model_class=fake_cls,
+        )
+
+    assert entered["n"] == 1
+    fake_cls.load.assert_called_once()
+    assert out is fake_cls.load.return_value


### PR DESCRIPTION
## Summary

Fixes MCP **refresh_tickers** aborting after a successful gather when the forecast phase tries to skip symbols that already have partitions.

### Root cause
1. **DuckDB**: `_get_stocks_without_forecast` used multi-statement `duckdb.sql()` and only caught `IOException`. A failed/closed default connection raised `InvalidInputException: unsuccessful or closed pending query result` and killed `forecast_for_tickers`.
2. **Torch ≥2.6** (needed on this host’s CUDA 13 venv): Darts full-model pickles need `weights_only=False` (included from portable torch load work).

### Fix
- Ephemeral DuckDB connection + single-statement hive scan in `list_symbols_with_saved_forecast`.
- `_get_stocks_without_forecast` reuses that helper (DRY); on any scan failure → treat all symbols as candidates (do not abort).
- `darts_torch_load_compat` for trusted checkpoint loads (CPU / any GPU).

### Host verification
- Unit tests for skip-scan + fallback.
- `./scripts/ci-local.sh` — 209 passed.
- Live smoke: `forecast --tickers TSLA --forecast_start_date 2026-07-13` → **ok**, parquet written; MCP restarted with checkout on `PYTHONPATH`.

## Test plan
- [x] `tests/canswim/test_forecast_skip_existing.py` (hive read, duckdb error fallback, subtract already-saved)
- [x] `tests/canswim/test_torch_compat.py`
- [x] `./scripts/ci-local.sh`
- [x] TSLA live-origin forecast on prod data dir
- [ ] Re-run MCP `refresh_tickers` for bulk list after merge