### PR TITLE
fix: DuckDB forecast sync for mixed date/time parquet (0.0.20260718)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable releases are documented here. Versioning follows date-style `0.0.YYYYMMDD` unless noted.
 
+## 0.0.20260718
+
+Successful refresh still left `get_forecast` empty (TSM job succeeded, DuckDB had 0 rows).
+
+### Highlights
+
+- **Root cause:** `sync_forecasts_to_search_db` DELETE then INSERT failed on mixed hive parquet (`date` vs legacy `time` columns)
+- **Fix:** `union_by_name` + schema-aware date expr; probe rows before DELETE; surface sync errors in forecast messages
+
+### Install
+
+```bash
+pip install canswim==0.0.20260718
+```
+
 ## 0.0.20260717
 
 Catch-up forecasts were failing with a misleading “covariate misalignment” error.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Flags: `python -m canswim -h` is the source of truth. Local site preview: `pip i
 
 ```bash
 pip install canswim
-# pin a release: pip install canswim==0.0.20260717
+# pin a release: pip install canswim==0.0.20260718
 
 # dev checkout
 pip install -e ".[dev]"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = canswim
-version = 0.0.20260717
+version = 0.0.20260718
 author = Ivelin Ivanov
 author_email = ivelin117@gmail.com
 description = Developer toolkit for CANSLIM-style investors (CLI, Gradio GUI, MCP)

--- a/src/canswim/db.py
+++ b/src/canswim/db.py
@@ -1134,24 +1134,67 @@ def sync_forecasts_to_search_db(
                     f'INSERT INTO stock_tickers ("{sym_col}") VALUES (?)', [s]
                 )
 
-        db_con.execute(
-            f"""--sql
-            DELETE FROM forecast
-            WHERE upper(CAST(symbol AS VARCHAR)) IN ({in_list})
-            """
-        )
-        # Production hive parquet uses column "date"; older fixtures used "time".
-        # DuckDB errors if a referenced column is missing, so pick from schema.
+        # Production hive uses column "date"; older files used "time". Mixed schemas
+        # across the hive break plain read_parquet (schema mismatch) and used to
+        # DELETE symbols then fail INSERT → empty get_forecast after a "successful"
+        # refresh. union_by_name + COALESCE handles both.
         sample_files = sorted(glob.glob(forecast_glob, recursive=True))
-        pq_cols = {
-            str(r[0]).lower()
-            for r in db_con.execute(
-                f"DESCRIBE SELECT * FROM read_parquet('{sample_files[0]}') LIMIT 0"
-            ).fetchall()
-        }
-        if "date" in pq_cols:
+        if not sample_files:
+            return {
+                "ok": True,
+                "symbols": syms,
+                "forecast_rows": 0,
+                "message": "No forecast parquet files found",
+            }
+        # Prefer reading only target-symbol partitions (faster + fewer schema mixes).
+        # Fall back to full hive glob when layout is non-standard.
+        per_sym_files: list[str] = []
+        for s in syms:
+            per_sym_files.extend(
+                sorted(
+                    glob.glob(
+                        f"{fpath}symbol={s}/**/*.parquet", recursive=True
+                    )
+                )
+            )
+        # DuckDB list for multi-file read
+        if per_sym_files:
+            file_list_sql = "[" + ", ".join(
+                "'" + p.replace("'", "''") + "'" for p in per_sym_files
+            ) + "]"
+            read_src = (
+                f"read_parquet({file_list_sql}, hive_partitioning = 1, "
+                f"union_by_name = true, hive_types_autocast = true)"
+            )
+        else:
+            read_src = (
+                f"read_parquet('{forecast_glob}', hive_partitioning = 1, "
+                f"union_by_name = true, hive_types_autocast = true)"
+            )
+        # Build date expression from actual columns present after union_by_name.
+        try:
+            pq_cols = {
+                str(r[0]).lower()
+                for r in db_con.execute(
+                    f"DESCRIBE SELECT * FROM {read_src} AS f LIMIT 0"
+                ).fetchall()
+            }
+        except Exception as e:
+            return {
+                "ok": False,
+                "error": f"Forecast parquet schema probe failed: {e}",
+                "symbols": syms,
+                "forecast_rows": 0,
+            }
+        has_date = "date" in pq_cols
+        has_time = "time" in pq_cols
+        if has_date and has_time:
+            date_expr = (
+                "COALESCE(TRY_CAST(f.date AS DATE), TRY_CAST(f.time AS DATE))"
+            )
+        elif has_date:
             date_expr = "CAST(f.date AS DATE)"
-        elif "time" in pq_cols:
+        elif has_time:
             date_expr = "CAST(f.time AS DATE)"
         else:
             return {
@@ -1162,6 +1205,35 @@ def sync_forecasts_to_search_db(
                 "symbols": syms,
                 "forecast_rows": 0,
             }
+        # Atomic replace: only delete after a successful staged read count
+        try:
+            staged = db_con.execute(
+                f"""--sql
+                SELECT count(*) FROM {read_src} AS f
+                WHERE upper(CAST(f.symbol AS VARCHAR)) IN ({in_list})
+                """
+            ).fetchone()[0]
+        except Exception as e:
+            return {
+                "ok": False,
+                "error": f"Forecast parquet read failed: {e}",
+                "symbols": syms,
+                "forecast_rows": 0,
+            }
+        if staged == 0:
+            return {
+                "ok": True,
+                "symbols": syms,
+                "forecast_rows": 0,
+                "message": "No forecast rows for symbols in parquet hive",
+            }
+
+        db_con.execute(
+            f"""--sql
+            DELETE FROM forecast
+            WHERE upper(CAST(symbol AS VARCHAR)) IN ({in_list})
+            """
+        )
         # Dedupe when multiple part files share symbol/start/date (common in hive dirs).
         db_con.execute(
             f"""--sql
@@ -1202,8 +1274,9 @@ def sync_forecasts_to_search_db(
                             {date_expr}
                         ORDER BY f.symbol
                     ) AS rn
-                FROM read_parquet('{forecast_glob}', hive_partitioning = 1) AS f
+                FROM {read_src} AS f
                 WHERE upper(CAST(f.symbol AS VARCHAR)) IN ({in_list})
+                  AND {date_expr} IS NOT NULL
             )
             WHERE rn = 1
             """

--- a/src/canswim/run_triggers.py
+++ b/src/canswim/run_triggers.py
@@ -1153,6 +1153,11 @@ def forecast_for_tickers(
                 messages.append(
                     f"Charts updated with {sync_fc.get('forecast_rows', 0)} forecast rows."
                 )
+            else:
+                messages.append(
+                    "Charts forecast sync failed: "
+                    + str(sync_fc.get("error") or sync_fc)
+                )
         except Exception as e:
             messages.append(f"Charts forecast sync note: {e}")
 

--- a/tests/canswim/test_db.py
+++ b/tests/canswim/test_db.py
@@ -240,6 +240,71 @@ def test_sync_forecasts_to_search_db_accepts_legacy_time_column(
     assert res["forecast_rows"] == 5
 
 
+def test_sync_forecasts_mixed_date_and_time_columns(mini_db, tmp_path: Path):
+    """Hive may mix legacy ``time`` and modern ``date`` part files — must not wipe DB."""
+    root = tmp_path / "forecast"
+    # modern date column
+    d1 = (
+        root
+        / "symbol=CCC"
+        / "forecast_start_year=2026"
+        / "forecast_start_month=3"
+        / "forecast_start_day=2"
+    )
+    d1.mkdir(parents=True)
+    dates1 = pd.bdate_range("2026-03-02", periods=3)
+    pd.DataFrame(
+        {
+            "date": dates1,
+            "symbol": "CCC",
+            "close_quantile_0.01": 90.0,
+            "close_quantile_0.05": 92.0,
+            "close_quantile_0.2": 95.0,
+            "close_quantile_0.5": 100.0,
+            "close_quantile_0.8": 105.0,
+            "close_quantile_0.95": 108.0,
+            "close_quantile_0.99": 110.0,
+            "forecast_start_year": 2026,
+            "forecast_start_month": 3,
+            "forecast_start_day": 2,
+        }
+    ).to_parquet(d1 / "part.parquet", index=False)
+    # legacy time column
+    d2 = (
+        root
+        / "symbol=CCC"
+        / "forecast_start_year=2026"
+        / "forecast_start_month=4"
+        / "forecast_start_day=6"
+    )
+    d2.mkdir(parents=True)
+    dates2 = pd.bdate_range("2026-04-06", periods=2)
+    pd.DataFrame(
+        {
+            "time": dates2,
+            "symbol": "CCC",
+            "close_quantile_0.01": 91.0,
+            "close_quantile_0.05": 93.0,
+            "close_quantile_0.2": 96.0,
+            "close_quantile_0.5": 101.0,
+            "close_quantile_0.8": 106.0,
+            "close_quantile_0.95": 109.0,
+            "close_quantile_0.99": 111.0,
+            "forecast_start_year": 2026,
+            "forecast_start_month": 4,
+            "forecast_start_day": 6,
+        }
+    ).to_parquet(d2 / "part.parquet", index=False)
+
+    res = sync_forecasts_to_search_db(
+        mini_db, ["CCC"], forecast_path=str(root)
+    )
+    assert res["ok"] is True, res
+    assert res["forecast_rows"] == 5
+    after = get_forecast_rows(mini_db, "CCC", latest_only=False)
+    assert len(after) == 5
+
+
 def test_get_close_prices(mini_db):
     df = get_close_prices(mini_db, "AAA")
     assert len(df) == 2


### PR DESCRIPTION
## Summary

Client share: TSM async job **succeeded** but `get_forecast` returned **empty**.

**Cause:** `sync_forecasts_to_search_db` deleted TSM rows then failed INSERT (`date` vs legacy `time` parquet schema mismatch).

**Fix:** `union_by_name`, COALESCE/schema probe, count before DELETE, report sync errors. Host already recovered TSM (588 rows).

Version **0.0.20260718**.

## Test plan
- [x] unit tests incl. mixed schema
- [x] manual sync TSM → get_forecast has rows
- [ ] merge + restart MCP