### PR TITLE
fix: 3y lookback + honest short_history errors (0.0.20260717)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable releases are documented here. Versioning follows date-style `0.0.YYYYMMDD` unless noted.
 
+## 0.0.20260717
+
+Catch-up forecasts were failing with a misleading “covariate misalignment” error.
+
+### Highlights
+
+- **Root cause:** scoped gather kept only ~**2 years** of prices; monthly catch-up origins need **≥336** pre-start bars, so origins like 2025-07/09/11 only had ~261–330 bars
+- **Fix:** forecast-scoped lookback **~3 years** (`FORECAST_LOOKBACK_YEARS=3`); refresh re-downloads longer history when local window starts too late
+- **Honest errors:** short pre-start history reports `fail_reason=short_history` (not covariates)
+
+### Install
+
+```bash
+pip install canswim==0.0.20260717
+```
+
 ## 0.0.20260716
 
 SuperGrok still called blocking `refresh_tickers` and disconnected mid-run. **Default path is now async.**

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Flags: `python -m canswim -h` is the source of truth. Local site preview: `pip i
 
 ```bash
 pip install canswim
-# pin a release: pip install canswim==0.0.20260716
+# pin a release: pip install canswim==0.0.20260717
 
 # dev checkout
 pip install -e ".[dev]"
@@ -78,7 +78,7 @@ Two separate steps, same backend (`canswim.run_triggers`). Details: **[docs/run_
 
 \*MCP write tools need `MCP_ALLOW_RUNS=1`. Full MCP guide: **[docs/mcp.md](docs/mcp.md)**.
 
-Scoped get-market-data uses **~2 years** of history, **fundamentals** (unless `--no_covariates`), and **skips downloads** when local files are already complete. Forecasts **stop** if data is incomplete (no invented prices).
+Scoped get-market-data uses **~3 years** of history (lookback + catch-up), **fundamentals** (unless `--no_covariates`), and **skips downloads** when local files are already complete. Forecasts **stop** if data is incomplete (no invented prices).
 
 ```bash
 python -m canswim gatherdata --tickers "AAPL, MSFT"

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -44,7 +44,7 @@ python -m canswim -h
 Same backend as the dashboard **Run** tab and MCP write tools. Policy detail: [run_triggers.md](run_triggers.md). Storage: [data_store.md](data_store.md).
 
 ```bash
-# 1) Get market data (~2y, missing-only; includes fundamentals unless --no_covariates)
+# 1) Get market data (~3y, missing-only; includes fundamentals unless --no_covariates)
 hfhub_sync=False python -m canswim gatherdata --tickers "AAPL, MSFT"
 
 # 2) Check start date (optional)

--- a/docs/run_triggers.md
+++ b/docs/run_triggers.md
@@ -23,7 +23,7 @@ Without `--tickers`, CLI `gatherdata` / `forecast` keep **full-universe / train-
 
 For scoped runs (`--tickers` / dashboard / MCP):
 
-- Target about the **last 2 years** of prices (enough to forecast)—not multi-decade history.
+- Target about the **last 3 years** of prices (model lookback + ~12 monthly catch-up origins)—not multi-decade history.
 - **Skip remote download** when local history is already complete and recent.
 - If history is short or gappy, download only the **missing window**.
 - If history is complete but stale, download only a **short tail** refresh.
@@ -68,7 +68,7 @@ After a successful gather, symbols are **synced into the DuckDB search DB** so C
 
 All-in-one for a short list (portfolio / new names). GUI label: **Refresh data & forecasts**.
 
-1. **Market data** — prices + fundamentals (missing-only, ~2y).  
+1. **Market data** — prices + fundamentals (missing-only, ~3y).  
 2. **Catch-up forecasts** — ~12 monthly origins + live for symbols that are ready.  
 3. **Charts list + DuckDB** — symbols appear in Charts; forecasts and backtest errors sync for Scans.
 
@@ -109,7 +109,7 @@ Operator detail only—primary UI uses plain language.
 ## Examples
 
 ```bash
-# Update market data for two symbols (missing-only, ~2y + fundamentals)
+# Update market data for two symbols (missing-only, ~3y + fundamentals)
 hfhub_sync=False python -m canswim gatherdata --tickers "AAPL, MSFT"
 
 # See start date
@@ -160,7 +160,7 @@ Same rules on both paths unless noted.
 
 | Requirement | Covered stocks (A) | IPOs / thin (B) | ETFs / funds (C) |
 |-------------|--------------------|-----------------|------------------|
-| **OHLCV history** | Full train window or ~2y scoped | Must eventually reach ~**2 years of sessions** for forecast-scoped readiness | Same price floor as stocks (~2y scoped) |
+| **OHLCV history** | Full train window or ~3y scoped | Must eventually reach ~**3 years of sessions** for forecast-scoped readiness | Same price floor as stocks (~3y scoped) |
 | **Own OHLC+volume as past covs** | Real | Real when listed | Real (ETF prints) |
 | **Earnings / key metrics / ownership** | Real when present | **Zero-fill** missing (#33) | **Zero-fill** missing (same mechanism; expected permanent) |
 | **Analyst estimates (future)** | Real when present | **Zero-fill** missing | **Zero-fill** missing |
@@ -197,7 +197,7 @@ extends the same idea).
 | You want to… | Expectation |
 |--------------|-------------|
 | Refresh **LLY / AAPL** | Market data + real fundamentals when APIs have them; catch-up forecasts as usual |
-| Refresh a **new IPO** | May **stop** until ~2y of sessions; fundamentals imputed once prices are ready |
+| Refresh a **new IPO** | May **stop** until enough sessions (~3y floor for catch-up); fundamentals imputed once prices are ready |
 | Refresh **XLF** or a sector ETF | Prices + market funds load; **no corporate fund rows** — imputed automatically; forecast should not fail on dimensionality alone |
 | Mix ETF + stocks in one list | Peers can supply templates; still fine if only ETFs (empty-batch path) |
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = canswim
-version = 0.0.20260716
+version = 0.0.20260717
 author = Ivelin Ivanov
 author_email = ivelin117@gmail.com
 description = Developer toolkit for CANSLIM-style investors (CLI, Gradio GUI, MCP)

--- a/src/canswim/dashboard/run_tab.py
+++ b/src/canswim/dashboard/run_tab.py
@@ -156,7 +156,7 @@ def _gather_summary(result: dict) -> str:
             lines.append("")
             lines.append("**What this means**")
             lines.append(
-                "Forecasts need about **two years** of trading sessions. "
+                "Forecasts need about **three years** of trading sessions. "
                 "Recent IPOs and new listings usually cannot be forecasted yet—"
                 "even if some prices were saved."
             )
@@ -222,7 +222,7 @@ def _gather_summary(result: dict) -> str:
         lines.append(
             f"**Not ready for forecasts yet ({len(incomplete)}):** "
             f"{_fmt_syms(incomplete)}  \n"
-            f"_Why: {why}. Prices may still be on file; forecasts need ~2 years of sessions._"
+            f"_Why: {why}. Prices may still be on file; forecasts need ~3 years of sessions._"
         )
 
     # Download activity as counts (avoid repeating every ticker twice)

--- a/src/canswim/forecast.py
+++ b/src/canswim/forecast.py
@@ -216,6 +216,8 @@ class CanswimForecaster:
         past_cov_list = []
         future_cov_list = []
         tickers_list = self.canswim_model.targets_ticker_list
+        # Structured skips for MCP/GUI (do not mislabel short history as covariates)
+        self.last_skip_details: list[dict] = []
         # trim end of targets (and past covs) for historical / as-of forecast starts
         if forecast_start_date is not None:
             fsd = pd.Timestamp(forecast_start_date).tz_localize(None).normalize()
@@ -261,10 +263,20 @@ class CanswimForecaster:
                             )
 
                     n_hist = len(target_sliced)
-                    if n_hist < self.canswim_model.min_samples:
+                    need = self.canswim_model.min_samples
+                    if n_hist < need:
+                        detail = {
+                            "symbol": tickers_list[i],
+                            "reason": "short_history",
+                            "n_hist": int(n_hist),
+                            "need": int(need),
+                            "asof": str(fsd.date()),
+                            "hist_end": str(target_sliced.end_time().date()),
+                        }
+                        self.last_skip_details.append(detail)
                         logger.info(
                             f"Skipping {tickers_list[i]}: only {n_hist} pre-start samples "
-                            f"(need >= {self.canswim_model.min_samples}); "
+                            f"(need >= {need}); "
                             f"as-of {fsd.date()}, hist ends {target_sliced.end_time().date()}."
                         )
                         continue
@@ -279,6 +291,18 @@ class CanswimForecaster:
                         f"n={n_hist}, forecast_start={fsd.date()}"
                     )
                 except (ValueError, KeyError, AssertionError) as e:
+                    self.last_skip_details.append(
+                        {
+                            "symbol": tickers_list[i],
+                            "reason": "align_error",
+                            "error": f"{type(e).__name__}: {e}",
+                            "asof": str(
+                                pd.Timestamp(forecast_start_date).date()
+                                if forecast_start_date is not None
+                                else ""
+                            ),
+                        }
+                    )
                     logger.warning(
                         f"Skipping {tickers_list[i]} for forecast start date "
                         f"{forecast_start_date} due to error: {type(e)}: {e}"

--- a/src/canswim/gather_policy.py
+++ b/src/canswim/gather_policy.py
@@ -1,12 +1,14 @@
 """Pure decisions for lean, missing-only market data gathers (no network).
 
-Forecast-scoped gathers (GUI / MCP / CLI ``--tickers``) only need about the last
-**two years** of history—enough for model lookback + horizon—not multi-decade
-training archives. Train-mode gathers still use the long ``train_date_start``.
+Forecast-scoped gathers (GUI / MCP / CLI ``--tickers``) keep about the last
+**three years** of history—enough for model lookback (``input_chunk`` ≈ 252) plus
+~12 monthly catch-up origins (each needs full lookback **before** that origin)—
+not multi-decade training archives. Train-mode gathers still use the long
+``train_date_start``.
 
 Skip is allowed only when local history **covers the full required window**
 (first bar near window start, enough eligible bars, and recent enough).
-Partial tails (e.g. 350 bars starting mid-window) must still fetch.
+Partial tails (e.g. bars starting mid-window) must still fetch.
 """
 
 from __future__ import annotations
@@ -21,12 +23,14 @@ from canswim.eligibility import PRICE_OHLCV_COLS, price_history_is_eligible
 
 DateLike = Union[str, date, datetime, pd.Timestamp]
 
-# ~2 calendar years of sessions; enough for input_chunk(252)+horizons with margin
-FORECAST_LOOKBACK_YEARS = 2
+# ~3 calendar years: catch-up (~12 months) + min_samples (~336 sessions) + pad.
+# With only 2y, oldest catch-up starts had ~261–330 pre-start bars (need 336) and
+# every origin failed while the user-facing error incorrectly said "covariates".
+FORECAST_LOOKBACK_YEARS = 3
 # Treat local prices as fresh if last bar is within this many calendar days of asof
 DEFAULT_FRESHNESS_DAYS = 5
-# Minimum complete OHLCV bars for forecast-only path (252+42+42) with small pad
-DEFAULT_FORECAST_MIN_BARS = 350
+# Min complete OHLCV bars for forecast-only path (~3y sessions with margin)
+DEFAULT_FORECAST_MIN_BARS = 550
 # Train needs long history before we skip remote (not the same as forecast)
 DEFAULT_TRAIN_MIN_BARS = 1500
 # First bar may lag window_start by weekends/holidays only

--- a/src/canswim/mcp/server.py
+++ b/src/canswim/mcp/server.py
@@ -204,7 +204,7 @@ def resolve_forecast_start(start_date: Optional[str] = None) -> dict[str, Any]:
     name="gather_tickers",
     description=(
         "Get / update market data for listed stock symbols (comma or newline separated). "
-        "Only downloads what is missing or out of date (~last 2 years for forecast use). "
+        "Only downloads what is missing or out of date (~last 3 years for forecast use). "
         "Same as CLI `gatherdata --tickers` and dashboard “Update market data”. "
         "Streams progress notifications when the client sends a progressToken. "
         "Requires MCP_ALLOW_RUNS=1."

--- a/src/canswim/run_triggers.py
+++ b/src/canswim/run_triggers.py
@@ -509,7 +509,7 @@ def gather_for_tickers(
 
         g = MarketDataGatherer()
         g.stocks_ticker_set = list(tickers)
-        # Scoped user runs: ~2y missing-only (not multi-decade train history)
+        # Scoped user runs: ~3y missing-only (not multi-decade train history)
         g.gather_mode = "forecast"
 
         if not getattr(g, "FMP_API_KEY", None):

--- a/src/canswim/run_triggers.py
+++ b/src/canswim/run_triggers.py
@@ -101,7 +101,7 @@ INCOMPLETE_DATA_MSG = (
     "Market history is incomplete or not ready for: {symbols}. "
     "Use Update market data for these symbols, then run the forecast again. "
     "Forecasts never invent missing prices. "
-    "Recent IPOs often lack enough history (~2 years of sessions)."
+    "Recent IPOs often lack enough history (~3 years of sessions for catch-up)."
 )
 
 COVARIATE_FAIL_MSG = (
@@ -111,6 +111,16 @@ COVARIATE_FAIL_MSG = (
     "Try Update market data again (includes fundamentals), then re-run the forecast. "
     "ETFs and other fund-thin names use zero-filled fund covariates (like IPOs); "
     "if this still fails, see Technical log for a feature-dimension mismatch."
+)
+
+# Catch-up as-of origins need full model lookback *before* the origin date.
+# Do not call this "covariate misalignment" — that misleads operators.
+SHORT_HISTORY_ASOF_MSG = (
+    "Could not build catch-up forecasts for: {symbols}. "
+    "Local daily price history is too short before those start dates "
+    "(model needs ~{need} trading days of lookback before each origin). "
+    "Run Update market data / refresh again to download a longer window "
+    "(~3 years), then retry. This is not a fundamentals alignment failure."
 )
 
 DIMENSIONALITY_FAIL_MSG = (
@@ -945,14 +955,23 @@ def forecast_for_tickers(
     skipped_all: list[str] = []
     model_loaded = False
     last_fail_reason: Optional[str] = None
+    all_skip_details: list[dict] = []
+    last_need_bars: Optional[int] = None
 
     def _incomplete_result(
         *,
         forecasted_syms: list[str],
         incomplete_syms: list[str],
         reason: str = "prices",
+        need_bars: Optional[int] = None,
+        skip_details: Optional[list] = None,
     ) -> dict[str, Any]:
-        if reason == "covariates":
+        if reason == "short_history":
+            err = SHORT_HISTORY_ASOF_MSG.format(
+                symbols=", ".join(incomplete_syms) or "requested symbols",
+                need=need_bars or 336,
+            )
+        elif reason == "covariates":
             err = COVARIATE_FAIL_MSG.format(
                 symbols=", ".join(incomplete_syms) or "requested symbols"
             )
@@ -973,10 +992,11 @@ def forecast_for_tickers(
             "skipped": incomplete_syms,
             "already_have_forecast": sorted(all_already),
             "messages": messages,
-            "need_gather": reason == "prices",
+            "need_gather": reason in ("prices", "short_history"),
             "need_covariates": reason == "covariates",
             "model_loaded": model_loaded,
             "fail_reason": reason,
+            "skip_details": list(skip_details or []),
             "catchup_months": months if mode == "catchup" else None,
         }
 
@@ -1044,14 +1064,36 @@ def forecast_for_tickers(
                         any_saved = True
             plan["forecasted"] = forecasted_o
             forecasted_all.extend(forecasted_o)
+            skips = list(getattr(cf, "last_skip_details", None) or [])
+            if skips:
+                all_skip_details.extend(skips)
+                for d in skips:
+                    if d.get("need") is not None:
+                        last_need_bars = int(d["need"])
+            short_only = bool(skips) and all(
+                d.get("reason") == "short_history" for d in skips
+            )
             if not any_group and not getattr(cf, "all_already_saved", False):
-                last_fail_reason = "covariates"
-                messages.append(
-                    f"Start {o}: no eligible symbols in model batch "
-                    f"(tried {', '.join(to_run)})."
+                last_fail_reason = (
+                    "short_history" if short_only else "covariates"
                 )
+                if short_only:
+                    sample = skips[0]
+                    messages.append(
+                        f"Start {o}: insufficient pre-start history "
+                        f"(e.g. {sample.get('symbol')} had {sample.get('n_hist')} "
+                        f"bars, need {sample.get('need')}). "
+                        "Longer price download required — not a covariate mismatch."
+                    )
+                else:
+                    messages.append(
+                        f"Start {o}: no eligible symbols in model batch "
+                        f"(tried {', '.join(to_run)})."
+                    )
             elif not any_saved and not getattr(cf, "all_already_saved", False):
-                last_fail_reason = "covariates"
+                last_fail_reason = (
+                    "short_history" if short_only else "covariates"
+                )
                 messages.append(f"Start {o}: no forecasts saved.")
             else:
                 messages.append(
@@ -1077,10 +1119,17 @@ def forecast_for_tickers(
                     incomplete.append(f"{t}@{o}")
 
         if incomplete and not forecasted_all:
+            reason = last_fail_reason or "covariates"
+            if all_skip_details and all(
+                d.get("reason") == "short_history" for d in all_skip_details
+            ):
+                reason = "short_history"
             return _incomplete_result(
                 forecasted_syms=[],
                 incomplete_syms=incomplete,
-                reason=last_fail_reason or "covariates",
+                reason=reason,
+                need_bars=last_need_bars,
+                skip_details=all_skip_details,
             )
 
         # Push parquet → DuckDB (+ backtest_error refresh) and Charts symbol list

--- a/tests/canswim/test_gather_policy.py
+++ b/tests/canswim/test_gather_policy.py
@@ -1,4 +1,4 @@
-"""Missing-only / 2y gather decisions (pure; no network)."""
+"""Missing-only / 3y gather decisions (pure; no network)."""
 
 from __future__ import annotations
 
@@ -11,6 +11,7 @@ import pytest
 from canswim.gather_policy import (
     DEFAULT_FORECAST_MIN_BARS,
     DEFAULT_TRAIN_MIN_BARS,
+    FORECAST_LOOKBACK_YEARS,
     SymbolFetchPlan,
     classify_incomplete_reason,
     evaluate_symbol_coverage,
@@ -38,15 +39,16 @@ def _ohlcv_frame(symbol: str, start: str, n_bars: int) -> pd.DataFrame:
     return df
 
 
-def test_forecast_window_is_about_two_years():
+def test_forecast_window_is_about_three_years():
+    assert FORECAST_LOOKBACK_YEARS == 3
     asof = pd.Timestamp("2026-07-10")
     start = forecast_window_start(asof=asof)
-    assert start == pd.Timestamp("2024-07-10")
+    assert start == pd.Timestamp("2023-07-10")
 
 
 def test_skip_when_local_complete_and_fresh():
-    # Full ~2y+ window ending at asof
-    df = _ohlcv_frame("AAPL", "2024-01-02", 650)
+    # Full ~3y+ window ending at asof
+    df = _ohlcv_frame("AAPL", "2023-01-02", 900)
     last = df.index.get_level_values("Date").max()
     asof = pd.Timestamp(last).strftime("%Y-%m-%d")
     plan = plan_symbol_price_fetch(
@@ -54,7 +56,7 @@ def test_skip_when_local_complete_and_fresh():
         df,
         mode="forecast",
         asof=asof,
-        min_bars=350,
+        min_bars=DEFAULT_FORECAST_MIN_BARS,
         freshness_days=5,
     )
     assert plan.action == "skip", plan
@@ -63,16 +65,16 @@ def test_skip_when_local_complete_and_fresh():
 
 
 def test_partial_window_tail_must_fetch():
-    """350+ bars starting mid-window must NOT skip — missing early window coverage."""
+    """Many bars starting mid-window must NOT skip — missing early window coverage."""
     asof = "2026-07-10"
-    # Window start ≈ 2024-07-10; start history much later
+    # Window start ≈ 2023-07-10; start history much later
     df = _ohlcv_frame("AAPL", "2025-01-02", 400)
     plan = plan_symbol_price_fetch(
         "AAPL",
         df,
         mode="forecast",
         asof=asof,
-        min_bars=350,
+        min_bars=DEFAULT_FORECAST_MIN_BARS,
         freshness_days=400,  # freshness alone would pass
     )
     assert plan.action == "fetch", plan
@@ -81,19 +83,23 @@ def test_partial_window_tail_must_fetch():
 
 
 def test_fetch_when_missing_symbol():
-    df = _ohlcv_frame("MSFT", "2024-01-02", 600)
+    df = _ohlcv_frame("MSFT", "2023-01-02", 800)
     plan = plan_symbol_price_fetch(
-        "AAPL", df, mode="forecast", asof="2026-07-10", min_bars=350
+        "AAPL",
+        df,
+        mode="forecast",
+        asof="2026-07-10",
+        min_bars=DEFAULT_FORECAST_MIN_BARS,
     )
     assert plan.action == "fetch"
     assert plan.fetch_start is not None
-    assert plan.fetch_start.startswith("2024-")
+    assert plan.fetch_start.startswith("2023-")
     assert plan.reason == "missing_local_symbol"
     assert plan.is_incomplete is True
 
 
 def test_fetch_stale_uses_tail_start():
-    df = _ohlcv_frame("AAPL", "2024-01-02", 550)
+    df = _ohlcv_frame("AAPL", "2023-01-02", 800)
     last = pd.Timestamp(df.index.get_level_values("Date").max())
     asof = last + pd.Timedelta(days=30)
     plan = plan_symbol_price_fetch(
@@ -101,7 +107,7 @@ def test_fetch_stale_uses_tail_start():
         df,
         mode="forecast",
         asof=asof,
-        min_bars=350,
+        min_bars=DEFAULT_FORECAST_MIN_BARS,
         freshness_days=5,
     )
     assert plan.action == "fetch", plan
@@ -115,7 +121,11 @@ def test_short_history_fetches_from_window():
     asof = "2026-07-10"
     df = _ohlcv_frame("AAPL", "2026-01-02", 20)
     plan = plan_symbol_price_fetch(
-        "AAPL", df, mode="forecast", asof=asof, min_bars=350
+        "AAPL",
+        df,
+        mode="forecast",
+        asof=asof,
+        min_bars=DEFAULT_FORECAST_MIN_BARS,
     )
     assert plan.action == "fetch"
     assert plan.fetch_start == forecast_window_start(asof=asof).strftime("%Y-%m-%d")
@@ -123,9 +133,9 @@ def test_short_history_fetches_from_window():
 
 
 def test_train_mode_partial_history_must_fetch():
-    """~2y of data is not enough to skip under train mode (long window)."""
+    """~3y of data is not enough to skip under train mode (long window)."""
     # Plenty of bars for forecast, but first bar far after train_min_start
-    df = _ohlcv_frame("AAPL", "2024-01-02", 600)
+    df = _ohlcv_frame("AAPL", "2023-01-02", 800)
     last = df.index.get_level_values("Date").max()
     plan = plan_symbol_price_fetch(
         "AAPL",


### PR DESCRIPTION
## Summary

Logs showed catch-up forecasts failing for many symbols with a **misleading covariates message**. Technical log actually said:

`Skipping X: only 330 pre-start samples (need >= 336); as-of 2025-11-03`

**Cause:** forecast-scoped gather kept ~2 years of OHLCV. Monthly catch-up starts need full model lookback **before** each origin → 2y is not enough.

**Fix:**
- `FORECAST_LOOKBACK_YEARS = 3`, `DEFAULT_FORECAST_MIN_BARS = 550`
- Track skip details; surface `fail_reason=short_history` + clear user message
- Version **0.0.20260717**

After deploy, refresh re-downloads longer price history when the local window starts too late.

## Test plan

- [x] `./scripts/ci-local.sh`
- [ ] Merge + restart MCP
- [ ] Re-run client refresh on a few tickers; gather should fetch older bars; catch-up should progress