### PR TITLE
test: never write production data; isolate test data_dir

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,6 +26,8 @@ jobs:
         python -m pip install --upgrade pip
         pip install -e ".[dev]"
     
+    # Empty scaffolding for optional relative reads only. Tests never write here:
+    # tests/conftest.py forces a per-test temp data_dir and blocks prod writes.
     - name: Create data directories
       run: |
         mkdir -p data/data-3rd-party

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@
 - Prefer the `canswim` conda env for CLI and pytest (also used by `ci-local.sh` when present).
 - Keep `hfhub_sync=False` for local gather/forecast unless explicitly testing HF sync.
 - Do not commit local slimmed `symbol_lists/all_stocks.csv` or gitignored `data/` artifacts from few-symbol runs.
+- **Tests must not write production data.** Reading optional local parquet (e.g. under `data/` even if it symlinks to `~/.canswim/data`) is allowed; all writes go to the per-test temp tree. Enforced by `tests/conftest.py` + `tests/isolation_policy.py` (autouse `data_dir`, block writes under `~/.canswim`). Do not weaken those guards.
 
 ## Documentation (keep in sync with code)
 

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -36,7 +36,16 @@ if [[ ${#PY[@]} -eq 0 ]]; then
   echo "    using: $(command -v python) ($("${PY[@]}" -V 2>&1))"
 fi
 
-mkdir -p data/data-3rd-party data/forecast
+# Tests use per-test temp data dirs (tests/conftest.py). Never mkdir/write under
+# repo data/ when it is a symlink to production ~/.canswim/data.
+if [[ -L data ]]; then
+  echo "    note: data/ is a symlink — not creating dirs there (prod isolation)"
+elif [[ -d data ]]; then
+  # Real directory (CI / fresh checkout): empty scaffolding only, no prod home.
+  mkdir -p data/data-3rd-party data/forecast
+else
+  mkdir -p data/data-3rd-party data/forecast
+fi
 
 # Ensure editable install has test deps (pytest moved to extras_require[dev])
 if ! "${PY[@]}" -c "import pytest" 2>/dev/null; then
@@ -46,6 +55,7 @@ fi
 
 echo "==> pytest tests/canswim/"
 # Recurse package (includes tests/canswim/dashboard/, etc.)
+# Isolation is enforced by tests/conftest.py (autouse temp data_dir + write guards).
 "${PY[@]}" -m pytest tests/canswim/ -q --tb=short
 
 echo "==> local CI OK"

--- a/tests/canswim/test_data_isolation.py
+++ b/tests/canswim/test_data_isolation.py
@@ -1,0 +1,95 @@
+"""Hard rule: tests may read prod data, never write to it."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+_td = Path(__file__).resolve().parents[1]
+if str(_td) not in sys.path:
+    sys.path.insert(0, str(_td))
+
+from isolation_policy import (  # noqa: E402
+    assert_write_allowed,
+    is_forbidden_write_path,
+)
+
+
+def test_autouse_sets_isolated_data_dir(canswim_isolated_data_dir):
+    import os
+
+    data_dir = Path(os.environ["data_dir"]).resolve()
+    assert data_dir == canswim_isolated_data_dir.resolve()
+    assert data_dir.is_dir()
+    prod = (Path.home() / ".canswim").resolve()
+    assert data_dir != prod
+    assert not str(data_dir).startswith(str(prod) + os.sep)
+
+
+def test_market_data_gatherer_uses_test_data_dir(canswim_isolated_data_dir):
+    from canswim.gather_data import MarketDataGatherer
+
+    g = MarketDataGatherer()
+    assert Path(g.data_dir).resolve() == canswim_isolated_data_dir.resolve()
+
+
+def test_get_db_path_under_test_data(canswim_isolated_data_dir):
+    from canswim.db import get_db_path
+
+    p = Path(get_db_path()).resolve()
+    assert p.parent == canswim_isolated_data_dir.resolve()
+    assert p.name == "test.duckdb"
+
+
+def test_write_parquet_to_test_dir_ok(canswim_isolated_data_dir):
+    path = canswim_isolated_data_dir / "data-3rd-party" / "t.parquet"
+    pd.DataFrame({"a": [1]}).to_parquet(path)
+    assert path.is_file()
+
+
+def test_write_parquet_to_prod_forbidden(tmp_path):
+    prod_file = (
+        Path.home()
+        / ".canswim"
+        / "data"
+        / "data-3rd-party"
+        / "test_must_not_write.parquet"
+    )
+    with pytest.raises(RuntimeError, match="forbidden|production"):
+        assert_write_allowed(prod_file, allowed_roots=[tmp_path.resolve()])
+    with pytest.raises(RuntimeError, match="forbidden|production"):
+        pd.DataFrame({"a": [1]}).to_parquet(prod_file)
+
+
+def test_repo_data_symlink_is_forbidden_write_target():
+    """When repo data/ → ~/.canswim/data, writes via data/ are blocked."""
+    repo_data = Path.cwd() / "data"
+    if not (repo_data.is_symlink() or repo_data.exists()):
+        pytest.skip("no repo data/ path")
+    try:
+        resolved = repo_data.resolve()
+    except OSError:
+        pytest.skip("cannot resolve data/")
+    prod = (Path.home() / ".canswim").resolve()
+    try:
+        linked = resolved == prod or resolved.is_relative_to(prod)
+    except AttributeError:
+        linked = str(resolved).startswith(str(prod))
+    if not linked:
+        pytest.skip("data/ is not prod-linked on this host")
+    target = repo_data / "data-3rd-party" / "test_must_not_write.parquet"
+    assert is_forbidden_write_path(target)
+    with pytest.raises(RuntimeError, match="forbidden|production"):
+        pd.DataFrame({"a": [1]}).to_parquet(target)
+
+
+def test_prod_read_still_allowed_if_present():
+    """Reading prod parquet is OK (hard rule allows reads)."""
+    path = Path("data/data-3rd-party/all_stocks_price_hist_1d.parquet")
+    if not path.is_file():
+        pytest.skip("no local price parquet")
+    df = pd.read_parquet(path)
+    assert df is not None

--- a/tests/canswim/test_forecast_skip_existing.py
+++ b/tests/canswim/test_forecast_skip_existing.py
@@ -56,8 +56,7 @@ def test_forecast_skips_model_when_all_already_saved(monkeypatch):
 
 def test_forecast_only_runs_missing_symbols(monkeypatch):
     monkeypatch.setenv("MCP_ALLOW_RUNS", "1")
-    monkeypatch.setenv("data_dir", "/tmp/canswim_fc_skip_test")
-    monkeypatch.setenv("data-3rd-party", "data-3rd-party")
+    # data_dir / data-3rd-party set by autouse isolation (tmp only)
 
     cf = MagicMock()
     cf.all_already_saved = False

--- a/tests/canswim/test_gather_policy.py
+++ b/tests/canswim/test_gather_policy.py
@@ -167,7 +167,7 @@ def test_incomplete_symbols_helper():
     assert "MSFT" in bad  # missing
 
 
-def test_gather_stock_price_skips_remote_when_all_skip():
+def test_gather_stock_price_skips_remote_when_all_skip(tmp_path):
     from canswim.gather_data import MarketDataGatherer
     from canswim.gather_policy import SymbolFetchPlan
 
@@ -184,10 +184,9 @@ def test_gather_stock_price_skips_remote_when_all_skip():
             reason="local_complete_and_fresh",
         )
     ]
-    # Post-eval uses real plan on full df — ensure coverage ok
-    last = df.index.get_level_values("Date").max()
+    fake_prices = tmp_path / "fake_prices.parquet"
 
-    with patch.object(g, "_data_file", return_value="/tmp/fake_prices.parquet"):
+    with patch.object(g, "_data_file", return_value=str(fake_prices)):
         with patch("pandas.read_parquet", return_value=df):
             with patch.object(g, "_fetch_stock_prices_fmp") as fmp:
                 with patch.object(g, "_fetch_stock_prices_yfinance") as yf:
@@ -210,7 +209,7 @@ def test_gather_stock_price_skips_remote_when_all_skip():
                     yf.assert_not_called()
 
 
-def test_gather_raises_when_remote_empty_for_missing_symbol():
+def test_gather_raises_when_remote_empty_for_missing_symbol(tmp_path):
     """Shipped gather_stock_price_data must not succeed with empty remote for missing sym."""
     from canswim.gather_data import MarketDataGatherer
 
@@ -220,8 +219,9 @@ def test_gather_raises_when_remote_empty_for_missing_symbol():
     g.gather_mode = "forecast"
     g.stocks_ticker_set = ["MSFT"]
     g.FMP_API_KEY = "fake"
+    fake_prices = tmp_path / "fake_prices2.parquet"
 
-    with patch.object(g, "_data_file", return_value="/tmp/fake_prices2.parquet"):
+    with patch.object(g, "_data_file", return_value=str(fake_prices)):
         with patch("pandas.read_parquet", return_value=df):
             with patch.object(
                 g, "_fetch_stock_prices_fmp", return_value=pd.DataFrame()

--- a/tests/canswim/test_run_triggers.py
+++ b/tests/canswim/test_run_triggers.py
@@ -242,8 +242,7 @@ def test_refresh_symbols_progress_callback(monkeypatch):
 
 def test_forecast_passes_resolved_start_to_forecaster(monkeypatch):
     monkeypatch.setenv("MCP_ALLOW_RUNS", "1")
-    monkeypatch.setenv("data_dir", "/tmp/canswim_test_data_unused")
-    monkeypatch.setenv("data-3rd-party", "data-3rd-party")
+    # data_dir set by autouse isolation — do not point at /tmp or prod
 
     cf = MagicMock()
     cf.all_already_saved = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,160 @@
+"""Pytest harness isolation: tests never write into production data.
+
+Hard rule
+---------
+- **Reads** of prod (e.g. optional real parquet under ``data/``) are allowed.
+- **Writes** must stay under the per-test temp tree (pytest ``tmp_path`` /
+  ``CANSWIM_TEST_DATA_DIR``). Writes under ``~/.canswim`` or a repo ``data/``
+  symlink that resolves there are **forbidden** and raise immediately.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_TESTS_DIR = Path(__file__).resolve().parent
+if str(_TESTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_TESTS_DIR))
+
+from isolation_policy import assert_write_allowed
+
+
+@pytest.fixture(autouse=True)
+def canswim_isolated_data_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> Path:
+    """Point default canswim I/O at a per-test temp tree; guard writes."""
+    root = tmp_path / "canswim_data"
+    # mkdir before Path.mkdir is patched
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "data-3rd-party").mkdir(exist_ok=True)
+    (root / "forecast").mkdir(exist_ok=True)
+
+    monkeypatch.setenv("data_dir", str(root))
+    monkeypatch.setenv("db_file", "test.duckdb")
+    monkeypatch.setenv("forecast_subdir", "forecast/")
+    monkeypatch.setenv("data-3rd-party", "data-3rd-party")
+    monkeypatch.setenv("hfhub_sync", "False")
+    monkeypatch.setenv("CANSWIM_TEST_DATA_DIR", str(root))
+
+    # Prevent ~/.env from clobbering isolation (load_dotenv(override=True))
+    try:
+        import importlib
+
+        import dotenv
+
+        real_load = dotenv.load_dotenv
+
+        def _load_dotenv_no_override(*args, **kwargs):
+            kwargs = dict(kwargs)
+            kwargs["override"] = False
+            return real_load(*args, **kwargs)
+
+        monkeypatch.setattr(dotenv, "load_dotenv", _load_dotenv_no_override)
+        for mod_name in (
+            "canswim.gather_data",
+            "canswim.hfhub",
+            "canswim.model",
+            "canswim.forecast",
+        ):
+            try:
+                mod = importlib.import_module(mod_name)
+                if hasattr(mod, "load_dotenv"):
+                    monkeypatch.setattr(mod, "load_dotenv", _load_dotenv_no_override)
+            except Exception:
+                pass
+    except ImportError:
+        pass
+
+    allowed_roots = [root.resolve(), tmp_path.resolve()]
+
+    import pandas as pd
+
+    real_to_parquet = pd.DataFrame.to_parquet
+    real_to_csv = pd.DataFrame.to_csv
+
+    def _guarded_to_parquet(self, path=None, *args, **kwargs):
+        if path is not None:
+            assert_write_allowed(path, allowed_roots=allowed_roots)
+        return real_to_parquet(self, path, *args, **kwargs)
+
+    def _guarded_to_csv(self, path_or_buf=None, *args, **kwargs):
+        if path_or_buf is not None and not hasattr(path_or_buf, "write"):
+            assert_write_allowed(path_or_buf, allowed_roots=allowed_roots)
+        return real_to_csv(self, path_or_buf, *args, **kwargs)
+
+    monkeypatch.setattr(pd.DataFrame, "to_parquet", _guarded_to_parquet)
+    monkeypatch.setattr(pd.DataFrame, "to_csv", _guarded_to_csv)
+
+    try:
+        import duckdb
+
+        real_connect = duckdb.connect
+
+        def _guarded_connect(database=":memory:", read_only=False, **kwargs):
+            if (
+                database
+                and database != ":memory:"
+                and not read_only
+                and not str(database).startswith(":memory:")
+            ):
+                assert_write_allowed(database, allowed_roots=allowed_roots)
+            return real_connect(database=database, read_only=read_only, **kwargs)
+
+        monkeypatch.setattr(duckdb, "connect", _guarded_connect)
+    except ImportError:
+        pass
+
+    real_write_text = Path.write_text
+    real_write_bytes = Path.write_bytes
+    real_mkdir = Path.mkdir
+    real_touch = Path.touch
+    real_unlink = Path.unlink
+
+    def _guarded_write_text(self, *args, **kwargs):
+        assert_write_allowed(self, allowed_roots=allowed_roots)
+        return real_write_text(self, *args, **kwargs)
+
+    def _guarded_write_bytes(self, *args, **kwargs):
+        assert_write_allowed(self, allowed_roots=allowed_roots)
+        return real_write_bytes(self, *args, **kwargs)
+
+    def _guarded_mkdir(self, *args, **kwargs):
+        assert_write_allowed(self, allowed_roots=allowed_roots)
+        return real_mkdir(self, *args, **kwargs)
+
+    def _guarded_touch(self, *args, **kwargs):
+        assert_write_allowed(self, allowed_roots=allowed_roots)
+        return real_touch(self, *args, **kwargs)
+
+    def _guarded_unlink(self, *args, **kwargs):
+        assert_write_allowed(self, allowed_roots=allowed_roots)
+        return real_unlink(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "write_text", _guarded_write_text)
+    monkeypatch.setattr(Path, "write_bytes", _guarded_write_bytes)
+    monkeypatch.setattr(Path, "mkdir", _guarded_mkdir)
+    monkeypatch.setattr(Path, "touch", _guarded_touch)
+    monkeypatch.setattr(Path, "unlink", _guarded_unlink)
+
+    import builtins
+
+    real_open = builtins.open
+
+    def _guarded_open(file, mode="r", *args, **kwargs):
+        mode_s = str(mode)
+        if any(c in mode_s for c in ("w", "a", "x")) or (
+            "+" in mode_s and "r" in mode_s
+        ):
+            try:
+                assert_write_allowed(file, allowed_roots=allowed_roots)
+            except TypeError:
+                pass
+        return real_open(file, mode, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", _guarded_open)
+
+    yield root

--- a/tests/isolation_policy.py
+++ b/tests/isolation_policy.py
@@ -1,0 +1,82 @@
+"""Production-data write policy for the test harness (read OK, write never)."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Iterable
+
+
+_PROD_HOME = (Path.home() / ".canswim").resolve()
+
+
+def _resolve(path: os.PathLike | str) -> Path:
+    return Path(path).expanduser().resolve()
+
+
+def _is_relative_to(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+        return True
+    except ValueError:
+        return False
+
+
+def prod_data_roots() -> list[Path]:
+    """Resolved directories that must never receive test writes."""
+    roots: list[Path] = [_PROD_HOME]
+    repo_data = Path.cwd() / "data"
+    try:
+        if repo_data.exists() or repo_data.is_symlink():
+            resolved = repo_data.resolve()
+            if _is_relative_to(resolved, _PROD_HOME) or resolved == _PROD_HOME:
+                roots.append(resolved)
+    except OSError:
+        pass
+    out: list[Path] = []
+    seen: set[str] = set()
+    for r in roots:
+        key = str(r)
+        if key not in seen:
+            seen.add(key)
+            out.append(r)
+    return out
+
+
+def is_forbidden_write_path(path: os.PathLike | str) -> bool:
+    """True if ``path`` resolves under production data (must not write)."""
+    try:
+        p = _resolve(path)
+    except OSError:
+        raw = Path(str(path))
+        if raw.parts and raw.parts[0] == "data":
+            # Relative data/... when repo data/ is prod-linked
+            try:
+                if (Path.cwd() / "data").resolve() == _PROD_HOME or _is_relative_to(
+                    (Path.cwd() / "data").resolve(), _PROD_HOME
+                ):
+                    return True
+            except OSError:
+                return True
+        return False
+    for root in prod_data_roots():
+        try:
+            root_r = root.resolve()
+        except OSError:
+            root_r = root
+        if p == root_r or _is_relative_to(p, root_r):
+            return True
+    return False
+
+
+def assert_write_allowed(
+    path: os.PathLike | str,
+    *,
+    allowed_roots: Iterable[Path],
+) -> None:
+    """Raise if a test is about to write into production data."""
+    if is_forbidden_write_path(path):
+        raise RuntimeError(
+            f"Test write forbidden under production data path: {path!s} "
+            f"(allowed roots={list(allowed_roots)})"
+        )


### PR DESCRIPTION
## Summary

Hard rule: **tests may read prod data, never write it.**

- Autouse `tests/conftest.py`: per-test `data_dir` under pytest `tmp_path`, `db_file=test.duckdb`, `hfhub_sync=False`
- Blocks `load_dotenv(override=True)` from clobbering isolation via `~/.env`
- Write guards on `DataFrame.to_parquet` / `to_csv`, `duckdb.connect` (non-RO), `Path` write/mkdir, and write-capable `open`
- Policy helpers in `tests/isolation_policy.py`; coverage in `test_data_isolation.py`
- `ci-local.sh` does not `mkdir` under a prod-linked `data/` symlink
- AGENTS.md documents the rule

## Test plan

- [x] `./scripts/ci-local.sh` — 207 passed
- [x] Isolation tests: write to test dir OK; write under `~/.canswim` / prod-linked `data/` raises; prod parquet read still allowed