### PR TITLE
chore: bump MCP version 0.0.20260715 (client rediscovery)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,11 +46,22 @@ User-facing docs live under `docs/` and the root `README.md`. **Update them in t
 |--------|-------------|
 | CLI task/flag or help text | `__main__.py` help; `docs/cli.md` and README if top-level |
 | Gather/forecast policy or Run tab labels | `docs/run_triggers.md`; UX string tests; README table if labels change |
-| MCP tools add/rename/remove | `docs/mcp.md` tool table (+ README link only if needed) |
+| MCP tools add/rename/remove **or behavior change** | `docs/mcp.md` tool table; **bump `setup.cfg` `version`** (date-style `0.0.YYYYMMDD`) + `CHANGELOG.md` so clients see a new version via MCP initialize / `get_server_info` and refresh tool discovery |
 | Prod deploy / systemd / Tailscale-Funnel MCP path | `docs/deploy_service.md` + README sketch |
 | Charts / Scans / Run layout or primary copy | Replace affected `docs/images/*.png` in the same PR |
 | Data paths / DuckDB vs parquet semantics | `docs/data_store.md` |
 | **Search DB / DuckDB schema** | See **Schema migrations** below |
+
+### MCP version (required on every MCP surface change)
+
+Clients (SuperGrok, connectors) cache tool lists. They re-discover when the **server version** changes.
+
+1. Bump `version` in `setup.cfg` (prefer next calendar day `0.0.YYYYMMDD`, or same day with a clear CHANGELOG entry if multiple bumps).
+2. Add a CHANGELOG section for that version.
+3. Version is resolved by `canswim.version` (checkout `setup.cfg` first, then installed metadata) → MCP protocol `server.version` and `get_server_info`.
+4. After deploy, restart `canswim-mcp` so remote clients see the new version.
+
+Do **not** ship MCP tool/behavior changes without a version bump.
 
 ## Schema migrations (required between app versions)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,16 @@ All notable releases are documented here. Versioning follows date-style `0.0.YYY
 
 ## 0.0.20260715
 
-MCP surface bump so clients rediscover tools after async refresh jobs.
+MCP surface bump so clients rediscover tools after async refresh jobs + portfolio-safe limits.
 
 ### Highlights
 
 - **MCP async refresh** — `refresh_job_start` + `refresh_job_status` (file-backed jobs under `{data_dir}/mcp_jobs/`); preferred for SuperGrok / short tool timeouts
+- **Portfolio jobs** — async max **~200** symbols, internal batches of ~20, `coverage` + strict `client_hint` (no full-account overclaim)
+- **No silent truncate** — over-max ticker lists return `ok=false` with `omitted_tickers` / `recommended_tool` (blocking max remains ~50)
+- **`get_server_info.refresh_guidance`** — preferred workflow for Schwab/large lists
 - **MCP progress diagnostics** — journal `progressToken` PRESENT/MISSING + emit lines (`MCP_PROGRESS_DEBUG`)
-- **Version discovery** — MCP `get_server_info` / protocol version read **checkout** `setup.cfg` when running via `PYTHONPATH` (not only a stale installed wheel)
+- **Version discovery** — MCP `get_server_info` / protocol version read **checkout** `setup.cfg` when running via `PYTHONPATH`
 - **Rule** — bump package version on every MCP tool/behavior change so clients refresh discovery
 
 ### Install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable releases are documented here. Versioning follows date-style `0.0.YYYYMMDD` unless noted.
 
+## 0.0.20260715
+
+MCP surface bump so clients rediscover tools after async refresh jobs.
+
+### Highlights
+
+- **MCP async refresh** — `refresh_job_start` + `refresh_job_status` (file-backed jobs under `{data_dir}/mcp_jobs/`); preferred for SuperGrok / short tool timeouts
+- **MCP progress diagnostics** — journal `progressToken` PRESENT/MISSING + emit lines (`MCP_PROGRESS_DEBUG`)
+- **Version discovery** — MCP `get_server_info` / protocol version read **checkout** `setup.cfg` when running via `PYTHONPATH` (not only a stale installed wheel)
+- **Rule** — bump package version on every MCP tool/behavior change so clients refresh discovery
+
+### Install
+
+```bash
+pip install canswim==0.0.20260715
+python -m canswim -h
+python -m canswim mcp
+```
+
 ## 0.0.20260714
 
 Operator UX and data-refresh wave on top of 0.0.20260713 (Run tab, catch-up forecasts, MCP schema/SQL, progress).
@@ -12,7 +31,7 @@ Operator UX and data-refresh wave on top of 0.0.20260713 (Run tab, catch-up fore
 - **Run tab** — one primary path; short help + “What this does” accordion; single progress bar; Charts replot after refresh
 - **Charts universe** — dropdown from CSV ∪ price parquet ∪ forecast hive (not `few_stocks` only); symbols added after refresh
 - **Search DB handshake** — rebuild Charts/Scans DuckDB from parquet when needed
-- **MCP** — `get_db_schema` + hardened read-only `run_select`; **live progress streaming** (`notifications/progress` + info logs) on `refresh_tickers` / `forecast_tickers` / `gather_tickers`; **async refresh jobs** (`refresh_job_start` + `refresh_job_status`) for short-timeout clients
+- **MCP** — `get_db_schema` + hardened read-only `run_select`; **live progress streaming** (`notifications/progress` + info logs) on `refresh_tickers` / `forecast_tickers` / `gather_tickers`
 - **Cross-tab Gradio fix** — Run handlers no longer depend on Charts-tab inputs (fixes hard Error toast on refresh)
 - **Gather status UX** — multi-bucket ready / short-history / IPO messaging
 - **Torch ≥2.6 checkpoint load** — `darts_torch_load_compat()` around trusted Darts full-model pickles (`weights_only=False`); CPU and any CUDA GPU; no host/arch hardcoding

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Flags: `python -m canswim -h` is the source of truth. Local site preview: `pip i
 
 ```bash
 pip install canswim
-# pin a release: pip install canswim==0.0.20260714
+# pin a release: pip install canswim==0.0.20260715
 
 # dev checkout
 pip install -e ".[dev]"

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -13,6 +13,10 @@ Expose precomputed TiDE forecasts and local market data to MCP clients (Claude D
 
 CLI `--tickers` and the dashboard **Run** tab do **not** need `MCP_ALLOW_RUNS`. Write tools share the same backend as CLI/GUI: [run_triggers.md](run_triggers.md).
 
+### Server version (client rediscovery)
+
+MCP initialize and **`get_server_info`** expose package version from `setup.cfg` (via `canswim.version`). **Any** MCP tool add/rename/remove or behavior change must bump that version in the same PR so remote clients refresh tool discovery instead of caching a stale list.
+
 ## Prerequisites
 
 1. Local parquet under `data/data-3rd-party/` and forecasts under `data/forecast/` (or your `data_dir`).

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -106,14 +106,17 @@ Canonical registration: `src/canswim/mcp/server.py`. Update this table in the **
 
 ### Async refresh (preferred for SuperGrok / short tool timeouts)
 
-Long refreshes can run for many minutes. Clients that **time out** mid-call should use the job pair instead of blocking `refresh_tickers`:
+Long refreshes can run for many minutes. **Portfolio / Schwab “refresh all positions”** must use the job pair — not blocking `refresh_tickers`:
 
-1. **`refresh_job_start`** with the ticker list → immediate `{ok, data: {job_id, status, poll_after_seconds, client_hint, …}}`.
-2. Sleep about `poll_after_seconds` (typically 5–15s).
-3. **`refresh_job_status`** with that `job_id` until `status` is `succeeded` or `failed` (`done=true`).
-4. On success, use `data.result` and/or read tools (`get_forecast`, `list_tickers`) to verify. **Do not claim completion while status is `queued` or `running`.**
+1. Call **`get_server_info`** once (note `version` + `refresh_guidance`).
+2. **`refresh_job_start`** with the full symbol list (≤ **~200** async max; blocking tool max is **~50**). Oversized lists **error** (no silent truncate).
+3. Sleep about `poll_after_seconds` (typically 5–15s).
+4. **`refresh_job_status`** until `status` is `succeeded` or `failed` (`done=true`).
+5. Report **`coverage`** (`requested_count`, `batches_ok` / `batches_failed`). **Only claim success for symbols in that job’s `ticker_list`.** If the account has more names, start another job for the remainder.
 
-Job state is file-backed under `{data_dir}/mcp_jobs/` so status survives **client** disconnects. Only **one** refresh job runs at a time; a second start returns an error pointing at the active `job_id`. If the MCP process restarts mid-job, status is marked failed and the client should start again.
+Workers process symbols in internal batches (~20) with progress on the job file. Job state is under `{data_dir}/mcp_jobs/` so status survives **client** disconnects. Only **one** refresh job runs at a time. If MCP restarts mid-job, status becomes failed — start again.
+
+**Do not** claim portfolio-wide success after a tool timeout, a `dry_run`, a subset list, or while status is still `queued`/`running`.
 
 ### Progress streaming (blocking long runs)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = canswim
-version = 0.0.20260714
+version = 0.0.20260715
 author = Ivelin Ivanov
 author_email = ivelin117@gmail.com
 description = Developer toolkit for CANSLIM-style investors (CLI, Gradio GUI, MCP)

--- a/src/canswim/__main__.py
+++ b/src/canswim/__main__.py
@@ -192,7 +192,10 @@ logger.info(
     ret=ret,
 )
 
-version = metadata.version("canswim")
+try:
+    from canswim.version import __version__ as version
+except Exception:
+    version = metadata.version("canswim")
 logger.info(f"canswim version: {version}")
 
 args = parser.parse_args()

--- a/src/canswim/mcp/__init__.py
+++ b/src/canswim/mcp/__init__.py
@@ -2,11 +2,6 @@
 
 from __future__ import annotations
 
+from canswim.version import __version__
+
 __all__ = ["__version__"]
-
-try:
-    from importlib.metadata import version as _pkg_version
-
-    __version__ = _pkg_version("canswim")
-except Exception:
-    __version__ = "0.0.0"

--- a/src/canswim/mcp/jobs.py
+++ b/src/canswim/mcp/jobs.py
@@ -20,6 +20,7 @@ from typing import Any, Callable, Optional
 from loguru import logger
 
 from canswim.run_triggers import (
+    DEFAULT_MAX_TICKERS,
     parse_ticker_list,
     refresh_symbols,
     require_runs_allowed,
@@ -34,6 +35,11 @@ STATUS_RUNNING = "running"
 STATUS_SUCCEEDED = "succeeded"
 STATUS_FAILED = "failed"
 TERMINAL = frozenset({STATUS_SUCCEEDED, STATUS_FAILED})
+
+# Portfolio-scale async refresh (blocking refresh_tickers stays at DEFAULT_MAX_TICKERS)
+JOB_MAX_TICKERS = 200
+# Internal worker chunks (GPU/memory + finer progress). Not exposed as separate jobs.
+WORKER_BATCH_SIZE = 20
 
 # Poll guidance for clients that sleep between status checks
 _POLL_QUEUED_S = 5
@@ -164,13 +170,19 @@ def _public_view(job: dict[str, Any]) -> dict[str, Any]:
     else:
         poll = _POLL_DONE_S
 
+    ticker_list = job.get("ticker_list") or []
+    requested_count = job.get("requested_count")
+    if requested_count is None and isinstance(ticker_list, list):
+        requested_count = len(ticker_list)
+    result = job.get("result") if done else None
     view: dict[str, Any] = {
         "job_id": job.get("job_id"),
         "kind": job.get("kind"),
         "status": status,
         "done": done,
         "tickers": job.get("tickers"),
-        "ticker_list": job.get("ticker_list"),
+        "ticker_list": ticker_list,
+        "requested_count": requested_count,
         "progress_pct": float(job.get("progress_pct") or 0),
         "message": job.get("message") or "",
         "created_at": job.get("created_at"),
@@ -179,24 +191,59 @@ def _public_view(job: dict[str, Any]) -> dict[str, Any]:
         "dry_run": job.get("dry_run"),
         "poll_after_seconds": poll,
         "next_tool": None if done else "refresh_job_status",
-        "client_hint": _client_hint(status, job.get("job_id"), poll),
+        "client_hint": _client_hint(
+            status,
+            job.get("job_id"),
+            poll,
+            requested_count=requested_count
+            if isinstance(requested_count, int)
+            else None,
+            result=result if isinstance(result, dict) else None,
+        ),
     }
     if job.get("error"):
         view["error"] = job["error"]
-    if done and job.get("result") is not None:
-        view["result"] = job["result"]
+    if done and result is not None:
+        view["result"] = result
+        if isinstance(result, dict) and result.get("coverage"):
+            view["coverage"] = result["coverage"]
     return view
 
 
-def _client_hint(status: str, job_id: Any, poll: int) -> str:
+def _client_hint(
+    status: str,
+    job_id: Any,
+    poll: int,
+    *,
+    requested_count: int | None = None,
+    result: dict[str, Any] | None = None,
+) -> str:
     if status == STATUS_SUCCEEDED:
+        cov = (result or {}).get("coverage") or {}
+        n_req = cov.get("requested_count", requested_count)
+        n_ok = cov.get("processed_count", n_req)
+        partial = cov.get("batches_failed", 0) not in (0, None)
+        base = (
+            f"Job finished. Coverage: processed {n_ok} of {n_req} requested symbols "
+            if n_req is not None
+            else "Job finished successfully. "
+        )
+        if partial:
+            return (
+                base
+                + "Some batches failed — report partial coverage; do not claim full portfolio success. "
+                "Inspect result.batch_results / result.coverage."
+            )
         return (
-            "Job finished successfully. Use result fields and/or get_forecast / "
-            "list_tickers to verify. Do not re-start unless the user asks."
+            base
+            + "Only claim success for symbols in this job’s ticker_list. "
+            "If the user has more positions, start another refresh_job_start for the remainder. "
+            "Verify with get_forecast / list_tickers as needed."
         )
     if status == STATUS_FAILED:
         return (
-            "Job failed. Report the error to the user. "
+            "Job failed. Report the error and coverage to the user. "
+            "Do not claim the portfolio is refreshed. "
             "They may retry with refresh_job_start after fixing the cause."
         )
     return (
@@ -238,12 +285,26 @@ def start_refresh_job(
             "runs_allowed": False,
         }
 
-    parsed = parse_ticker_list(tickers)
+    parsed = parse_ticker_list(
+        tickers,
+        max_tickers=JOB_MAX_TICKERS,
+        overflow="error",
+    )
     if not parsed.get("ok"):
+        err = parsed.get("error") or "bad tickers"
+        # Point portfolio-sized lists at the job max clearly
+        if parsed.get("truncated") and parsed.get("requested_count"):
+            err = (
+                f"{err} Async job max is {JOB_MAX_TICKERS} symbols "
+                f"(blocking refresh_tickers max is {DEFAULT_MAX_TICKERS}). "
+                "Start sequential jobs for remaining batches after each succeeds."
+            )
         return {
             "ok": False,
-            "error": parsed.get("error") or "bad tickers",
+            "error": err,
             "data": parsed,
+            "client_hint": parsed.get("client_hint"),
+            "recommended_tool": parsed.get("recommended_tool") or "refresh_job_start",
         }
 
     with _start_lock:
@@ -262,18 +323,24 @@ def start_refresh_job(
             }
 
         job_id = _new_job_id()
-        ticker_csv = ",".join(parsed["tickers"])
+        tlist = list(parsed["tickers"])
+        ticker_csv = ",".join(tlist)
+        n = len(tlist)
         job: dict[str, Any] = {
             "job_id": job_id,
             "kind": JOB_KIND_REFRESH,
             "status": STATUS_QUEUED,
             "done": False,
             "tickers": ticker_csv,
-            "ticker_list": list(parsed["tickers"]),
+            "ticker_list": tlist,
+            "requested_count": n,
             "include_covariates": bool(include_covariates),
             "dry_run": bool(dry_run),
             "progress_pct": 0.0,
-            "message": "Queued — waiting for worker…",
+            "message": (
+                f"Queued — {n} symbol(s), "
+                f"{(n + WORKER_BATCH_SIZE - 1) // WORKER_BATCH_SIZE} batch(es)…"
+            ),
             "created_at": _utc_now(),
             "updated_at": _utc_now(),
             "owner_pid": os.getpid(),
@@ -287,7 +354,7 @@ def start_refresh_job(
             name=f"canswim-refresh-job-{job_id[:8]}",
             args=(job_id,),
             kwargs={
-                "tickers": ticker_csv,
+                "ticker_list": tlist,
                 "include_covariates": bool(include_covariates),
                 "dry_run": bool(dry_run),
             },
@@ -298,9 +365,9 @@ def start_refresh_job(
         thr.start()
 
     logger.info(
-        "MCP refresh job started job_id={} tickers={} dry_run={}",
+        "MCP refresh job started job_id={} n_tickers={} dry_run={}",
         job_id,
-        ticker_csv,
+        n,
         dry_run,
     )
     # Re-read in case worker already advanced
@@ -311,10 +378,24 @@ def start_refresh_job(
     }
 
 
+def _merge_symbol_lists(*lists: Any) -> list[str]:
+    out: list[str] = []
+    seen: set[str] = set()
+    for lst in lists:
+        if not lst:
+            continue
+        for x in lst:
+            s = str(x).strip().upper()
+            if s and s not in seen:
+                seen.add(s)
+                out.append(s)
+    return out
+
+
 def _run_refresh_worker(
     job_id: str,
     *,
-    tickers: str,
+    ticker_list: list[str],
     include_covariates: bool,
     dry_run: bool,
 ) -> None:
@@ -336,43 +417,147 @@ def _run_refresh_worker(
             logger.warning("job progress write failed {}: {}", job_id, e)
 
     try:
+        symbols = [str(s).strip().upper() for s in ticker_list if str(s).strip()]
+        n = len(symbols)
+        batches = [
+            symbols[i : i + WORKER_BATCH_SIZE]
+            for i in range(0, n, WORKER_BATCH_SIZE)
+        ] or [[]]
+        n_batches = len(batches)
+
         job = read_job(job_id)
         if job is None:
             return
         job["status"] = STATUS_RUNNING
-        job["message"] = "Starting refresh (market data + catch-up forecasts)…"
+        job["message"] = (
+            f"Starting refresh: {n} symbol(s) in {n_batches} batch(es)…"
+        )
         job["progress_pct"] = 0.0
+        job["requested_count"] = n
         _write_job(job)
 
-        result = refresh_symbols(
-            tickers,
-            include_covariates=include_covariates,
-            dry_run=dry_run,
-            force_allow=False,
-            progress_cb=_progress,
-        )
+        batch_results: list[dict[str, Any]] = []
+        ready: list[str] = []
+        incomplete: list[str] = []
+        forecasted: list[str] = []
+        messages: list[str] = []
+        batches_ok = 0
+        batches_failed = 0
+        last_error: str | None = None
+
+        for bi, batch in enumerate(batches):
+            if not batch:
+                continue
+            batch_csv = ",".join(batch)
+            base = bi / n_batches
+            span = 1.0 / n_batches
+
+            def _batch_cb(
+                frac: float,
+                desc: str = "",
+                *,
+                _base=base,
+                _span=span,
+                _bi=bi,
+                _batch=batch,
+            ) -> None:
+                try:
+                    f = max(0.0, min(1.0, float(frac)))
+                except (TypeError, ValueError):
+                    f = 0.0
+                msg = (
+                    f"Batch {_bi + 1}/{n_batches} "
+                    f"({len(_batch)} symbols): {desc or 'working…'}"
+                )
+                _progress(_base + _span * f, msg)
+
+            _progress(base, f"Batch {bi + 1}/{n_batches}: starting {batch_csv[:80]}…")
+            result = refresh_symbols(
+                batch_csv,
+                include_covariates=include_covariates,
+                dry_run=dry_run,
+                force_allow=False,
+                progress_cb=_batch_cb,
+                max_tickers=max(len(batch), DEFAULT_MAX_TICKERS),
+            )
+            batch_results.append(
+                {
+                    "batch_index": bi,
+                    "tickers": batch,
+                    "ok": bool(result.get("ok")),
+                    "error": result.get("error"),
+                    "ready": result.get("ready"),
+                    "incomplete": result.get("incomplete"),
+                    "forecast": (result.get("forecast") or {}).get("forecasted")
+                    if isinstance(result.get("forecast"), dict)
+                    else None,
+                }
+            )
+            if result.get("ok"):
+                batches_ok += 1
+            else:
+                batches_failed += 1
+                last_error = result.get("error") or last_error or "batch failed"
+            ready = _merge_symbol_lists(ready, result.get("ready"))
+            incomplete = _merge_symbol_lists(incomplete, result.get("incomplete"))
+            fc = result.get("forecast") if isinstance(result.get("forecast"), dict) else {}
+            forecasted = _merge_symbol_lists(forecasted, fc.get("forecasted"))
+            for m in result.get("messages") or []:
+                messages.append(str(m))
+            _progress((bi + 1) / n_batches, f"Finished batch {bi + 1}/{n_batches}.")
+
+        coverage = {
+            "requested_count": n,
+            "processed_count": n,
+            "batch_count": n_batches,
+            "batches_ok": batches_ok,
+            "batches_failed": batches_failed,
+            "ready_count": len(ready),
+            "incomplete_count": len(incomplete),
+            "forecasted_count": len(forecasted),
+            "full_list_complete": batches_failed == 0 and n > 0,
+        }
+        merged: dict[str, Any] = {
+            "ok": batches_failed == 0 and n > 0,
+            "ready": ready,
+            "incomplete": incomplete,
+            "forecasted": forecasted,
+            "messages": messages,
+            "coverage": coverage,
+            "batch_results": batch_results,
+            "dry_run": dry_run,
+        }
+        if last_error and batches_failed:
+            merged["error"] = last_error
 
         job = read_job(job_id) or {}
         job["job_id"] = job_id
-        if result.get("ok"):
+        job["requested_count"] = n
+        if merged["ok"]:
             job["status"] = STATUS_SUCCEEDED
             job["done"] = True
             job["progress_pct"] = 100.0
-            job["message"] = "Refresh complete."
+            job["message"] = (
+                f"Refresh complete for {n} symbol(s) "
+                f"({batches_ok}/{n_batches} batches ok)."
+            )
             job["error"] = None
-            job["result"] = result
+            job["result"] = merged
         else:
             job["status"] = STATUS_FAILED
             job["done"] = True
-            job["error"] = result.get("error") or "refresh failed"
-            job["message"] = job["error"]
-            job["result"] = result
-            # keep structured remote_api on result for clients
+            job["error"] = last_error or "refresh failed"
+            job["message"] = (
+                f"Refresh finished with errors: {batches_failed}/{n_batches} "
+                f"batch(es) failed; {len(ready)} ready, {len(forecasted)} forecasted."
+            )
+            job["result"] = merged
         _write_job(job)
         logger.info(
-            "MCP refresh job finished job_id={} status={}",
+            "MCP refresh job finished job_id={} status={} coverage={}",
             job_id,
             job.get("status"),
+            coverage,
         )
     except Exception as e:
         logger.exception("MCP refresh job crashed job_id={}: {}", job_id, e)

--- a/src/canswim/mcp/server.py
+++ b/src/canswim/mcp/server.py
@@ -52,7 +52,10 @@ def health_check() -> dict[str, Any]:
 
 @mcp.tool(
     name="get_server_info",
-    description="Server metadata: version, read-only flag, tool list, db path.",
+    description=(
+        "Server metadata: version (bump ⇒ re-discover tools), read-only flag, "
+        "tool list, db path, and refresh_guidance for portfolio async jobs."
+    ),
 )
 def get_server_info() -> dict[str, Any]:
     return meta.get_server_info_impl()
@@ -254,15 +257,12 @@ async def forecast_tickers(
 @mcp.tool(
     name="refresh_tickers",
     description=(
-        "All-in-one refresh for listed symbols: update market data, then catch-up "
-        "forecasts (monthly origins for ~12 months + live). Best default when a "
-        "user or agent says “gather and forecast” or “refresh these names”. "
-        "Same as dashboard “Refresh data & forecasts”. Streams live progress "
-        "(notifications/progress + info logs) when the client sends a "
-        "progressToken — same stages as the Run-tab progress bar. "
-        "Requires MCP_ALLOW_RUNS=1. May take many minutes for large lists — "
-        "prefer refresh_job_start + refresh_job_status if the client times out "
-        "on long tools. dry_run=true plans only."
+        "BLOCKING all-in-one refresh (market data + ~12 monthly catch-up forecasts "
+        "+ live). Max ~50 symbols; larger lists return an error (not silent truncate). "
+        "May take many minutes and times out on SuperGrok — for portfolios / "
+        "Schwab positions prefer refresh_job_start + refresh_job_status. "
+        "Only claim success for symbols in THIS call. Requires MCP_ALLOW_RUNS=1. "
+        "dry_run=true plans only. Streams progressToken notifications while open."
     ),
 )
 async def refresh_tickers(
@@ -284,13 +284,12 @@ async def refresh_tickers(
 @mcp.tool(
     name="refresh_job_start",
     description=(
-        "Start a background refresh job and return immediately with a job_id. "
-        "Same work as refresh_tickers (market data + ~12 monthly catch-up forecasts "
-        "+ live), but does not block the tool call for many minutes. "
-        "After start, call refresh_job_status with the job_id every "
-        "poll_after_seconds until status is succeeded or failed. "
-        "Only one refresh job may run at a time. Requires MCP_ALLOW_RUNS=1. "
-        "Preferred path for SuperGrok and other clients with short tool timeouts. "
+        "PREFERRED for portfolio refresh: start background gather+catch-up forecast "
+        "and return immediately with job_id. Accepts up to ~200 symbols (batched "
+        "internally). After start, poll refresh_job_status until succeeded/failed; "
+        "report coverage (requested_count, batches) — never claim full-account success "
+        "for symbols not in this job. Only one job at a time. Requires MCP_ALLOW_RUNS=1. "
+        "Use this instead of blocking refresh_tickers for Schwab/large lists. "
         "dry_run=true plans only."
     ),
 )

--- a/src/canswim/mcp/tools/jobs.py
+++ b/src/canswim/mcp/tools/jobs.py
@@ -32,6 +32,8 @@ def refresh_job_start_impl(
         data=out.get("data"),
         active_job_id=out.get("active_job_id"),
         runs_allowed=out.get("runs_allowed"),
+        client_hint=out.get("client_hint"),
+        recommended_tool=out.get("recommended_tool"),
     )
 
 

--- a/src/canswim/mcp/tools/meta.py
+++ b/src/canswim/mcp/tools/meta.py
@@ -63,6 +63,10 @@ def health_check_impl() -> dict[str, Any]:
 
 def get_server_info_impl() -> dict[str, Any]:
     allow_runs = runs_allowed()
+    # Import limits here so tool metadata stays in sync with jobs/run_triggers
+    from canswim.mcp.jobs import JOB_MAX_TICKERS
+    from canswim.run_triggers import DEFAULT_MAX_TICKERS
+
     return ok_result(
         {
             "name": "canswim-mcp",
@@ -78,6 +82,23 @@ def get_server_info_impl() -> dict[str, Any]:
                 "Prefer refresh_job_start + refresh_job_status for long refreshes "
                 "(clients that time out on multi-minute tools)."
             ),
+            "refresh_guidance": {
+                "preferred_tools": ["refresh_job_start", "refresh_job_status"],
+                "blocking_tool": "refresh_tickers",
+                "blocking_max_tickers": DEFAULT_MAX_TICKERS,
+                "async_job_max_tickers": JOB_MAX_TICKERS,
+                "workflow": (
+                    "1) refresh_job_start with the full symbol list (≤ async max). "
+                    "2) poll refresh_job_status every poll_after_seconds until done. "
+                    "3) report coverage from result (requested_count / batches). "
+                    "Never claim portfolio-wide success after a timeout, truncated list, "
+                    "or a subset dry_run. If more symbols remain, start another job."
+                ),
+                "client_hint": (
+                    "Do not use blocking refresh_tickers for large Schwab portfolios. "
+                    "Use async jobs and only claim success for symbols in that job."
+                ),
+            },
             "db_path": get_db_path(),
             "tools": TOOL_NAMES,
             "read_tools": READ_TOOL_NAMES,

--- a/src/canswim/mcp/tools/runs.py
+++ b/src/canswim/mcp/tools/runs.py
@@ -125,9 +125,14 @@ def refresh_tickers_impl(
     if blocked is not None:
         return err_result(blocked["error"], runs_allowed=False)
 
-    parsed = parse_ticker_list(tickers)
+    parsed = parse_ticker_list(tickers, overflow="error")
     if not parsed["ok"]:
-        return err_result(parsed.get("error") or "bad tickers", data=parsed)
+        return err_result(
+            parsed.get("error") or "bad tickers",
+            data=parsed,
+            client_hint=parsed.get("client_hint"),
+            recommended_tool=parsed.get("recommended_tool") or "refresh_job_start",
+        )
 
     result = refresh_symbols(
         tickers,
@@ -137,6 +142,17 @@ def refresh_tickers_impl(
         progress_cb=progress_cb,
     )
     if result.get("ok"):
+        n = len(parsed.get("tickers") or [])
+        result = dict(result)
+        result.setdefault(
+            "client_hint",
+            (
+                f"Blocking refresh finished for {n} symbol(s) only "
+                f"(this call). Do not claim a larger portfolio is refreshed. "
+                "For full portfolios use refresh_job_start + refresh_job_status."
+            ),
+        )
+        result.setdefault("requested_count", n)
         return ok_result(result)
     # Propagate gather remote_api if present under nested gather
     remote = result.get("remote_api") or (result.get("gather") or {}).get(
@@ -148,6 +164,10 @@ def refresh_tickers_impl(
         remote_api=remote,
         fail_reason=result.get("fail_reason")
         or (result.get("gather") or {}).get("fail_reason"),
+        client_hint=(
+            "Refresh failed. Do not claim success. "
+            "Prefer refresh_job_start for long runs; poll refresh_job_status."
+        ),
     )
 
 

--- a/src/canswim/run_triggers.py
+++ b/src/canswim/run_triggers.py
@@ -271,14 +271,24 @@ def parse_ticker_list(
     text: Union[str, Sequence[str], None],
     *,
     max_tickers: int = DEFAULT_MAX_TICKERS,
+    overflow: str = "error",
 ) -> dict[str, Any]:
     """Parse comma- and/or newline-separated ticker text.
+
+    Parameters
+    ----------
+    overflow:
+      ``"error"`` (default) — if more than ``max_tickers`` unique symbols,
+      return ``ok=False`` with the full counts (do **not** silently drop).
+      ``"truncate"`` — keep the first ``max_tickers`` and set ``truncated=True``
+      (legacy CLI; prefer ``error`` for MCP so clients cannot over-claim coverage).
 
     Returns
     -------
     dict with keys:
       ok, tickers (accepted unique upper), rejected (list of {token, reason}),
-      truncated (bool), messages (list[str])
+      truncated (bool), messages (list[str]); on overflow error also
+      requested_count, max_tickers, omitted_tickers, client_hint
     """
     if text is None:
         return {
@@ -313,11 +323,6 @@ def parse_ticker_list(
         seen.add(t)
         accepted.append(t)
 
-    truncated = False
-    if len(accepted) > max_tickers:
-        truncated = True
-        accepted = accepted[:max_tickers]
-
     messages: list[str] = []
     if not accepted:
         messages.append("No valid tickers after parsing.")
@@ -325,14 +330,52 @@ def parse_ticker_list(
             "ok": False,
             "tickers": [],
             "rejected": rejected,
-            "truncated": truncated,
+            "truncated": False,
             "messages": messages,
             "error": "No valid tickers after parsing.",
         }
+
+    truncated = False
+    omitted: list[str] = []
+    mode = (overflow or "error").strip().lower()
+    if len(accepted) > max_tickers:
+        truncated = True
+        omitted = accepted[max_tickers:]
+        if mode == "truncate":
+            accepted = accepted[:max_tickers]
+            messages.append(f"Truncated to first {max_tickers} tickers.")
+        else:
+            sample = ", ".join(omitted[:8])
+            more = f" (+{len(omitted) - 8} more)" if len(omitted) > 8 else ""
+            err = (
+                f"Got {len(accepted)} tickers; max is {max_tickers} per call. "
+                f"Do not claim a full-list refresh. Prefer refresh_job_start "
+                f"(up to job max) or split into batches of ≤{max_tickers}. "
+                f"Omitted examples: {sample}{more}."
+            )
+            if rejected:
+                messages.append(f"{len(rejected)} token(s) rejected.")
+            return {
+                "ok": False,
+                "tickers": accepted[:max_tickers],
+                "omitted_tickers": omitted,
+                "rejected": rejected,
+                "truncated": True,
+                "requested_count": len(accepted),
+                "max_tickers": max_tickers,
+                "messages": messages + [err],
+                "error": err,
+                "client_hint": (
+                    "Too many symbols for one call. Start refresh_job_start with "
+                    f"≤{max_tickers} symbols per job (or the higher async job limit), "
+                    "poll refresh_job_status until done, then start the next batch. "
+                    "Never report portfolio-wide success after a truncated or failed call."
+                ),
+                "recommended_tool": "refresh_job_start",
+            }
+
     if rejected:
         messages.append(f"{len(rejected)} token(s) rejected.")
-    if truncated:
-        messages.append(f"Truncated to first {max_tickers} tickers.")
 
     return {
         "ok": True,
@@ -340,6 +383,8 @@ def parse_ticker_list(
         "rejected": rejected,
         "truncated": truncated,
         "messages": messages,
+        "requested_count": len(accepted) + len(omitted),
+        "max_tickers": max_tickers,
     }
 
 

--- a/src/canswim/version.py
+++ b/src/canswim/version.py
@@ -1,0 +1,51 @@
+"""Single package version for CLI, GUI, and MCP discovery.
+
+Prefer ``setup.cfg`` in the git checkout (PYTHONPATH / editable deploys) so a
+host that runs ``python -m canswim`` from a repo tree reports the **source**
+version, not a stale wheel. Fall back to ``importlib.metadata``.
+
+**Rule:** any MCP tool add/rename/remove or behavioral change that clients
+should rediscover must bump ``version`` in ``setup.cfg`` (and CHANGELOG).
+"""
+
+from __future__ import annotations
+
+import configparser
+from importlib import metadata
+from pathlib import Path
+
+
+def _version_from_setup_cfg() -> str | None:
+    # src/canswim/version.py → parents[2] == repo root when layout is repo/src/canswim
+    here = Path(__file__).resolve()
+    candidates = [
+        here.parents[2] / "setup.cfg",  # repo/setup.cfg
+        here.parents[1] / "setup.cfg",
+        Path.cwd() / "setup.cfg",
+    ]
+    for cfg_path in candidates:
+        if not cfg_path.is_file():
+            continue
+        try:
+            parser = configparser.ConfigParser()
+            parser.read(cfg_path, encoding="utf-8")
+            ver = parser.get("metadata", "version", fallback="").strip()
+            if ver:
+                return ver
+        except (OSError, configparser.Error):
+            continue
+    return None
+
+
+def _version_from_metadata() -> str | None:
+    try:
+        return metadata.version("canswim")
+    except Exception:
+        return None
+
+
+def get_version() -> str:
+    return _version_from_setup_cfg() or _version_from_metadata() or "0.0.0"
+
+
+__version__ = get_version()

--- a/tests/canswim/test_docs_sync.py
+++ b/tests/canswim/test_docs_sync.py
@@ -45,6 +45,16 @@ def test_mcp_tool_names_documented():
     assert not missing, f"docs/mcp.md missing tools: {missing}"
 
 
+def test_setup_cfg_version_in_changelog():
+    """Current setup.cfg version must have a CHANGELOG section (MCP rediscovery)."""
+    cfg = _read("setup.cfg")
+    m = re.search(r"(?m)^version\s*=\s*(\S+)", cfg)
+    assert m, "setup.cfg missing version"
+    ver = m.group(1)
+    cl = _read("CHANGELOG.md")
+    assert f"## {ver}" in cl, f"CHANGELOG.md missing section for {ver}"
+
+
 def test_cli_tasks_mentioned_in_cli_doc():
     main_src = _read("src/canswim/__main__.py")
     # choices list in argparse

--- a/tests/canswim/test_mcp_jobs.py
+++ b/tests/canswim/test_mcp_jobs.py
@@ -217,3 +217,63 @@ def test_server_registers_job_tools():
         names = set(tool_manager._tools.keys())
         assert "refresh_job_start" in names
         assert "refresh_job_status" in names
+
+
+def test_job_rejects_over_job_max(jobs_env):
+    from canswim.mcp.jobs import JOB_MAX_TICKERS
+
+    syms = [f"B{i:03d}" for i in range(JOB_MAX_TICKERS + 5)]
+    out = job_tools.refresh_job_start_impl(",".join(syms))
+    assert out["ok"] is False
+    assert str(JOB_MAX_TICKERS) in out["error"]
+    assert out.get("client_hint") or (out.get("data") or {}).get("client_hint")
+
+
+def test_job_batches_large_list(jobs_env):
+    """Worker should call refresh_symbols per batch and report coverage."""
+    calls: list[str] = []
+
+    def fake_refresh(tickers, **kwargs):
+        calls.append(tickers)
+        ts = [t for t in tickers.replace(" ", ",").split(",") if t]
+        return {
+            "ok": True,
+            "ready": ts,
+            "incomplete": [],
+            "forecast": {"ok": True, "forecasted": ts},
+            "messages": [],
+        }
+
+    # 45 symbols → 3 batches of 20
+    syms = [f"C{i:03d}" for i in range(45)]
+    with patch("canswim.mcp.jobs.refresh_symbols", side_effect=fake_refresh):
+        start = job_tools.refresh_job_start_impl(",".join(syms))
+        assert start["ok"] is True
+        jid = start["data"]["job_id"]
+        assert start["data"]["requested_count"] == 45
+        deadline = time.time() + 8.0
+        status = None
+        while time.time() < deadline:
+            status = job_tools.refresh_job_status_impl(jid)
+            if status["data"]["done"]:
+                break
+            time.sleep(0.05)
+
+    assert status["data"]["status"] == "succeeded"
+    assert status["data"]["coverage"]["requested_count"] == 45
+    assert status["data"]["coverage"]["full_list_complete"] is True
+    assert len(calls) == 3  # 20+20+5
+    assert "only claim success" in status["data"]["client_hint"].lower() or (
+        "ticker_list" in status["data"]["client_hint"].lower()
+    )
+
+
+def test_get_server_info_refresh_guidance(jobs_env, monkeypatch):
+    monkeypatch.setenv("MCP_ALLOW_RUNS", "1")
+    from canswim.mcp.tools import meta
+
+    info = meta.get_server_info_impl()
+    assert info["ok"] is True
+    g = info["data"]["refresh_guidance"]
+    assert g["preferred_tools"][0] == "refresh_job_start"
+    assert g["async_job_max_tickers"] >= g["blocking_max_tickers"]

--- a/tests/canswim/test_run_triggers.py
+++ b/tests/canswim/test_run_triggers.py
@@ -44,13 +44,22 @@ def test_parse_invalid_and_duplicate():
     assert "duplicate" in reasons
 
 
-def test_parse_max_truncation():
-    text = ",".join(f"T{i:03d}" for i in range(60))
-    # T000 style may fail ticker regex (digit after letter ok) — use AAA, AAB...
-    syms = []
-    for i in range(60):
-        syms.append(f"A{i:03d}")  # A000 invalid? letter then digits ok up to 10
+def test_parse_max_overflow_errors_by_default():
+    """MCP-safe: over max must not silently truncate with ok=True."""
+    syms = [f"A{i:03d}" for i in range(60)]
     r = parse_ticker_list(",".join(syms), max_tickers=10)
+    assert r["ok"] is False
+    assert r["truncated"] is True
+    assert r["requested_count"] == 60
+    assert r["max_tickers"] == 10
+    assert len(r["omitted_tickers"]) == 50
+    assert "refresh_job_start" in (r.get("recommended_tool") or "")
+    assert r.get("client_hint")
+
+
+def test_parse_max_truncation_legacy_mode():
+    syms = [f"A{i:03d}" for i in range(60)]
+    r = parse_ticker_list(",".join(syms), max_tickers=10, overflow="truncate")
     assert r["ok"] is True
     assert len(r["tickers"]) == 10
     assert r["truncated"] is True

--- a/tests/canswim/test_version.py
+++ b/tests/canswim/test_version.py
@@ -1,0 +1,41 @@
+"""Package / MCP version discovery (clients refresh on version change)."""
+
+from __future__ import annotations
+
+import configparser
+from pathlib import Path
+
+from canswim.version import __version__, get_version
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _setup_cfg_version() -> str:
+    parser = configparser.ConfigParser()
+    parser.read(ROOT / "setup.cfg", encoding="utf-8")
+    return parser.get("metadata", "version").strip()
+
+
+def test_version_matches_setup_cfg():
+    assert get_version() == _setup_cfg_version()
+    assert __version__ == _setup_cfg_version()
+
+
+def test_mcp_exports_same_version():
+    from canswim.mcp import __version__ as mcp_ver
+    from canswim.mcp.tools import meta
+
+    assert mcp_ver == _setup_cfg_version()
+    info = meta.get_server_info_impl()
+    assert info["ok"] is True
+    assert info["data"]["version"] == _setup_cfg_version()
+
+
+def test_docs_require_version_bump_on_mcp_change():
+    agents = (ROOT / "AGENTS.md").read_text(encoding="utf-8")
+    assert "setup.cfg" in agents
+    assert "MCP version" in agents or "bump" in agents.lower()
+    mcp_doc = (ROOT / "docs" / "mcp.md").read_text(encoding="utf-8")
+    assert "get_server_info" in mcp_doc
+    assert "version" in mcp_doc.lower()


### PR DESCRIPTION
## Summary

Missed version bump when async refresh jobs landed. Clients cache tool discovery against server version.

- Bump `setup.cfg` → **0.0.20260715**
- `canswim.version` reads checkout `setup.cfg` first (host PYTHONPATH deploy)
- AGENTS.md + docs/mcp.md: **always bump version on MCP surface changes**
- Tests: version matches setup.cfg; CHANGELOG has current section

## Test plan

- [x] `./scripts/ci-local.sh` (233 passed)
- [ ] Restart `canswim-mcp`; `get_server_info` shows `0.0.20260715`