### PR TITLE
fix(mcp): MCP-only data access; hide host DuckDB from clients (0.0.20260720)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable releases are documented here. Versioning follows date-style `0.0.YYYYMMDD` unless noted.
 
+## 0.0.20260720
+
+Remote clients kept inventing a local DuckDB they could open; MCP text leaked host paths and engine details.
+
+### Highlights
+
+- **Client access boundary** — `get_server_info` / `health_check` / schema & SQL tools no longer return host `db_path`, `data_dir`, or “open local DuckDB” language
+- Explicit **`access`** message: data only via MCP tools; no client-side database file
+- Prefer purpose-built tools (`get_chart_data`, …); `run_select` framed as optional MCP analytics, not a private DB connection
+
+### Install
+
+```bash
+pip install canswim==0.0.20260720
+```
+
 ## 0.0.20260719
 
 MCP clients needed three tools and custom grouping to recreate the dashboard Charts tab.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,8 +1,20 @@
 # MCP server
 
-Expose precomputed TiDE forecasts and local market data to MCP clients (Claude Desktop, Cursor, etc.) over the **same DuckDB search database** used by the dashboard.
+Expose precomputed TiDE forecasts and market data to MCP clients (Claude Desktop, Cursor, SuperGrok, etc.). **Remote clients only access data through MCP tools** — there is no client-side database file, host path, or direct DuckDB connection for the connector.
+
+On the **host**, the server reads the same search store as the dashboard (operators: [data_store.md](data_store.md)). That is an implementation detail; do not surface host paths or engine names in client-facing product copy.
 
 **NOT FINANCIAL OR INVESTMENT ADVICE. USE AT YOUR OWN RISK.**
+
+## Client access boundary
+
+| Clients may | Clients must not assume |
+|-------------|-------------------------|
+| Call MCP tools (`get_chart_data`, `get_forecast`, `get_close_price`, …) | A local DuckDB/file path on their machine |
+| Optional `get_db_schema` + `run_select` **via MCP** | Opening the host search DB outside this server |
+| Use `get_server_info.access` as the source of truth | SQL against “the DuckDB” without `run_select` |
+
+`get_server_info` includes an **`access`** string and **does not** return `db_path` / `data_dir` / `db_file` to remote clients.
 
 ## Behavior
 
@@ -114,7 +126,7 @@ Canonical registration: `src/canswim/mcp/server.py`. Update this table in the **
 3. For **each** entry in `data.forecasts` (monthly backtests + latest live): plot `median` **dashed** and **fill** between `low` and `high` (see `plot_hints.client_recipe`). Do **not** drop to latest-only.
 4. Optional table: `data.reward_risk` (uptrending starts in the same confidence mapping).
 
-No `get_close_price` + `get_forecast` stitching required. Restart `canswim-mcp` after deploy so clients see version **0.0.20260719** and rediscover the tool.
+No `get_close_price` + `get_forecast` stitching required. Restart `canswim-mcp` after deploy so clients see the current package version and rediscover tools.
 
 ### Async refresh (default — SuperGrok / short tool timeouts)
 
@@ -154,14 +166,16 @@ progress emit (`MCP progress: …` / `MCP progress emit: …`). Set
 journalctl --user -u canswim-mcp -f | rg 'MCP progress'
 ```
 
-### Custom SQL (read-only)
+### Custom SQL (read-only, still MCP-only)
 
-1. Call **`get_db_schema`** so the client AI sees tables, types, and indexes.
-2. Call **`run_select`** with one `SELECT` or `WITH … SELECT` statement.
+Prefer purpose-built tools first (`get_chart_data`, `get_forecast`, …). For ad-hoc analytics:
+
+1. Call **`get_db_schema`** for logical tables/columns (no host path in the payload).
+2. Call **`run_select`** with one `SELECT` or `WITH … SELECT` statement **through MCP**.
 3. Guards:
    - Statement must start with `SELECT` or `WITH` (and contain `SELECT`).
    - DDL/DML keywords, multi-statement `;`, `PRAGMA`, `ATTACH`, `COPY`, etc. are **rejected**.
-   - DuckDB is opened **read-only** (`connect_readonly`).
+   - Server executes read-only; the client never receives a DB file path.
    - Results are wrapped with `LIMIT` (default 5000).
 4. **Writes are never free-form SQL** — only gated tools (`gather_tickers`, `forecast_tickers`, `refresh_tickers`, `refresh_job_start`) when `MCP_ALLOW_RUNS=1`.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = canswim
-version = 0.0.20260719
+version = 0.0.20260720
 author = Ivelin Ivanov
 author_email = ivelin117@gmail.com
 description = Developer toolkit for CANSLIM-style investors (CLI, Gradio GUI, MCP)

--- a/src/canswim/db.py
+++ b/src/canswim/db.py
@@ -1917,24 +1917,24 @@ def describe_search_schema(
         "schema_version_current": CURRENT_SCHEMA_VERSION,
         "migrations": list_migrations(),
         "sql_policy": (
-            "Custom SQL via run_select: single SELECT or WITH…SELECT only; "
-            "enforced + DuckDB read-only connection. "
-            "Mutations only via gather_tickers / forecast_tickers / refresh_tickers / refresh_job_start "
-            "when MCP_ALLOW_RUNS=1."
+            "Custom analytics SQL via MCP run_select only: single SELECT or "
+            "WITH…SELECT; read-only. Remote clients have no database file path. "
+            "Mutations only via gather_tickers / forecast_tickers / refresh_tickers / "
+            "refresh_job_start when MCP_ALLOW_RUNS=1."
         ),
         "tables": [],
         "indexes": [],
         "expected_tables": list(SEARCH_TABLES),
         "notes": [
-            "Parquet under data/ is the system of record; this DuckDB is the "
-            "search/UI cache (Charts, Scans, MCP).",
+            "Remote clients access data only through MCP tools (not a local DB file).",
             "forecast.start_date = forecast origin; forecast.date = horizon day.",
             "Join company_profile on upper(symbol) for sector/industry filters.",
             "Schema version is stored in canswim_schema_meta; "
-            "see docs/data_store.md for migration steps between app versions.",
+            "operators: see docs/data_store.md for migrations.",
         ],
     }
     if not out["db_exists"]:
+        # Keep path for server logs/tests; MCP layer strips host paths for clients.
         out["error"] = f"Database file not found: {path}"
         return out
     out["schema_version"] = get_schema_version(path)
@@ -2052,10 +2052,11 @@ def describe_search_schema(
 
 
 def format_schema_markdown(schema: dict[str, Any]) -> str:
-    """Compact Markdown schema dump for MCP client context."""
+    """Compact Markdown schema dump for MCP client context (no host paths)."""
     lines = [
-        f"# CANSWIM search DB schema",
-        f"Path: `{schema.get('db_path')}`",
+        "# CANSWIM data schema (MCP tools only)",
+        "",
+        schema.get("access") or "",
         "",
         schema.get("sql_policy") or "",
         "",

--- a/src/canswim/mcp/__init__.py
+++ b/src/canswim/mcp/__init__.py
@@ -1,4 +1,4 @@
-"""CANSWIM MCP server (read-only tools over the local DuckDB search DB)."""
+"""CANSWIM MCP server (read tools for forecasts/market data; MCP-only access)."""
 
 from __future__ import annotations
 

--- a/src/canswim/mcp/server.py
+++ b/src/canswim/mcp/server.py
@@ -1,8 +1,8 @@
 """CANSWIM MCP server entrypoint.
 
-Default is READ-ONLY — precomputed TiDE forecasts and market data from the
-local DuckDB search database. Optional write tools (gather/forecast) are
-registered for discoverability but require ``MCP_ALLOW_RUNS=1`` to execute.
+Default is READ-ONLY — precomputed TiDE forecasts and market data exposed
+only through MCP tools (remote clients have no host DB file). Optional write
+tools (gather/forecast) require ``MCP_ALLOW_RUNS=1`` to execute.
 """
 
 from __future__ import annotations
@@ -44,7 +44,10 @@ mcp._mcp_server.version = SERVER_VERSION
 
 @mcp.tool(
     name="health_check",
-    description="Check whether the local CANSWIM DuckDB search database is ready.",
+    description=(
+        "Check whether CANSWIM data is ready on the server. "
+        "Does not grant filesystem or database access — use MCP tools only."
+    ),
 )
 def health_check() -> dict[str, Any]:
     return meta.health_check_impl()
@@ -54,7 +57,8 @@ def health_check() -> dict[str, Any]:
     name="get_server_info",
     description=(
         "Server metadata: version (bump ⇒ re-discover tools), read-only flag, "
-        "tool list, db path, and refresh_guidance for portfolio async jobs."
+        "tool list, access boundary (MCP-only data), and refresh_guidance for "
+        "portfolio async jobs."
     ),
 )
 def get_server_info() -> dict[str, Any]:
@@ -63,7 +67,7 @@ def get_server_info() -> dict[str, Any]:
 
 @mcp.tool(
     name="list_tickers",
-    description="List stock symbols available in the local search database.",
+    description="List stock symbols available via this MCP server.",
 )
 def list_tickers() -> dict[str, Any]:
     return tickers.list_tickers_impl()
@@ -127,7 +131,10 @@ def scan_forecasts(
 
 @mcp.tool(
     name="get_close_price",
-    description="Historical close prices for a symbol from the local DuckDB (optional ISO date range).",
+    description=(
+        "Historical close prices for a symbol via MCP (optional ISO date range). "
+        "Not a filesystem or local-database API."
+    ),
 )
 def get_close_price(
     symbol: str,
@@ -150,7 +157,7 @@ def get_close_price(
         "plot median dashed and fill low–high — do not filter to latest only; "
         "no other tools needed for the default chart. "
         "confidence: 80/95/99 (default 80 → low quantile 0.2, high 0.95). "
-        "history_years: default 2. Read-only DuckDB (no torch)."
+        "history_years: default 2. Read-only MCP data (no torch)."
     ),
 )
 def get_chart_data(
@@ -181,10 +188,10 @@ def get_backtest_error(
 @mcp.tool(
     name="get_db_schema",
     description=(
-        "Export the local DuckDB search database schema for analytics SQL: "
-        "tables, columns (name/type/nullable), indexes, optional row counts, "
-        "and purpose notes. Also returns a compact markdown summary for agent "
-        "context. Use this before writing complex run_select queries. Read-only. "
+        "Logical table/column schema for optional MCP analytics (run_select). "
+        "Does not expose a host database path or grant a client DB connection — "
+        "schema is only for writing run_select queries through this server. "
+        "Prefer get_chart_data / get_forecast / get_close_price when possible. "
         "format: 'json' | 'markdown' | 'both' (default both)."
     ),
 )
@@ -203,12 +210,13 @@ def get_db_schema(
 @mcp.tool(
     name="run_select",
     description=(
-        "Run a single read-only SQL query against the local DuckDB search database "
-        "(same as Advanced Queries). Allowed: one SELECT or WITH…SELECT. "
-        "DDL/DML/multi-statement/PRAGMA/ATTACH are rejected. Connection is always "
-        "read-only. Writes only via gather_tickers / forecast_tickers / refresh_tickers "
-        "/ refresh_job_start when MCP_ALLOW_RUNS=1. Call get_db_schema first for "
-        "table/index layout. Results capped by row_limit (default 5000)."
+        "Optional analytics: one read-only SELECT or WITH…SELECT via this MCP server "
+        "(not a local database on the client). "
+        "DDL/DML/multi-statement/PRAGMA/ATTACH rejected. "
+        "Prefer purpose-built tools (get_chart_data, get_forecast, …) for charts "
+        "and standard queries. Call get_db_schema first for table layout. "
+        "Writes only via gather/forecast/refresh tools when MCP_ALLOW_RUNS=1. "
+        "Results capped by row_limit (default 5000)."
     ),
 )
 def run_select(sql: str, row_limit: int = 5000) -> dict[str, Any]:

--- a/src/canswim/mcp/tools/_common.py
+++ b/src/canswim/mcp/tools/_common.py
@@ -202,17 +202,26 @@ def ensure_db_ready(db_path: Optional[str] = None) -> tuple[bool, str]:
         try:
             init_search_db(path, same_data=False, target_column="Close")
         except Exception as e:
-            return False, f"Failed to init DuckDB at {path}: {e}"
+            # Log path server-side; do not leak host paths to MCP clients.
+            logger.error(f"MCP_INIT_DB failed at {path}: {e}")
+            return False, (
+                "Failed to initialize CANSWIM search data on the server. "
+                "An operator must fix host data setup."
+            )
         if tables_present(path):
             return True, path
-        return False, f"DuckDB init completed but expected tables missing at {path}"
+        return False, (
+            "CANSWIM search data init finished but required datasets are still missing. "
+            "An operator must repair the host data store."
+        )
 
     return (
         False,
         (
-            f"Search database missing or incomplete at {path}. "
-            "Run `python -m canswim dashboard` once to build it, "
-            "or set MCP_INIT_DB=1 to build from local parquet on MCP start."
+            "CANSWIM data is not ready on the server. "
+            "Remote clients cannot open a local database file — use MCP tools only. "
+            "An operator must build search data on the host "
+            "(run dashboard once, or set MCP_INIT_DB=1 on the server process)."
         ),
     )
 

--- a/src/canswim/mcp/tools/meta.py
+++ b/src/canswim/mcp/tools/meta.py
@@ -2,11 +2,9 @@
 
 from __future__ import annotations
 
-import os
-from pathlib import Path
 from typing import Any
 
-from canswim.db import SEARCH_TABLES, get_db_path, tables_present
+from canswim.db import SEARCH_TABLES, tables_present
 from canswim.mcp import __version__
 from canswim.mcp.tools._common import err_result, ok_result, resolve_db_path
 from canswim.run_triggers import runs_allowed
@@ -39,24 +37,36 @@ WRITE_TOOL_NAMES = [
 
 TOOL_NAMES = READ_TOOL_NAMES + WRITE_TOOL_NAMES
 
+# Shown to remote clients so they do not invent host filesystem / engine access.
+CLIENT_ACCESS_BOUNDARY = (
+    "All CANSWIM data is available only through this MCP server's tools. "
+    "There is no client-accessible database file, no local DuckDB path, and no "
+    "host filesystem for the remote client. Prefer purpose-built tools "
+    "(get_chart_data, get_forecast, get_close_price, …). Optional analytics: "
+    "get_db_schema + run_select only — still via MCP, never a separate DB connection."
+)
+
 
 def health_check_impl() -> dict[str, Any]:
     db_path = resolve_db_path()
-    exists = Path(db_path).is_file()
     ready = tables_present(db_path)
     allow_runs = runs_allowed()
     payload = {
-        "db_path": db_path,
-        "db_file_exists": exists,
+        "data_ready": ready,
+        # Compatibility aliases (no paths / engine names)
         "tables_ready": ready,
-        "expected_tables": list(SEARCH_TABLES),
+        "datasets": list(SEARCH_TABLES),
         "is_read_only": not allow_runs,
         "runs_allowed": allow_runs,
+        "access": CLIENT_ACCESS_BOUNDARY,
         "disclaimer": "NOT FINANCIAL OR INVESTMENT ADVICE. USE AT YOUR OWN RISK.",
     }
     if not ready:
         return err_result(
-            "Search database not ready. Run dashboard once or set MCP_INIT_DB=1.",
+            "CANSWIM data is not ready on the server. "
+            "An operator must build or refresh the search data on the host "
+            "(dashboard once, or MCP_INIT_DB on the server process). "
+            "Remote clients cannot access a local database file.",
             data=payload,
         )
     return ok_result(payload)
@@ -74,14 +84,15 @@ def get_server_info_impl() -> dict[str, Any]:
             "version": __version__,
             "is_read_only": not allow_runs,
             "runs_allowed": allow_runs,
+            "access": CLIENT_ACCESS_BOUNDARY,
             "model": (
-                "TiDE precomputed forecasts (read tools). "
-                "Custom SQL: run_select is SELECT/WITH only on a read-only DuckDB "
-                "connection; get_db_schema exports tables/indexes for query authoring. "
+                "TiDE precomputed forecasts via MCP read tools only. "
+                "Charts: prefer get_chart_data (one-shot). "
+                "Optional analytics: get_db_schema + run_select (SELECT/WITH only "
+                "through MCP — not a client-side database). "
                 "Write tools gather_tickers/forecast_tickers/refresh_tickers/"
-                "refresh_job_start require MCP_ALLOW_RUNS=1 and may load torch. "
-                "Prefer refresh_job_start + refresh_job_status for long refreshes "
-                "(clients that time out on multi-minute tools)."
+                "refresh_job_start require MCP_ALLOW_RUNS=1 on the server. "
+                "Prefer refresh_tickers + refresh_job_status for long refreshes."
             ),
             "refresh_guidance": {
                 "preferred_tools": [
@@ -107,16 +118,9 @@ def get_server_info_impl() -> dict[str, Any]:
                     "refresh_job_status. Never claim success from the start response alone."
                 ),
             },
-            "db_path": get_db_path(),
             "tools": TOOL_NAMES,
             "read_tools": READ_TOOL_NAMES,
             "write_tools": WRITE_TOOL_NAMES,
-            "env": {
-                "data_dir": os.getenv("data_dir", "data"),
-                "db_file": os.getenv("db_file", "local.duckdb"),
-                "MCP_INIT_DB": os.getenv("MCP_INIT_DB", ""),
-                "MCP_ALLOW_RUNS": os.getenv("MCP_ALLOW_RUNS", ""),
-            },
             "disclaimer": "NOT FINANCIAL OR INVESTMENT ADVICE. USE AT YOUR OWN RISK.",
         }
     )

--- a/src/canswim/mcp/tools/query.py
+++ b/src/canswim/mcp/tools/query.py
@@ -1,20 +1,43 @@
-"""Advanced SELECT-only SQL + schema export for MCP clients."""
+"""Advanced SELECT-only analytics + schema export for MCP clients.
+
+Framed as an MCP query API — not a client-side database connection.
+"""
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from pathlib import Path
+from typing import Any
 
 from canswim.db import (
     SelectOnlyError,
     dataframe_to_records,
     describe_search_schema,
+    format_schema_markdown,
     run_select,
 )
 from canswim.mcp.tools._common import ensure_db_ready, err_result, ok_result, resolve_db_path
+from canswim.mcp.tools.meta import CLIENT_ACCESS_BOUNDARY
+
+# Client-facing policy (no engine/path leakage)
+_SQL_POLICY = (
+    "Analytics SQL runs only through the MCP run_select tool "
+    "(one SELECT or WITH…SELECT). Remote clients have no database file, "
+    "no host path, and no separate connection. "
+    "Writes only via gather_tickers / forecast_tickers / refresh_tickers / "
+    "refresh_job_start when the server allows runs."
+)
+_SCHEMA_NOTES = [
+    "Use MCP tools only — never assume a local database on the client machine.",
+    "Prefer get_chart_data / get_forecast / get_close_price over ad-hoc SQL when possible.",
+    "Logical tables (for run_select): stock_tickers, close_price, forecast, "
+    "latest_forecast, backtest_error, company_profile.",
+    "forecast.start_date = forecast origin; forecast.date = horizon day.",
+    "Join company_profile on upper(symbol) for sector/industry filters.",
+]
 
 
 def run_select_impl(sql: str, row_limit: int = 5000) -> dict[str, Any]:
-    """Execute a single read-only SELECT (or WITH…SELECT). Never opens R/W."""
+    """Execute a single read-only SELECT (or WITH…SELECT) via MCP only."""
     ready, msg = ensure_db_ready()
     if not ready:
         return err_result(msg)
@@ -29,6 +52,7 @@ def run_select_impl(sql: str, row_limit: int = 5000) -> dict[str, Any]:
                 "rows": dataframe_to_records(df),
                 "read_only": True,
                 "row_limit": int(row_limit),
+                "access": CLIENT_ACCESS_BOUNDARY,
             }
         )
     except SelectOnlyError as e:
@@ -42,20 +66,17 @@ def get_db_schema_impl(
     include_sample_values: bool = False,
     format: str = "both",
 ) -> dict[str, Any]:
-    """Export search DuckDB schema (tables, columns, indexes) for agent SQL.
+    """Export logical table schema for MCP run_select authoring.
 
     ``format``: ``json`` | ``markdown`` | ``both`` (default both).
+    Host paths and storage-engine details are omitted from the client payload.
     """
     ready, msg = ensure_db_ready()
     if not ready:
-        # Still try to describe if file exists — agents need schema even if
-        # optional tables missing; ensure_db_ready is strict on core tables.
         db_path = resolve_db_path()
-        from pathlib import Path
-
         if not Path(db_path).is_file():
             return err_result(msg)
-        # fall through with partial DB
+        # fall through with partial data
 
     db_path = resolve_db_path()
     try:
@@ -65,24 +86,43 @@ def get_db_schema_impl(
             include_sample_values=include_sample_values,
         )
         if schema.get("error") and not schema.get("tables"):
-            return err_result(schema["error"], data=schema)
+            return err_result(
+                "CANSWIM schema is unavailable (data not ready on the server)."
+            )
+
+        # Client-safe view: no db_path, no engine/path notes from host describe
+        client_schema = {
+            "read_only": True,
+            "access": CLIENT_ACCESS_BOUNDARY,
+            "sql_policy": _SQL_POLICY,
+            "notes": list(_SCHEMA_NOTES),
+            "expected_tables": schema.get("expected_tables"),
+            "table_names": schema.get("table_names"),
+            "schema_version": schema.get("schema_version"),
+            "tables": schema.get("tables") or [],
+            "indexes": schema.get("indexes") or [],
+        }
+        md = format_schema_markdown(client_schema)
 
         fmt = (format or "both").strip().lower()
         data: dict[str, Any] = {
-            "db_path": schema.get("db_path"),
             "read_only": True,
-            "sql_policy": schema.get("sql_policy"),
-            "notes": schema.get("notes"),
+            "access": CLIENT_ACCESS_BOUNDARY,
+            "sql_policy": _SQL_POLICY,
+            "notes": list(_SCHEMA_NOTES),
             "expected_tables": schema.get("expected_tables"),
             "table_names": schema.get("table_names"),
+            "schema_version": schema.get("schema_version"),
         }
         if fmt in ("json", "both"):
             data["tables"] = schema.get("tables")
             data["indexes"] = schema.get("indexes")
         if fmt in ("markdown", "both"):
-            data["markdown"] = schema.get("markdown") or ""
+            data["markdown"] = md
         if schema.get("error"):
-            data["warning"] = schema["error"]
+            data["warning"] = (
+                "Partial schema: some datasets may be missing on the server."
+            )
         return ok_result(data)
     except Exception as e:
         return err_result(str(e))

--- a/tests/canswim/test_mcp_tools.py
+++ b/tests/canswim/test_mcp_tools.py
@@ -101,6 +101,10 @@ def test_health_and_info(mcp_env, monkeypatch):
     h = meta.health_check_impl()
     assert h["ok"] is True
     assert h["data"]["is_read_only"] is True
+    assert h["data"]["data_ready"] is True
+    # No host filesystem / engine leakage to remote clients
+    assert "db_path" not in h["data"]
+    assert "db_file_exists" not in h["data"]
     info = meta.get_server_info_impl()
     assert info["ok"] is True
     assert info["data"]["is_read_only"] is True
@@ -108,6 +112,28 @@ def test_health_and_info(mcp_env, monkeypatch):
     assert "list_tickers" in info["data"]["tools"]
     assert "gather_tickers" in info["data"]["tools"]
     assert "forecast_tickers" in info["data"]["write_tools"]
+    assert "db_path" not in info["data"]
+    assert "env" not in info["data"]
+    access = (info["data"].get("access") or "").lower()
+    assert "mcp" in access
+    assert "only" in access
+    assert "duckdb" in access  # explicit: no client DuckDB access
+    assert "no client" in access or "not" in access
+
+
+def test_schema_and_select_omit_host_paths(mcp_env):
+    sch = query.get_db_schema_impl(format="both")
+    assert sch["ok"] is True
+    d = sch["data"]
+    assert "db_path" not in d
+    assert "access" in d
+    md = (d.get("markdown") or "").lower()
+    assert "path:" not in md
+    assert "/home/" not in md
+    assert ".duckdb" not in md
+    sel = query.run_select_impl("SELECT 1 AS n")
+    assert sel["ok"] is True
+    assert "access" in sel["data"]
 
 
 def test_write_tools_blocked_without_opt_in(mcp_env, monkeypatch):


### PR DESCRIPTION
## Summary
- Remote SuperGrok clients kept treating CANSWIM as a local DuckDB they could query outside MCP.
- **Client boundary:** `get_server_info` / `health_check` no longer return `db_path`, `data_dir`, or `db_file`; add explicit `access` string.
- Tool descriptions and errors avoid “local DuckDB” / host paths; `get_db_schema` / `run_select` framed as optional MCP analytics.
- Version **0.0.20260720** for rediscovery after restart.

## Test plan
- [x] Local CI 261 passed
- [x] New tests: no `db_path` in health/info; schema markdown has no paths
- [ ] Remote CI green; merge; restart `canswim-mcp`