### PR TITLE
fix(mcp): refresh_tickers defaults to async job (0.0.20260716)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable releases are documented here. Versioning follows date-style `0.0.YYYYMMDD` unless noted.
 
+## 0.0.20260716
+
+SuperGrok still called blocking `refresh_tickers` and disconnected mid-run. **Default path is now async.**
+
+### Highlights
+
+- **`refresh_tickers` defaults to background job** (`wait=false`) — returns `job_id` immediately; poll `refresh_job_status`
+- **`wait=true`** keeps the old blocking path (opt-in only)
+- Stronger `client_hint` / `refresh_guidance` so start response is never treated as completion
+
+### Install
+
+```bash
+pip install canswim==0.0.20260716
+```
+
 ## 0.0.20260715
 
 MCP surface bump so clients rediscover tools after async refresh jobs + portfolio-safe limits.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Flags: `python -m canswim -h` is the source of truth. Local site preview: `pip i
 
 ```bash
 pip install canswim
-# pin a release: pip install canswim==0.0.20260715
+# pin a release: pip install canswim==0.0.20260716
 
 # dev checkout
 pip install -e ".[dev]"

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -100,21 +100,23 @@ Canonical registration: `src/canswim/mcp/server.py`. Update this table in the **
 | `resolve_forecast_start` | Preview week-aligned start (≡ CLI `resolve_start`) | — |
 | `gather_tickers` | Scoped gather (≡ `gatherdata --tickers`) | `MCP_ALLOW_RUNS=1` |
 | `forecast_tickers` | Scoped forecast; blank start = monthly catch-up + live | `MCP_ALLOW_RUNS=1` |
-| `refresh_tickers` | Gather + catch-up forecast (blocking; ≡ dashboard **Refresh data & forecasts**) | `MCP_ALLOW_RUNS=1` |
-| `refresh_job_start` | **Async** refresh: same pipeline as `refresh_tickers`, returns `job_id` immediately | `MCP_ALLOW_RUNS=1` |
-| `refresh_job_status` | Poll a job from `refresh_job_start` (`progress_pct`, `message`, `result`) | — |
+| `refresh_tickers` | Gather + catch-up forecast — **async by default** (returns `job_id`; ≡ dashboard refresh). `wait=true` = old blocking path | `MCP_ALLOW_RUNS=1` |
+| `refresh_job_start` | Explicit async start (same as `refresh_tickers` with `wait=false`) | `MCP_ALLOW_RUNS=1` |
+| `refresh_job_status` | Poll a job from `refresh_tickers` / `refresh_job_start` | — |
 
-### Async refresh (preferred for SuperGrok / short tool timeouts)
+### Async refresh (default — SuperGrok / short tool timeouts)
 
-Long refreshes can run for many minutes. **Portfolio / Schwab “refresh all positions”** must use the job pair — not blocking `refresh_tickers`:
+Long refreshes take many minutes. **`refresh_tickers` starts a background job and returns immediately** (do not treat the start response as completion):
 
 1. Call **`get_server_info`** once (note `version` + `refresh_guidance`).
-2. **`refresh_job_start`** with the full symbol list (≤ **~200** async max; blocking tool max is **~50**). Oversized lists **error** (no silent truncate).
+2. **`refresh_tickers`** with the symbol list (≤ **~200** async max). Response includes `job_id`, `poll_after_seconds`, `client_hint`. Oversized lists **error** (no silent truncate).
 3. Sleep about `poll_after_seconds` (typically 5–15s).
 4. **`refresh_job_status`** until `status` is `succeeded` or `failed` (`done=true`).
-5. Report **`coverage`** (`requested_count`, `batches_ok` / `batches_failed`). **Only claim success for symbols in that job’s `ticker_list`.** If the account has more names, start another job for the remainder.
+5. Report **`coverage`**. **Only claim success for symbols in that job’s `ticker_list`.**
 
-Workers process symbols in internal batches (~20) with progress on the job file. Job state is under `{data_dir}/mcp_jobs/` so status survives **client** disconnects. Only **one** refresh job runs at a time. If MCP restarts mid-job, status becomes failed — start again.
+Optional: `wait=true` on `refresh_tickers` forces the old blocking path (max ~50; SuperGrok will disconnect — avoid).
+
+Workers batch symbols (~20). Job state is under `{data_dir}/mcp_jobs/`. Only **one** refresh job at a time.
 
 **Do not** claim portfolio-wide success after a tool timeout, a `dry_run`, a subset list, or while status is still `queued`/`running`.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = canswim
-version = 0.0.20260715
+version = 0.0.20260716
 author = Ivelin Ivanov
 author_email = ivelin117@gmail.com
 description = Developer toolkit for CANSLIM-style investors (CLI, Gradio GUI, MCP)

--- a/src/canswim/mcp/server.py
+++ b/src/canswim/mcp/server.py
@@ -257,20 +257,47 @@ async def forecast_tickers(
 @mcp.tool(
     name="refresh_tickers",
     description=(
-        "BLOCKING all-in-one refresh (market data + ~12 monthly catch-up forecasts "
-        "+ live). Max ~50 symbols; larger lists return an error (not silent truncate). "
-        "May take many minutes and times out on SuperGrok — for portfolios / "
-        "Schwab positions prefer refresh_job_start + refresh_job_status. "
-        "Only claim success for symbols in THIS call. Requires MCP_ALLOW_RUNS=1. "
-        "dry_run=true plans only. Streams progressToken notifications while open."
+        "Refresh market data + catch-up forecasts for listed symbols. "
+        "DEFAULT (wait=false): starts a BACKGROUND job and returns immediately with "
+        "job_id — then call refresh_job_status until done. This is required for "
+        "SuperGrok / Schwab portfolios (blocking calls disconnect mid-run). "
+        "Accepts up to ~200 symbols when async. "
+        "wait=true: old blocking path (max ~50; may take many minutes; times out). "
+        "Only claim success for symbols in the job’s ticker_list after status=succeeded. "
+        "Requires MCP_ALLOW_RUNS=1. dry_run=true plans only."
     ),
 )
 async def refresh_tickers(
     tickers: str,
     include_covariates: bool = True,
     dry_run: bool = False,
+    wait: bool = False,
     ctx: Context | None = None,
 ) -> dict[str, Any]:
+    # Default async: SuperGrok always called blocking refresh_tickers and disconnected
+    # before the final result (ClosedResourceError). Job path returns in milliseconds.
+    if not wait:
+        out = job_tools.refresh_job_start_impl(
+            tickers=tickers,
+            include_covariates=include_covariates,
+            dry_run=dry_run,
+        )
+        if out.get("ok") and isinstance(out.get("data"), dict):
+            data = dict(out["data"])
+            data["via"] = "refresh_tickers→async_job"
+            data["next_tool"] = data.get("next_tool") or "refresh_job_status"
+            hint = data.get("client_hint") or ""
+            data["client_hint"] = (
+                "refresh_tickers started a BACKGROUND job (not finished yet). "
+                f"Call refresh_job_status with job_id={data.get('job_id')} after "
+                f"~{data.get('poll_after_seconds', 15)}s. "
+                "Do NOT claim the portfolio is refreshed until status is succeeded "
+                "or failed. "
+                + (hint if hint else "")
+            )
+            out = {**out, "data": data}
+        return out
+
     progress_cb = bind_mcp_progress(ctx, tool="refresh_tickers")
     return await asyncio.to_thread(
         run_tools.refresh_tickers_impl,
@@ -284,13 +311,10 @@ async def refresh_tickers(
 @mcp.tool(
     name="refresh_job_start",
     description=(
-        "PREFERRED for portfolio refresh: start background gather+catch-up forecast "
-        "and return immediately with job_id. Accepts up to ~200 symbols (batched "
-        "internally). After start, poll refresh_job_status until succeeded/failed; "
-        "report coverage (requested_count, batches) — never claim full-account success "
-        "for symbols not in this job. Only one job at a time. Requires MCP_ALLOW_RUNS=1. "
-        "Use this instead of blocking refresh_tickers for Schwab/large lists. "
-        "dry_run=true plans only."
+        "Start background gather+catch-up forecast; return job_id immediately "
+        "(same as refresh_tickers with wait=false). Up to ~200 symbols, batched. "
+        "Poll refresh_job_status until done. Only one job at a time. "
+        "Requires MCP_ALLOW_RUNS=1. dry_run=true plans only."
     ),
 )
 def refresh_job_start(
@@ -308,9 +332,9 @@ def refresh_job_start(
 @mcp.tool(
     name="refresh_job_status",
     description=(
-        "Poll status of a job started by refresh_job_start. "
+        "Poll status of a job started by refresh_tickers (default) or refresh_job_start. "
         "Returns status (queued|running|succeeded|failed), progress_pct, message, "
-        "poll_after_seconds, client_hint, and result when done. "
+        "poll_after_seconds, client_hint, coverage, and result when done. "
         "Always available (no MCP_ALLOW_RUNS gate). "
         "Do not claim the refresh finished until status is succeeded or failed."
     ),

--- a/src/canswim/mcp/tools/meta.py
+++ b/src/canswim/mcp/tools/meta.py
@@ -83,20 +83,27 @@ def get_server_info_impl() -> dict[str, Any]:
                 "(clients that time out on multi-minute tools)."
             ),
             "refresh_guidance": {
-                "preferred_tools": ["refresh_job_start", "refresh_job_status"],
-                "blocking_tool": "refresh_tickers",
+                "preferred_tools": [
+                    "refresh_tickers",
+                    "refresh_job_status",
+                ],
+                "alias_start": "refresh_job_start",
+                "status_tool": "refresh_job_status",
+                "default_refresh_tickers": "async_job (wait=false)",
+                "blocking_opt_in": "refresh_tickers wait=true (max ~50; may timeout)",
                 "blocking_max_tickers": DEFAULT_MAX_TICKERS,
                 "async_job_max_tickers": JOB_MAX_TICKERS,
                 "workflow": (
-                    "1) refresh_job_start with the full symbol list (≤ async max). "
+                    "1) refresh_tickers with the full symbol list (≤ async max) — "
+                    "returns job_id immediately (does NOT wait for forecasts). "
                     "2) poll refresh_job_status every poll_after_seconds until done. "
-                    "3) report coverage from result (requested_count / batches). "
-                    "Never claim portfolio-wide success after a timeout, truncated list, "
-                    "or a subset dry_run. If more symbols remain, start another job."
+                    "3) report coverage (requested_count / batches). "
+                    "Never claim portfolio-wide success after a timeout, while "
+                    "status is queued/running, or for symbols not in ticker_list."
                 ),
                 "client_hint": (
-                    "Do not use blocking refresh_tickers for large Schwab portfolios. "
-                    "Use async jobs and only claim success for symbols in that job."
+                    "refresh_tickers is async by default. Always poll "
+                    "refresh_job_status. Never claim success from the start response alone."
                 ),
             },
             "db_path": get_db_path(),

--- a/tests/canswim/test_mcp_jobs.py
+++ b/tests/canswim/test_mcp_jobs.py
@@ -275,5 +275,39 @@ def test_get_server_info_refresh_guidance(jobs_env, monkeypatch):
     info = meta.get_server_info_impl()
     assert info["ok"] is True
     g = info["data"]["refresh_guidance"]
-    assert g["preferred_tools"][0] == "refresh_job_start"
+    assert "refresh_tickers" in g["preferred_tools"]
+    assert g["status_tool"] == "refresh_job_status"
     assert g["async_job_max_tickers"] >= g["blocking_max_tickers"]
+
+
+def test_refresh_tickers_tool_defaults_to_async_job(jobs_env, monkeypatch):
+    """Server refresh_tickers(wait=false) must start a job, not block."""
+    monkeypatch.setenv("MCP_ALLOW_RUNS", "1")
+    import asyncio
+    from unittest.mock import patch
+
+    from canswim.mcp import server as srv
+
+    with patch(
+        "canswim.mcp.jobs.refresh_symbols",
+        return_value={
+            "ok": True,
+            "ready": ["AAA"],
+            "incomplete": [],
+            "forecast": {"ok": True, "forecasted": ["AAA"]},
+        },
+    ):
+        out = asyncio.run(srv.refresh_tickers(tickers="AAA", wait=False))
+    assert out["ok"] is True
+    assert out["data"]["job_id"]
+    assert out["data"]["via"] == "refresh_tickers→async_job"
+    assert out["data"]["next_tool"] == "refresh_job_status"
+    assert "BACKGROUND" in out["data"]["client_hint"]
+    # Wait for worker so we don't leave a dangling thread mid-assert noise
+    jid = out["data"]["job_id"]
+    deadline = time.time() + 5.0
+    while time.time() < deadline:
+        st = job_tools.refresh_job_status_impl(jid)
+        if st["data"]["done"]:
+            break
+        time.sleep(0.05)


### PR DESCRIPTION
## Summary

Host logs after 0.0.20260715: SuperGrok still called **blocking** `refresh_tickers`, session DELETE ~1 min in, progress `ClosedResourceError`, then overclaimed success. Share text still describes the old path.

**Fix:** `refresh_tickers` **defaults to async job start** (`wait=false`) — returns `job_id` + hard `client_hint` immediately. Poll `refresh_job_status`. Opt-in `wait=true` for blocking.

Version **0.0.20260716** for rediscovery.

## Test plan

- [x] local CI / unit tests
- [ ] merge + restart MCP
- [ ] SuperGrok: `refresh_tickers` returns `job_id` in <1s; poll status