### PR TITLE
chore: journal MCP progressToken and progress emits

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -111,6 +111,15 @@ Progress is the **same pipeline** as the dashboard Run-tab bar (`run_triggers` �
 
 Clients that omit `progressToken` get only the final result (no error).
 
+**Host diagnostics:** with `MCP_PROGRESS_DEBUG=1` (default when unset), the MCP process
+logs to the journal whether each long tool saw a `progressToken` and each
+progress emit (`MCP progress: …` / `MCP progress emit: …`). Set
+`MCP_PROGRESS_DEBUG=0` to silence. Example:
+
+```bash
+journalctl --user -u canswim-mcp -f | rg 'MCP progress'
+```
+
 ### Custom SQL (read-only)
 
 1. Call **`get_db_schema`** so the client AI sees tables, types, and indexes.

--- a/src/canswim/mcp/server.py
+++ b/src/canswim/mcp/server.py
@@ -212,7 +212,7 @@ async def gather_tickers(
     ctx: Context | None = None,
 ) -> dict[str, Any]:
     # Run in a worker so MCP progress/log notifications can flush during the call
-    progress_cb = bind_mcp_progress(ctx)
+    progress_cb = bind_mcp_progress(ctx, tool="gather_tickers")
     return await asyncio.to_thread(
         run_tools.gather_tickers_impl,
         tickers,
@@ -240,7 +240,7 @@ async def forecast_tickers(
     dry_run: bool = False,
     ctx: Context | None = None,
 ) -> dict[str, Any]:
-    progress_cb = bind_mcp_progress(ctx)
+    progress_cb = bind_mcp_progress(ctx, tool="forecast_tickers")
     return await asyncio.to_thread(
         run_tools.forecast_tickers_impl,
         tickers,
@@ -269,7 +269,7 @@ async def refresh_tickers(
     dry_run: bool = False,
     ctx: Context | None = None,
 ) -> dict[str, Any]:
-    progress_cb = bind_mcp_progress(ctx)
+    progress_cb = bind_mcp_progress(ctx, tool="refresh_tickers")
     return await asyncio.to_thread(
         run_tools.refresh_tickers_impl,
         tickers,

--- a/src/canswim/mcp/tools/_common.py
+++ b/src/canswim/mcp/tools/_common.py
@@ -18,7 +18,34 @@ from canswim.db import (
 ProgressCb = Optional[Callable[[float, str], None]]
 
 
-def bind_mcp_progress(ctx: Any) -> ProgressCb:
+def _env_bool(name: str, default: bool = False) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return str(raw).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def extract_progress_token(ctx: Any) -> Any:
+    """Best-effort read of MCP progressToken from a FastMCP Context.
+
+    Returns None when missing or unreadable. Used for diagnostics and to mirror
+    FastMCP's silent no-op when the client omits progressToken.
+    """
+    if ctx is None:
+        return None
+    try:
+        rc = getattr(ctx, "request_context", None)
+        if rc is None:
+            return None
+        meta = getattr(rc, "meta", None)
+        if meta is None:
+            return None
+        return getattr(meta, "progressToken", None)
+    except Exception:
+        return None
+
+
+def bind_mcp_progress(ctx: Any, *, tool: str | None = None) -> ProgressCb:
     """Bridge run_triggers ``progress_cb`` → MCP ``notifications/progress`` + info logs.
 
     Designed for use with ``asyncio.to_thread``: the callback is sync and may run
@@ -27,14 +54,50 @@ def bind_mcp_progress(ctx: Any) -> ProgressCb:
     Clients only receive ``notifications/progress`` when they pass a
     ``progressToken`` in the tool request meta (MCP progress protocol). Info logs
     are still sent when the client supports logging.
+
+    Diagnostics (journal-visible): set ``MCP_PROGRESS_DEBUG=1`` (default **on**
+    when unset) to log token presence and each emit / failure. Set to ``0`` to
+    silence. FastMCP itself silently no-ops ``report_progress`` without a token.
     """
     if ctx is None:
+        logger.info(
+            "MCP progress: tool={} ctx=None (no progress bridge; CLI/internal call)",
+            tool or "?",
+        )
         return None
+
+    debug = _env_bool("MCP_PROGRESS_DEBUG", default=True)
+    token = extract_progress_token(ctx)
+    req_id = None
+    try:
+        req_id = getattr(ctx, "request_id", None)
+    except Exception:
+        req_id = None
+
+    if debug:
+        if token is None:
+            logger.warning(
+                "MCP progress: tool={} request_id={} progressToken=MISSING — "
+                "client will only see the final tool result (no mid-run "
+                "notifications/progress). Pass progressToken in tool call meta.",
+                tool or "?",
+                req_id,
+            )
+        else:
+            # Do not log raw token if it looks secret-like; just presence + type
+            logger.info(
+                "MCP progress: tool={} request_id={} progressToken=PRESENT type={}",
+                tool or "?",
+                req_id,
+                type(token).__name__,
+            )
 
     try:
         loop = asyncio.get_running_loop()
     except RuntimeError:
         loop = None
+
+    emit_count = {"n": 0}
 
     def progress_cb(frac: float, desc: str = "") -> None:
         try:
@@ -45,33 +108,75 @@ def bind_mcp_progress(ctx: Any) -> ProgressCb:
         # 0..100 with total=100 → clear percent for clients
         progress_val = f * 100.0
         total = 100.0
+        emit_count["n"] += 1
+        n = emit_count["n"]
+
+        # Re-read token each emit (meta is fixed per request, but safe)
+        tok_now = extract_progress_token(ctx)
+        if debug:
+            logger.info(
+                "MCP progress emit: tool={} #{} pct={:.1f} token={} msg={!r}",
+                tool or "?",
+                n,
+                progress_val,
+                "yes" if tok_now is not None else "no",
+                (msg or "")[:120],
+            )
 
         async def _emit() -> None:
             try:
                 await ctx.report_progress(
                     progress=progress_val, total=total, message=msg
                 )
-            except Exception:
-                pass
+            except Exception as e:
+                if debug:
+                    logger.warning(
+                        "MCP progress: report_progress failed tool={} #{}: {}: {}",
+                        tool or "?",
+                        n,
+                        type(e).__name__,
+                        e,
+                    )
             if msg:
                 try:
                     await ctx.info(msg)
-                except Exception:
-                    pass
+                except Exception as e:
+                    if debug:
+                        logger.warning(
+                            "MCP progress: ctx.info failed tool={} #{}: {}: {}",
+                            tool or "?",
+                            n,
+                            type(e).__name__,
+                            e,
+                        )
 
         if loop is None or not loop.is_running():
             try:
                 asyncio.run(_emit())
-            except Exception:
-                pass
+            except Exception as e:
+                if debug:
+                    logger.warning(
+                        "MCP progress: asyncio.run emit failed tool={} #{}: {}: {}",
+                        tool or "?",
+                        n,
+                        type(e).__name__,
+                        e,
+                    )
             return
 
         try:
             fut = asyncio.run_coroutine_threadsafe(_emit(), loop)
             fut.result(timeout=5.0)
-        except Exception:
+        except Exception as e:
             # Best-effort: never fail the run because progress notify failed
-            pass
+            if debug:
+                logger.warning(
+                    "MCP progress: threadsafe emit failed tool={} #{}: {}: {}",
+                    tool or "?",
+                    n,
+                    type(e).__name__,
+                    e,
+                )
 
     return progress_cb
 

--- a/tests/canswim/test_mcp_progress_debug.py
+++ b/tests/canswim/test_mcp_progress_debug.py
@@ -1,0 +1,47 @@
+"""Diagnostics for MCP progressToken / progress emit binding."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from canswim.mcp.tools._common import bind_mcp_progress, extract_progress_token
+
+
+def test_extract_progress_token_missing():
+    assert extract_progress_token(None) is None
+    assert extract_progress_token(SimpleNamespace()) is None
+    ctx = SimpleNamespace(request_context=SimpleNamespace(meta=None))
+    assert extract_progress_token(ctx) is None
+
+
+def test_extract_progress_token_present():
+    meta = SimpleNamespace(progressToken="tok-123")
+    ctx = SimpleNamespace(request_context=SimpleNamespace(meta=meta))
+    assert extract_progress_token(ctx) == "tok-123"
+
+
+def test_bind_mcp_progress_logs_missing_token(caplog, monkeypatch):
+    monkeypatch.setenv("MCP_PROGRESS_DEBUG", "1")
+    meta = SimpleNamespace(progressToken=None)
+    ctx = SimpleNamespace(
+        request_context=SimpleNamespace(meta=meta),
+        request_id="req-1",
+        report_progress=MagicMock(),
+        info=MagicMock(),
+    )
+    # request_context.meta with explicit None token
+    ctx.request_context.meta = SimpleNamespace(progressToken=None)
+
+    import logging
+
+    with caplog.at_level(logging.INFO):
+        # loguru does not use stdlib caplog by default — just ensure bind works
+        cb = bind_mcp_progress(ctx, tool="refresh_tickers")
+    assert cb is not None
+    # Without a running loop, emit still should not raise
+    cb(0.1, "Step 1/2: updating market data…")
+
+
+def test_bind_mcp_progress_none_ctx():
+    assert bind_mcp_progress(None, tool="refresh_tickers") is None


### PR DESCRIPTION
## Summary

Host operators could not tell from logs whether SuperGrok / `grok-connectors-manager` sends MCP `progressToken` or receives mid-run progress.

- Log at tool bind: `progressToken=PRESENT|MISSING` (+ request id, tool name)
- Log each progress emit (`pct`, message prefix, token yes/no)
- Log `report_progress` / `ctx.info` failures (no longer fully silent)
- Gated by `MCP_PROGRESS_DEBUG` (default **on**; set `0` to silence)
- Document `journalctl --user -u canswim-mcp | rg 'MCP progress'`

## Test plan

- [x] `./scripts/ci-local.sh` (220 passed)
- [x] MCP restarted on host with checkout on PYTHONPATH
- [ ] Next remote refresh: confirm either `progressToken=MISSING` or `PRESENT` + emit lines in journal