### PR TITLE
feat(mcp): async refresh jobs (start + status poll)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Operator UX and data-refresh wave on top of 0.0.20260713 (Run tab, catch-up fore
 - **Run tab** — one primary path; short help + “What this does” accordion; single progress bar; Charts replot after refresh
 - **Charts universe** — dropdown from CSV ∪ price parquet ∪ forecast hive (not `few_stocks` only); symbols added after refresh
 - **Search DB handshake** — rebuild Charts/Scans DuckDB from parquet when needed
-- **MCP** — `get_db_schema` + hardened read-only `run_select`; **live progress streaming** (`notifications/progress` + info logs) on `refresh_tickers` / `forecast_tickers` / `gather_tickers`
+- **MCP** — `get_db_schema` + hardened read-only `run_select`; **live progress streaming** (`notifications/progress` + info logs) on `refresh_tickers` / `forecast_tickers` / `gather_tickers`; **async refresh jobs** (`refresh_job_start` + `refresh_job_status`) for short-timeout clients
 - **Cross-tab Gradio fix** — Run handlers no longer depend on Charts-tab inputs (fixes hard Error toast on refresh)
 - **Gather status UX** — multi-bucket ready / short-history / IPO messaging
 - **Torch ≥2.6 checkpoint load** — `darts_torch_load_compat()` around trusted Darts full-model pickles (`weights_only=False`); CPU and any CUDA GPU; no host/arch hardcoding

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -9,7 +9,7 @@ Expose precomputed TiDE forecasts and local market data to MCP clients (Claude D
 | Mode | How | Tools |
 |------|-----|--------|
 | **Read-only (default)** | `python -m canswim mcp` | health, list, forecast/scan/price queries, `get_db_schema`, `run_select` (SELECT / WITH…SELECT only) |
-| **Runs allowed** | `MCP_ALLOW_RUNS=1` (or `CANSWIM_ALLOW_RUNS=1`) | also `gather_tickers`, `forecast_tickers`, `refresh_tickers` |
+| **Runs allowed** | `MCP_ALLOW_RUNS=1` (or `CANSWIM_ALLOW_RUNS=1`) | also `gather_tickers`, `forecast_tickers`, `refresh_tickers`, `refresh_job_start` |
 
 CLI `--tickers` and the dashboard **Run** tab do **not** need `MCP_ALLOW_RUNS`. Write tools share the same backend as CLI/GUI: [run_triggers.md](run_triggers.md).
 
@@ -96,11 +96,24 @@ Canonical registration: `src/canswim/mcp/server.py`. Update this table in the **
 | `resolve_forecast_start` | Preview week-aligned start (≡ CLI `resolve_start`) | — |
 | `gather_tickers` | Scoped gather (≡ `gatherdata --tickers`) | `MCP_ALLOW_RUNS=1` |
 | `forecast_tickers` | Scoped forecast; blank start = monthly catch-up + live | `MCP_ALLOW_RUNS=1` |
-| `refresh_tickers` | Gather + catch-up forecast (≡ dashboard **Refresh data & forecasts**) | `MCP_ALLOW_RUNS=1` |
+| `refresh_tickers` | Gather + catch-up forecast (blocking; ≡ dashboard **Refresh data & forecasts**) | `MCP_ALLOW_RUNS=1` |
+| `refresh_job_start` | **Async** refresh: same pipeline as `refresh_tickers`, returns `job_id` immediately | `MCP_ALLOW_RUNS=1` |
+| `refresh_job_status` | Poll a job from `refresh_job_start` (`progress_pct`, `message`, `result`) | — |
 
-### Progress streaming (long runs)
+### Async refresh (preferred for SuperGrok / short tool timeouts)
 
-`refresh_tickers`, `forecast_tickers`, and `gather_tickers` stream **live progress** while they run:
+Long refreshes can run for many minutes. Clients that **time out** mid-call should use the job pair instead of blocking `refresh_tickers`:
+
+1. **`refresh_job_start`** with the ticker list → immediate `{ok, data: {job_id, status, poll_after_seconds, client_hint, …}}`.
+2. Sleep about `poll_after_seconds` (typically 5–15s).
+3. **`refresh_job_status`** with that `job_id` until `status` is `succeeded` or `failed` (`done=true`).
+4. On success, use `data.result` and/or read tools (`get_forecast`, `list_tickers`) to verify. **Do not claim completion while status is `queued` or `running`.**
+
+Job state is file-backed under `{data_dir}/mcp_jobs/` so status survives **client** disconnects. Only **one** refresh job runs at a time; a second start returns an error pointing at the active `job_id`. If the MCP process restarts mid-job, status is marked failed and the client should start again.
+
+### Progress streaming (blocking long runs)
+
+`refresh_tickers`, `forecast_tickers`, and `gather_tickers` stream **live progress** while they run (and while the tool call stays open):
 
 | Channel | When the client sees it |
 |---------|-------------------------|
@@ -109,7 +122,7 @@ Canonical registration: `src/canswim/mcp/server.py`. Update this table in the **
 
 Progress is the **same pipeline** as the dashboard Run-tab bar (`run_triggers` → `progress_cb`). Work runs off the MCP event loop so notifications can flush mid-run. Final tool result is still the usual `{ok, data|error}` payload when the job finishes.
 
-Clients that omit `progressToken` get only the final result (no error).
+Clients that omit `progressToken` get only the final result (no error). Async jobs use **file status** instead of mid-call progress notifications.
 
 **Host diagnostics:** with `MCP_PROGRESS_DEBUG=1` (default when unset), the MCP process
 logs to the journal whether each long tool saw a `progressToken` and each
@@ -129,7 +142,7 @@ journalctl --user -u canswim-mcp -f | rg 'MCP progress'
    - DDL/DML keywords, multi-statement `;`, `PRAGMA`, `ATTACH`, `COPY`, etc. are **rejected**.
    - DuckDB is opened **read-only** (`connect_readonly`).
    - Results are wrapped with `LIMIT` (default 5000).
-4. **Writes are never free-form SQL** — only gated tools (`gather_tickers`, `forecast_tickers`, `refresh_tickers`) when `MCP_ALLOW_RUNS=1`.
+4. **Writes are never free-form SQL** — only gated tools (`gather_tickers`, `forecast_tickers`, `refresh_tickers`, `refresh_job_start`) when `MCP_ALLOW_RUNS=1`.
 
 ## Related docs
 

--- a/docs/run_triggers.md
+++ b/docs/run_triggers.md
@@ -9,7 +9,7 @@ User-facing actions for a **short list of symbols**. Implementation: `canswim.ru
 
 | Step | What it does | CLI | GUI | MCP |
 |------|----------------|-----|-----|-----|
-| **Refresh data & forecasts** | Gather + catch-up forecasts (**default** GUI path) | MCP `refresh_tickers` | **Refresh data & forecasts** | `refresh_tickers` |
+| **Refresh data & forecasts** | Gather + catch-up forecasts (**default** GUI path) | MCP `refresh_tickers` or **async** `refresh_job_start` + `refresh_job_status` | **Refresh data & forecasts** | `refresh_tickers` / `refresh_job_*` |
 | **Get market data** | Update local prices **and** model fundamentals for listed symbols | `gatherdata --tickers "AAPL,MSFT"` | **Update market data** | `gather_tickers` |
 | **Run a forecast** | Forecast those symbols (blank start = monthly catch-up + live) | `forecast --tickers "AAPL" …` | **Run forecast** | `forecast_tickers` |
 | **Check start date** | Show which forecast start date will be used | `resolve_start` | **Check start date** | `resolve_forecast_start` |
@@ -74,7 +74,7 @@ All-in-one for a short list (portfolio / new names). GUI label: **Refresh data &
 
 **Skipped:** work already on file; short-history / IPO names (reported in status).
 
-MCP tool name remains `refresh_tickers` (same pipeline).
+MCP: blocking tool `refresh_tickers` (same pipeline), or **async** `refresh_job_start` + `refresh_job_status` for clients that time out on long tool calls (see [mcp.md](mcp.md)).
 
 ## Run a forecast
 

--- a/src/canswim/db.py
+++ b/src/canswim/db.py
@@ -1805,7 +1805,7 @@ def run_select(
         raise SelectOnlyError(
             "Only single read-only SELECT (or WITH … SELECT) statements are allowed. "
             "No DDL/DML/multi-statement. Writes must use dedicated tools "
-            "(gather_tickers / forecast_tickers / refresh_tickers)."
+            "(gather_tickers / forecast_tickers / refresh_tickers / refresh_job_start)."
         )
     wrapped = f"SELECT * FROM ({sql.rstrip().rstrip(';')}) AS _q LIMIT {int(row_limit)}"
     with connect_readonly(db_path) as db_con:
@@ -1846,7 +1846,7 @@ def describe_search_schema(
         "sql_policy": (
             "Custom SQL via run_select: single SELECT or WITH…SELECT only; "
             "enforced + DuckDB read-only connection. "
-            "Mutations only via gather_tickers / forecast_tickers / refresh_tickers "
+            "Mutations only via gather_tickers / forecast_tickers / refresh_tickers / refresh_job_start "
             "when MCP_ALLOW_RUNS=1."
         ),
         "tables": [],

--- a/src/canswim/mcp/jobs.py
+++ b/src/canswim/mcp/jobs.py
@@ -1,0 +1,390 @@
+"""File-backed async jobs for long MCP runs (refresh / gather / forecast).
+
+Designed for clients (e.g. SuperGrok) that time out on multi-minute tool
+calls: start returns immediately with a ``job_id``; poll ``get_job_status``
+until terminal. Progress is persisted under ``{data_dir}/mcp_jobs/`` so
+status survives client disconnects (not MCP process restarts mid-run).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+from loguru import logger
+
+from canswim.run_triggers import (
+    parse_ticker_list,
+    refresh_symbols,
+    require_runs_allowed,
+)
+
+# fraction 0..1, human message — same contract as run_triggers.ProgressCb
+ProgressCb = Optional[Callable[[float, str], None]]
+
+JOB_KIND_REFRESH = "refresh"
+STATUS_QUEUED = "queued"
+STATUS_RUNNING = "running"
+STATUS_SUCCEEDED = "succeeded"
+STATUS_FAILED = "failed"
+TERMINAL = frozenset({STATUS_SUCCEEDED, STATUS_FAILED})
+
+# Poll guidance for clients that sleep between status checks
+_POLL_QUEUED_S = 5
+_POLL_RUNNING_S = 15
+_POLL_DONE_S = 0
+
+# In-process live workers (job_id → thread). Lost on process restart.
+_live_lock = threading.Lock()
+_live_threads: dict[str, threading.Thread] = {}
+_start_lock = threading.Lock()  # single-flight refresh starts
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def jobs_dir() -> Path:
+    """Job JSON store: under data_dir so tests stay isolated from prod."""
+    root = Path(os.getenv("data_dir", "data"))
+    d = root / "mcp_jobs"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _job_path(job_id: str) -> Path:
+    # only allow simple ids (uuid hex / uuid with dashes)
+    safe = str(job_id).strip()
+    if not safe or ".." in safe or "/" in safe or "\\" in safe:
+        raise ValueError(f"invalid job_id: {job_id!r}")
+    return jobs_dir() / f"{safe}.json"
+
+
+def _atomic_write(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + f".{os.getpid()}.tmp")
+    text = json.dumps(payload, indent=2, default=str, sort_keys=False)
+    tmp.write_text(text, encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def read_job(job_id: str) -> Optional[dict[str, Any]]:
+    try:
+        path = _job_path(job_id)
+    except ValueError:
+        return None
+    if not path.is_file():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as e:
+        logger.warning("Failed to read job {}: {}", job_id, e)
+        return None
+
+
+def _write_job(job: dict[str, Any]) -> dict[str, Any]:
+    job = dict(job)
+    job["updated_at"] = _utc_now()
+    _atomic_write(_job_path(job["job_id"]), job)
+    return job
+
+
+def _new_job_id() -> str:
+    return uuid.uuid4().hex
+
+
+def find_active_refresh_job() -> Optional[dict[str, Any]]:
+    """Return a non-terminal refresh job if one exists (file or live thread)."""
+    for path in sorted(jobs_dir().glob("*.json")):
+        try:
+            job = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if job.get("kind") != JOB_KIND_REFRESH:
+            continue
+        if job.get("status") in TERMINAL:
+            continue
+        # Reconcile orphans before treating as active
+        job = _reconcile_orphan(job)
+        if job.get("status") not in TERMINAL:
+            return job
+    return None
+
+
+def _reconcile_orphan(job: dict[str, Any]) -> dict[str, Any]:
+    """If status is running/queued but no live worker in this process, mark failed."""
+    jid = job.get("job_id")
+    status = job.get("status")
+    if status not in (STATUS_QUEUED, STATUS_RUNNING) or not jid:
+        return job
+    with _live_lock:
+        thr = _live_threads.get(jid)
+        alive = thr is not None and thr.is_alive()
+    if alive:
+        return job
+    # Job file claims in-flight but this process has no worker (restart or crash)
+    owner_pid = job.get("owner_pid")
+    if owner_pid is not None and int(owner_pid) == os.getpid() and status == STATUS_QUEUED:
+        # Just created; thread may not be registered yet — leave alone briefly
+        created = job.get("created_at") or ""
+        try:
+            # If updated within last 2s, still starting
+            # Compare by re-reading mtime
+            path = _job_path(jid)
+            if path.is_file() and (time.time() - path.stat().st_mtime) < 2.0:
+                return job
+        except OSError:
+            pass
+    job = dict(job)
+    job["status"] = STATUS_FAILED
+    job["error"] = (
+        "Job interrupted (MCP process restart or worker exit). "
+        "Start again with refresh_job_start."
+    )
+    job["message"] = job["error"]
+    job["done"] = True
+    job["progress_pct"] = float(job.get("progress_pct") or 0)
+    return _write_job(job)
+
+
+def _public_view(job: dict[str, Any]) -> dict[str, Any]:
+    """Client-facing snapshot with poll guidance (Grok-friendly)."""
+    status = job.get("status") or STATUS_FAILED
+    done = status in TERMINAL
+    if status == STATUS_QUEUED:
+        poll = _POLL_QUEUED_S
+    elif status == STATUS_RUNNING:
+        poll = _POLL_RUNNING_S
+    else:
+        poll = _POLL_DONE_S
+
+    view: dict[str, Any] = {
+        "job_id": job.get("job_id"),
+        "kind": job.get("kind"),
+        "status": status,
+        "done": done,
+        "tickers": job.get("tickers"),
+        "ticker_list": job.get("ticker_list"),
+        "progress_pct": float(job.get("progress_pct") or 0),
+        "message": job.get("message") or "",
+        "created_at": job.get("created_at"),
+        "updated_at": job.get("updated_at"),
+        "include_covariates": job.get("include_covariates"),
+        "dry_run": job.get("dry_run"),
+        "poll_after_seconds": poll,
+        "next_tool": None if done else "refresh_job_status",
+        "client_hint": _client_hint(status, job.get("job_id"), poll),
+    }
+    if job.get("error"):
+        view["error"] = job["error"]
+    if done and job.get("result") is not None:
+        view["result"] = job["result"]
+    return view
+
+
+def _client_hint(status: str, job_id: Any, poll: int) -> str:
+    if status == STATUS_SUCCEEDED:
+        return (
+            "Job finished successfully. Use result fields and/or get_forecast / "
+            "list_tickers to verify. Do not re-start unless the user asks."
+        )
+    if status == STATUS_FAILED:
+        return (
+            "Job failed. Report the error to the user. "
+            "They may retry with refresh_job_start after fixing the cause."
+        )
+    return (
+        f"Job still in progress (status={status}). "
+        f"Wait about {poll}s, then call refresh_job_status with job_id={job_id}. "
+        "Do not claim the refresh is complete until status is succeeded or failed. "
+        "Do not call refresh_tickers / refresh_job_start again while this job runs."
+    )
+
+
+def get_job_status(job_id: str) -> dict[str, Any]:
+    """Load job, reconcile orphans, return public view. Always readable."""
+    job = read_job(job_id)
+    if job is None:
+        return {
+            "ok": False,
+            "error": f"Unknown job_id: {job_id}",
+            "job_id": job_id,
+        }
+    job = _reconcile_orphan(job)
+    return {"ok": True, "data": _public_view(job)}
+
+
+def start_refresh_job(
+    tickers: str,
+    *,
+    include_covariates: bool = True,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    """Validate, enqueue, spawn background refresh; return immediately.
+
+    Requires ``MCP_ALLOW_RUNS=1``. Only one non-terminal refresh job at a time.
+    """
+    blocked = require_runs_allowed()
+    if blocked is not None:
+        return {
+            "ok": False,
+            "error": blocked["error"],
+            "runs_allowed": False,
+        }
+
+    parsed = parse_ticker_list(tickers)
+    if not parsed.get("ok"):
+        return {
+            "ok": False,
+            "error": parsed.get("error") or "bad tickers",
+            "data": parsed,
+        }
+
+    with _start_lock:
+        active = find_active_refresh_job()
+        if active is not None:
+            view = _public_view(active)
+            return {
+                "ok": False,
+                "error": (
+                    f"A refresh job is already {active.get('status')} "
+                    f"(job_id={active.get('job_id')}). "
+                    "Poll refresh_job_status until it finishes, then start a new one."
+                ),
+                "data": view,
+                "active_job_id": active.get("job_id"),
+            }
+
+        job_id = _new_job_id()
+        ticker_csv = ",".join(parsed["tickers"])
+        job: dict[str, Any] = {
+            "job_id": job_id,
+            "kind": JOB_KIND_REFRESH,
+            "status": STATUS_QUEUED,
+            "done": False,
+            "tickers": ticker_csv,
+            "ticker_list": list(parsed["tickers"]),
+            "include_covariates": bool(include_covariates),
+            "dry_run": bool(dry_run),
+            "progress_pct": 0.0,
+            "message": "Queued — waiting for worker…",
+            "created_at": _utc_now(),
+            "updated_at": _utc_now(),
+            "owner_pid": os.getpid(),
+            "error": None,
+            "result": None,
+        }
+        _write_job(job)
+
+        thr = threading.Thread(
+            target=_run_refresh_worker,
+            name=f"canswim-refresh-job-{job_id[:8]}",
+            args=(job_id,),
+            kwargs={
+                "tickers": ticker_csv,
+                "include_covariates": bool(include_covariates),
+                "dry_run": bool(dry_run),
+            },
+            daemon=True,
+        )
+        with _live_lock:
+            _live_threads[job_id] = thr
+        thr.start()
+
+    logger.info(
+        "MCP refresh job started job_id={} tickers={} dry_run={}",
+        job_id,
+        ticker_csv,
+        dry_run,
+    )
+    # Re-read in case worker already advanced
+    latest = read_job(job_id) or job
+    return {
+        "ok": True,
+        "data": _public_view(latest),
+    }
+
+
+def _run_refresh_worker(
+    job_id: str,
+    *,
+    tickers: str,
+    include_covariates: bool,
+    dry_run: bool,
+) -> None:
+    def _progress(frac: float, desc: str = "") -> None:
+        try:
+            f = max(0.0, min(1.0, float(frac)))
+        except (TypeError, ValueError):
+            f = 0.0
+        job = read_job(job_id)
+        if job is None:
+            return
+        job["status"] = STATUS_RUNNING
+        job["done"] = False
+        job["progress_pct"] = round(f * 100.0, 1)
+        job["message"] = (str(desc).strip() if desc else "") or job.get("message") or ""
+        try:
+            _write_job(job)
+        except OSError as e:
+            logger.warning("job progress write failed {}: {}", job_id, e)
+
+    try:
+        job = read_job(job_id)
+        if job is None:
+            return
+        job["status"] = STATUS_RUNNING
+        job["message"] = "Starting refresh (market data + catch-up forecasts)…"
+        job["progress_pct"] = 0.0
+        _write_job(job)
+
+        result = refresh_symbols(
+            tickers,
+            include_covariates=include_covariates,
+            dry_run=dry_run,
+            force_allow=False,
+            progress_cb=_progress,
+        )
+
+        job = read_job(job_id) or {}
+        job["job_id"] = job_id
+        if result.get("ok"):
+            job["status"] = STATUS_SUCCEEDED
+            job["done"] = True
+            job["progress_pct"] = 100.0
+            job["message"] = "Refresh complete."
+            job["error"] = None
+            job["result"] = result
+        else:
+            job["status"] = STATUS_FAILED
+            job["done"] = True
+            job["error"] = result.get("error") or "refresh failed"
+            job["message"] = job["error"]
+            job["result"] = result
+            # keep structured remote_api on result for clients
+        _write_job(job)
+        logger.info(
+            "MCP refresh job finished job_id={} status={}",
+            job_id,
+            job.get("status"),
+        )
+    except Exception as e:
+        logger.exception("MCP refresh job crashed job_id={}: {}", job_id, e)
+        job = read_job(job_id) or {"job_id": job_id, "kind": JOB_KIND_REFRESH}
+        job["status"] = STATUS_FAILED
+        job["done"] = True
+        job["error"] = f"{type(e).__name__}: {e}"
+        job["message"] = job["error"]
+        try:
+            _write_job(job)
+        except OSError:
+            pass
+    finally:
+        with _live_lock:
+            _live_threads.pop(job_id, None)

--- a/src/canswim/mcp/server.py
+++ b/src/canswim/mcp/server.py
@@ -20,6 +20,7 @@ from mcp.server.fastmcp import Context, FastMCP  # noqa: E402
 
 from canswim.mcp import __version__ as SERVER_VERSION  # noqa: E402
 from canswim.mcp.tools import forecasts, meta, prices, query, tickers  # noqa: E402
+from canswim.mcp.tools import jobs as job_tools  # noqa: E402
 from canswim.mcp.tools import runs as run_tools  # noqa: E402
 from canswim.mcp.tools._common import bind_mcp_progress  # noqa: E402
 from canswim.run_triggers import runs_allowed  # noqa: E402
@@ -176,8 +177,8 @@ def get_db_schema(
         "(same as Advanced Queries). Allowed: one SELECT or WITH…SELECT. "
         "DDL/DML/multi-statement/PRAGMA/ATTACH are rejected. Connection is always "
         "read-only. Writes only via gather_tickers / forecast_tickers / refresh_tickers "
-        "when MCP_ALLOW_RUNS=1. Call get_db_schema first for table/index layout. "
-        "Results capped by row_limit (default 5000)."
+        "/ refresh_job_start when MCP_ALLOW_RUNS=1. Call get_db_schema first for "
+        "table/index layout. Results capped by row_limit (default 5000)."
     ),
 )
 def run_select(sql: str, row_limit: int = 5000) -> dict[str, Any]:
@@ -259,8 +260,9 @@ async def forecast_tickers(
         "Same as dashboard “Refresh data & forecasts”. Streams live progress "
         "(notifications/progress + info logs) when the client sends a "
         "progressToken — same stages as the Run-tab progress bar. "
-        "Requires MCP_ALLOW_RUNS=1. May take many minutes for large lists. "
-        "dry_run=true plans only."
+        "Requires MCP_ALLOW_RUNS=1. May take many minutes for large lists — "
+        "prefer refresh_job_start + refresh_job_status if the client times out "
+        "on long tools. dry_run=true plans only."
     ),
 )
 async def refresh_tickers(
@@ -277,6 +279,45 @@ async def refresh_tickers(
         dry_run,
         progress_cb,
     )
+
+
+@mcp.tool(
+    name="refresh_job_start",
+    description=(
+        "Start a background refresh job and return immediately with a job_id. "
+        "Same work as refresh_tickers (market data + ~12 monthly catch-up forecasts "
+        "+ live), but does not block the tool call for many minutes. "
+        "After start, call refresh_job_status with the job_id every "
+        "poll_after_seconds until status is succeeded or failed. "
+        "Only one refresh job may run at a time. Requires MCP_ALLOW_RUNS=1. "
+        "Preferred path for SuperGrok and other clients with short tool timeouts. "
+        "dry_run=true plans only."
+    ),
+)
+def refresh_job_start(
+    tickers: str,
+    include_covariates: bool = True,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    return job_tools.refresh_job_start_impl(
+        tickers=tickers,
+        include_covariates=include_covariates,
+        dry_run=dry_run,
+    )
+
+
+@mcp.tool(
+    name="refresh_job_status",
+    description=(
+        "Poll status of a job started by refresh_job_start. "
+        "Returns status (queued|running|succeeded|failed), progress_pct, message, "
+        "poll_after_seconds, client_hint, and result when done. "
+        "Always available (no MCP_ALLOW_RUNS gate). "
+        "Do not claim the refresh finished until status is succeeded or failed."
+    ),
+)
+def refresh_job_status(job_id: str) -> dict[str, Any]:
+    return job_tools.refresh_job_status_impl(job_id=job_id)
 
 
 def _resolve_transport(

--- a/src/canswim/mcp/tools/jobs.py
+++ b/src/canswim/mcp/tools/jobs.py
@@ -1,0 +1,46 @@
+"""MCP tool wrappers for async jobs (refresh_job_start / refresh_job_status)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from canswim.mcp import jobs as job_core
+from canswim.mcp.tools._common import err_result, ok_result
+
+JOB_TOOL_NAMES = [
+    "refresh_job_start",
+    "refresh_job_status",
+]
+
+
+def refresh_job_start_impl(
+    tickers: str,
+    include_covariates: bool = True,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    """Start background refresh; return job_id immediately (does not wait)."""
+    out = job_core.start_refresh_job(
+        tickers,
+        include_covariates=include_covariates,
+        dry_run=dry_run,
+    )
+    if out.get("ok"):
+        return ok_result(out["data"])
+    # Busy / blocked / bad tickers — still surface structured data when present
+    return err_result(
+        out.get("error") or "could not start job",
+        data=out.get("data"),
+        active_job_id=out.get("active_job_id"),
+        runs_allowed=out.get("runs_allowed"),
+    )
+
+
+def refresh_job_status_impl(job_id: str) -> dict[str, Any]:
+    """Poll a job started by refresh_job_start. Always available (no runs gate)."""
+    jid = (job_id or "").strip()
+    if not jid:
+        return err_result("job_id is required")
+    out = job_core.get_job_status(jid)
+    if out.get("ok"):
+        return ok_result(out["data"])
+    return err_result(out.get("error") or "status failed", job_id=jid)

--- a/src/canswim/mcp/tools/meta.py
+++ b/src/canswim/mcp/tools/meta.py
@@ -12,7 +12,7 @@ from canswim.mcp.tools._common import err_result, ok_result, resolve_db_path
 from canswim.run_triggers import runs_allowed
 
 
-# Always-registered tools (read path + start-date preview)
+# Always-registered tools (read path + start-date preview + job status)
 READ_TOOL_NAMES = [
     "health_check",
     "get_server_info",
@@ -25,6 +25,7 @@ READ_TOOL_NAMES = [
     "get_db_schema",
     "run_select",
     "resolve_forecast_start",
+    "refresh_job_status",
 ]
 
 # Mutation tools (registered always for discoverability; gated at invoke time)
@@ -32,6 +33,7 @@ WRITE_TOOL_NAMES = [
     "gather_tickers",
     "forecast_tickers",
     "refresh_tickers",
+    "refresh_job_start",
 ]
 
 TOOL_NAMES = READ_TOOL_NAMES + WRITE_TOOL_NAMES
@@ -71,8 +73,10 @@ def get_server_info_impl() -> dict[str, Any]:
                 "TiDE precomputed forecasts (read tools). "
                 "Custom SQL: run_select is SELECT/WITH only on a read-only DuckDB "
                 "connection; get_db_schema exports tables/indexes for query authoring. "
-                "Write tools gather_tickers/forecast_tickers/refresh_tickers require "
-                "MCP_ALLOW_RUNS=1 and may load torch for forecast."
+                "Write tools gather_tickers/forecast_tickers/refresh_tickers/"
+                "refresh_job_start require MCP_ALLOW_RUNS=1 and may load torch. "
+                "Prefer refresh_job_start + refresh_job_status for long refreshes "
+                "(clients that time out on multi-minute tools)."
             ),
             "db_path": get_db_path(),
             "tools": TOOL_NAMES,

--- a/tests/canswim/test_mcp_jobs.py
+++ b/tests/canswim/test_mcp_jobs.py
@@ -1,0 +1,219 @@
+"""Async MCP refresh jobs (file-backed start + status poll)."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from canswim.mcp import jobs as job_core
+from canswim.mcp.tools import jobs as job_tools
+
+
+@pytest.fixture
+def jobs_env(canswim_isolated_data_dir: Path, monkeypatch: pytest.MonkeyPatch):
+    """Use autouse isolated data_dir; enable MCP runs for job start."""
+    monkeypatch.setenv("MCP_ALLOW_RUNS", "1")
+    yield canswim_isolated_data_dir
+
+
+def test_start_blocked_without_allow_runs(jobs_env, monkeypatch):
+    monkeypatch.delenv("MCP_ALLOW_RUNS", raising=False)
+    monkeypatch.delenv("CANSWIM_ALLOW_RUNS", raising=False)
+    out = job_tools.refresh_job_start_impl("AAPL,MSFT")
+    assert out["ok"] is False
+    assert "MCP_ALLOW_RUNS" in out["error"]
+
+
+def test_start_rejects_bad_tickers(jobs_env):
+    out = job_tools.refresh_job_start_impl("")
+    assert out["ok"] is False
+
+
+def test_status_unknown_job(jobs_env):
+    out = job_tools.refresh_job_status_impl("deadbeefcafebabe")
+    assert out["ok"] is False
+    assert "Unknown" in out["error"]
+
+
+def test_status_empty_id(jobs_env):
+    out = job_tools.refresh_job_status_impl("  ")
+    assert out["ok"] is False
+
+
+def test_job_lifecycle_succeeds(jobs_env):
+    """Worker runs refresh_symbols mock and reaches succeeded."""
+    seen_cb: list[tuple[float, str]] = []
+
+    def fake_refresh(tickers, **kwargs):
+        cb = kwargs.get("progress_cb")
+        if cb:
+            cb(0.2, "Gather…")
+            seen_cb.append((0.2, "Gather…"))
+            cb(0.8, "Forecast…")
+        return {
+            "ok": True,
+            "ready": ["WWD"],
+            "incomplete": [],
+            "gather": {"ok": True},
+            "forecast": {"ok": True, "forecasted": ["WWD"]},
+        }
+
+    with patch("canswim.mcp.jobs.refresh_symbols", side_effect=fake_refresh):
+        start = job_tools.refresh_job_start_impl("WWD", dry_run=True)
+        assert start["ok"] is True
+        jid = start["data"]["job_id"]
+        assert start["data"]["next_tool"] == "refresh_job_status"
+        assert start["data"]["poll_after_seconds"] >= 0
+        assert "client_hint" in start["data"]
+
+        # Wait for background worker
+        deadline = time.time() + 5.0
+        status = None
+        while time.time() < deadline:
+            status = job_tools.refresh_job_status_impl(jid)
+            assert status["ok"] is True
+            if status["data"]["done"]:
+                break
+            time.sleep(0.05)
+
+    assert status is not None
+    assert status["data"]["status"] == "succeeded"
+    assert status["data"]["done"] is True
+    assert status["data"]["progress_pct"] == 100.0
+    assert status["data"]["poll_after_seconds"] == 0
+    assert status["data"]["next_tool"] is None
+    assert status["data"]["result"]["ok"] is True
+    assert seen_cb  # progress was forwarded to job file
+
+    # Job file lives under data_dir/mcp_jobs
+    job_file = Path(jobs_env) / "mcp_jobs" / f"{jid}.json"
+    assert job_file.is_file()
+
+
+def test_job_lifecycle_failed(jobs_env):
+    def fake_refresh(tickers, **kwargs):
+        return {"ok": False, "error": "boom from gather"}
+
+    with patch("canswim.mcp.jobs.refresh_symbols", side_effect=fake_refresh):
+        start = job_tools.refresh_job_start_impl("AAA")
+        jid = start["data"]["job_id"]
+        deadline = time.time() + 5.0
+        status = None
+        while time.time() < deadline:
+            status = job_tools.refresh_job_status_impl(jid)
+            if status["data"]["done"]:
+                break
+            time.sleep(0.05)
+
+    assert status["data"]["status"] == "failed"
+    assert "boom" in status["data"]["error"]
+    assert status["data"]["done"] is True
+
+
+def test_single_flight_rejects_second_start(jobs_env):
+    import threading
+
+    release = threading.Event()
+    entered = threading.Event()
+
+    def slow_refresh(tickers, **kwargs):
+        entered.set()
+        release.wait(timeout=5.0)
+        return {
+            "ok": True,
+            "ready": ["A"],
+            "gather": {"ok": True},
+            "forecast": {"ok": True},
+        }
+
+    with patch("canswim.mcp.jobs.refresh_symbols", side_effect=slow_refresh):
+        first = job_tools.refresh_job_start_impl("AAPL")
+        assert first["ok"] is True
+        jid1 = first["data"]["job_id"]
+        assert entered.wait(timeout=2.0)
+
+        second = job_tools.refresh_job_start_impl("MSFT")
+        assert second["ok"] is False
+        assert second.get("active_job_id") == jid1
+        assert "already" in second["error"].lower()
+
+        release.set()
+        deadline = time.time() + 5.0
+        st = None
+        while time.time() < deadline:
+            st = job_tools.refresh_job_status_impl(jid1)
+            if st["data"]["done"]:
+                break
+            time.sleep(0.05)
+        assert st is not None
+        assert st["data"]["status"] == "succeeded"
+
+    # After finish, a new job may start
+    with patch(
+        "canswim.mcp.jobs.refresh_symbols",
+        return_value={"ok": True, "ready": ["MSFT"]},
+    ):
+        third = job_tools.refresh_job_start_impl("MSFT")
+        assert third["ok"] is True
+        jid3 = third["data"]["job_id"]
+        assert jid3 != jid1
+        deadline = time.time() + 5.0
+        while time.time() < deadline:
+            if job_tools.refresh_job_status_impl(jid3)["data"]["done"]:
+                break
+            time.sleep(0.05)
+
+
+def test_orphan_running_marked_failed(jobs_env):
+    """File says running but no live thread → reconcile to failed."""
+    jid = "abc123orphan"
+    path = job_core.jobs_dir() / f"{jid}.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    import json
+    from datetime import datetime, timezone
+
+    now = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+    path.write_text(
+        json.dumps(
+            {
+                "job_id": jid,
+                "kind": "refresh",
+                "status": "running",
+                "done": False,
+                "tickers": "ZZZ",
+                "progress_pct": 40.0,
+                "message": "halfway",
+                "created_at": now,
+                "updated_at": now,
+                "owner_pid": 1,  # not this process
+                "error": None,
+                "result": None,
+            }
+        ),
+        encoding="utf-8",
+    )
+    # Touch mtime into the past so grace window doesn't apply
+    import os
+
+    past = time.time() - 60
+    os.utime(path, (past, past))
+
+    st = job_tools.refresh_job_status_impl(jid)
+    assert st["ok"] is True
+    assert st["data"]["status"] == "failed"
+    assert "interrupted" in st["data"]["error"].lower()
+
+
+def test_server_registers_job_tools():
+    from canswim.mcp import server as srv
+
+    assert callable(srv.refresh_job_start)
+    assert callable(srv.refresh_job_status)
+    tool_manager = getattr(srv.mcp, "_tool_manager", None)
+    if tool_manager is not None and hasattr(tool_manager, "_tools"):
+        names = set(tool_manager._tools.keys())
+        assert "refresh_job_start" in names
+        assert "refresh_job_status" in names

--- a/tests/canswim/test_mcp_tools.py
+++ b/tests/canswim/test_mcp_tools.py
@@ -78,14 +78,18 @@ def test_tool_names_cover_surface():
         "gather_tickers",
         "forecast_tickers",
         "refresh_tickers",
+        "refresh_job_start",
+        "refresh_job_status",
     }
     assert set(TOOL_NAMES) == expected
     assert set(WRITE_TOOL_NAMES) == {
         "gather_tickers",
         "forecast_tickers",
         "refresh_tickers",
+        "refresh_job_start",
     }
     assert "resolve_forecast_start" in READ_TOOL_NAMES
+    assert "refresh_job_status" in READ_TOOL_NAMES
     assert "get_db_schema" in READ_TOOL_NAMES
 
 
@@ -270,6 +274,8 @@ def test_server_registers_tools(mcp_env):
         assert "run_select" in names
         assert "get_db_schema" in names
         assert "refresh_tickers" in names
+        assert "refresh_job_start" in names
+        assert "refresh_job_status" in names
     else:
         # Fallback: tools list API if present
         tools = getattr(mcp_server.mcp, "list_tools", None)

--- a/tests/canswim/test_ux_split_labels.py
+++ b/tests/canswim/test_ux_split_labels.py
@@ -227,6 +227,8 @@ def test_mcp_tool_descriptions_are_plain():
     # Tool description block for forecast should be plain language
     assert "Run a forecast for listed stock symbols" in src
     assert 'name="refresh_tickers"' in src
+    assert 'name="refresh_job_start"' in src
+    assert 'name="refresh_job_status"' in src
     assert "progressToken" in src or "progress" in src.lower()
     assert "bind_mcp_progress" in src
 


### PR DESCRIPTION
## Summary

Long `refresh_tickers` calls time out on SuperGrok-class clients. This adds an **async job** path:

1. **`refresh_job_start`** — validate tickers, spawn background worker, return `job_id` immediately (requires `MCP_ALLOW_RUNS=1`)
2. **`refresh_job_status`** — poll progress/status (always available); includes `client_hint` and `poll_after_seconds`

Same work as `refresh_tickers` (gather + monthly catch-up). State is file-backed under `{data_dir}/mcp_jobs/`. Only one refresh job at a time. Orphan running jobs after MCP restart are marked failed.

Blocking `refresh_tickers` remains for clients that can hold the call open (with progressToken streaming).

## Test plan

- [x] `./scripts/ci-local.sh` (229 passed)
- [x] Unit tests: lifecycle succeed/fail, single-flight, orphan reconcile, runs gate
- [ ] After merge: restart `canswim-mcp`, from SuperGrok call `refresh_job_start` then poll `refresh_job_status`