### PR TITLE
fix(mcp): chart tool discoverability + version 0.0.20260721

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable releases are documented here. Versioning follows date-style `0.0.YYYYMMDD` unless noted.
 
+## 0.0.20260721
+
+SuperGrok kept claiming `get_chart_data` was unavailable and fell back to `get_close_price` + `get_forecast` (latest-only, no backtests).
+
+### Highlights
+
+- **`plot_chart`** alias of `get_chart_data` (same payload) for connectors that miss one name
+- Tool descriptions assert **PRIMARY / AVAILABLE**; `get_forecast` / `get_close_price` redirect to chart tools
+- **`chart_guidance`** on `get_server_info` — do not claim unavailable if listed; do not stitch prices+forecast for full charts
+- Coerce string confidence / history_years / bool args from loose clients
+
+### Install
+
+```bash
+pip install canswim==0.0.20260721
+```
+
 ## 0.0.20260720
 
 Remote clients kept inventing a local DuckDB they could open; MCP text leaked host paths and engine details.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -105,8 +105,9 @@ Canonical registration: `src/canswim/mcp/server.py`. Update this table in the **
 | `get_forecast` | Quantile forecast rows for a symbol | — |
 | `get_reward_risk` | Reward/risk for a forecast (confidence 80/95/99) | — |
 | `scan_forecasts` | Universe scan (≡ dashboard Scans) | — |
-| `get_close_price` | Historical closes | — |
-| `get_chart_data` | **One-shot** dashboard Charts payload: ~1–2y actual close, all in-window forecast overlays (backtests + live) with median + low/high band, reward/risk, `plot_hints` — plot without stitching other tools | — |
+| `get_close_price` | Historical closes only (not a full chart) | — |
+| `get_chart_data` | **PRIMARY one-shot** dashboard Charts payload: ~1–2y actual close, all in-window forecast overlays (backtests + live) with median + low/high band, reward/risk, `plot_hints` | — |
+| `plot_chart` | **Alias** of `get_chart_data` (same args/payload) — use if a connector omits `get_chart_data` | — |
 | `get_backtest_error` | Forecast vs actual error (mean abs log-error) | — |
 | `get_db_schema` | Tables, columns, indexes, row counts + markdown (for agent SQL) | — |
 | `run_select` | Single read-only `SELECT` or `WITH…SELECT` (≡ Advanced Queries) | — |
@@ -119,14 +120,14 @@ Canonical registration: `src/canswim/mcp/server.py`. Update this table in the **
 
 ### One-shot chart (dashboard Charts equivalent)
 
-**`get_chart_data(symbol)`** is the only tool needed to plot the Charts tab view:
+**`get_chart_data(symbol)`** (alias **`plot_chart`**) is the only tool needed for the Charts tab view. Both names are registered; if a client says the tool is “unavailable”, reconnect the connector and call **`plot_chart`** if `get_chart_data` is missing from its tool list.
 
-1. Call **`get_chart_data`** with the symbol (optional `confidence` 80/95/99, default 80; `history_years` default 2).
+1. Call **`get_chart_data`** or **`plot_chart`** with the symbol (optional `confidence` 80/95/99, default 80; `history_years` default 2).
 2. Plot `data.actual.dates` / `data.actual.close` as a **solid** price line.
-3. For **each** entry in `data.forecasts` (monthly backtests + latest live): plot `median` **dashed** and **fill** between `low` and `high` (see `plot_hints.client_recipe`). Do **not** drop to latest-only.
-4. Optional table: `data.reward_risk` (uptrending starts in the same confidence mapping).
+3. For **each** entry in `data.forecasts` (monthly backtests + latest live): plot `median` **dashed** and **fill** between `low` and `high`. Do **not** drop to latest-only.
+4. Optional table: `data.reward_risk`.
 
-No `get_close_price` + `get_forecast` stitching required. Restart `canswim-mcp` after deploy so clients see the current package version and rediscover tools.
+**Do not** use `get_close_price` + `get_forecast` for a full chart (that is latest-only and omits backtests). See `get_server_info.chart_guidance`. Restart `canswim-mcp` after deploy so clients rediscover tools (version bump).
 
 ### Async refresh (default — SuperGrok / short tool timeouts)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = canswim
-version = 0.0.20260720
+version = 0.0.20260721
 author = Ivelin Ivanov
 author_email = ivelin117@gmail.com
 description = Developer toolkit for CANSLIM-style investors (CLI, Gradio GUI, MCP)

--- a/src/canswim/mcp/server.py
+++ b/src/canswim/mcp/server.py
@@ -73,11 +73,64 @@ def list_tickers() -> dict[str, Any]:
     return tickers.list_tickers_impl()
 
 
+_CHART_TOOL_DESC = (
+    "PRIMARY chart tool (AVAILABLE on this server). "
+    "Call with symbol only for a full dashboard chart: ~1–2y actual closes + "
+    "ALL in-window forecast overlays (monthly backtests + latest live) with "
+    "median and low/high bands, plus plot_hints. "
+    "Do NOT claim this tool is unavailable; do NOT use get_close_price+"
+    "get_forecast for a full chart (that omits backtests). "
+    "Plot: actual solid; each forecasts[] median dashed + fill low–high. "
+    "confidence 80/95/99 (default 80); history_years default 2."
+)
+
+
+@mcp.tool(
+    name="get_chart_data",
+    description=_CHART_TOOL_DESC,
+)
+def get_chart_data(
+    symbol: str,
+    confidence: int = 80,
+    history_years: float = 2.0,
+    include_reward_risk: bool = True,
+) -> dict[str, Any]:
+    return charts.get_chart_data_impl(
+        symbol=symbol,
+        confidence=confidence,
+        history_years=history_years,
+        include_reward_risk=include_reward_risk,
+    )
+
+
+@mcp.tool(
+    name="plot_chart",
+    description=(
+        "Alias of get_chart_data — same one-shot dashboard chart payload. "
+        "Use if get_chart_data is missing from your connector tool list. "
+        + _CHART_TOOL_DESC
+    ),
+)
+def plot_chart(
+    symbol: str,
+    confidence: int = 80,
+    history_years: float = 2.0,
+    include_reward_risk: bool = True,
+) -> dict[str, Any]:
+    return charts.get_chart_data_impl(
+        symbol=symbol,
+        confidence=confidence,
+        history_years=history_years,
+        include_reward_risk=include_reward_risk,
+    )
+
+
 @mcp.tool(
     name="get_forecast",
     description=(
         "Return precomputed TiDE forecast quantile rows for a symbol. "
-        "By default returns only the latest forecast start_date. "
+        "By default returns only the latest forecast start_date "
+        "(NOT a full chart with backtests — use get_chart_data / plot_chart). "
         "Optional start_date (YYYY-MM-DD) returns forecasts from that date onward."
     ),
 )
@@ -133,7 +186,8 @@ def scan_forecasts(
     name="get_close_price",
     description=(
         "Historical close prices for a symbol via MCP (optional ISO date range). "
-        "Not a filesystem or local-database API."
+        "Prices only — for a full chart with forecast/backtest overlays call "
+        "get_chart_data or plot_chart instead."
     ),
 )
 def get_close_price(
@@ -144,33 +198,6 @@ def get_close_price(
 ) -> dict[str, Any]:
     return prices.get_close_price_impl(
         symbol=symbol, start=start, end=end, row_limit=row_limit
-    )
-
-
-@mcp.tool(
-    name="get_chart_data",
-    description=(
-        "ONE-SHOT dashboard Charts payload for a symbol: ~1–2y actual close line, "
-        "ALL in-window forecast overlays (monthly backtests + latest live) with "
-        "median + low/high confidence band, reward/risk rows, and plot_hints. "
-        "Client recipe: plot actual.dates/close solid; for EACH forecasts[] entry "
-        "plot median dashed and fill low–high — do not filter to latest only; "
-        "no other tools needed for the default chart. "
-        "confidence: 80/95/99 (default 80 → low quantile 0.2, high 0.95). "
-        "history_years: default 2. Read-only MCP data (no torch)."
-    ),
-)
-def get_chart_data(
-    symbol: str,
-    confidence: int = 80,
-    history_years: float = 2.0,
-    include_reward_risk: bool = True,
-) -> dict[str, Any]:
-    return charts.get_chart_data_impl(
-        symbol=symbol,
-        confidence=confidence,
-        history_years=history_years,
-        include_reward_risk=include_reward_risk,
     )
 
 

--- a/src/canswim/mcp/tools/charts.py
+++ b/src/canswim/mcp/tools/charts.py
@@ -12,6 +12,37 @@ from canswim.db import (
 from canswim.mcp.tools._common import ensure_db_ready, err_result, ok_result, resolve_db_path
 
 
+def _coerce_confidence(confidence: Any) -> int:
+    try:
+        return int(confidence)
+    except (TypeError, ValueError):
+        raise ValueError(
+            f"confidence must be one of {sorted(CHART_CONFIDENCE_TO_LOW_QUANTILE)}"
+        ) from None
+
+
+def _coerce_history_years(history_years: Any) -> float:
+    try:
+        return float(history_years)
+    except (TypeError, ValueError) as e:
+        raise ValueError("history_years must be a positive number") from e
+
+
+def _coerce_bool(value: Any, default: bool = True) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    s = str(value).strip().lower()
+    if s in {"1", "true", "yes", "on"}:
+        return True
+    if s in {"0", "false", "no", "off"}:
+        return False
+    return default
+
+
 def get_chart_data_impl(
     symbol: str,
     confidence: int = 80,
@@ -24,7 +55,13 @@ def get_chart_data_impl(
         return err_result(msg)
     if not symbol or not str(symbol).strip():
         return err_result("symbol is required")
-    if confidence not in CHART_CONFIDENCE_TO_LOW_QUANTILE:
+    try:
+        conf = _coerce_confidence(confidence)
+        hy = _coerce_history_years(history_years)
+        include_rr = _coerce_bool(include_reward_risk, default=True)
+    except ValueError as e:
+        return err_result(str(e))
+    if conf not in CHART_CONFIDENCE_TO_LOW_QUANTILE:
         return err_result(
             f"confidence must be one of {sorted(CHART_CONFIDENCE_TO_LOW_QUANTILE)}"
         )
@@ -33,10 +70,13 @@ def get_chart_data_impl(
         payload = get_chart_data(
             db_path,
             symbol=str(symbol).strip().upper(),
-            confidence=int(confidence),
-            history_years=history_years,
-            include_reward_risk=bool(include_reward_risk),
+            confidence=conf,
+            history_years=hy,
+            include_reward_risk=include_rr,
         )
+        # Explicit for clients that only skim the top of the response
+        payload["tool"] = "get_chart_data"
+        payload["available"] = True
         return ok_result(payload)
     except ValueError as e:
         return err_result(str(e))

--- a/src/canswim/mcp/tools/meta.py
+++ b/src/canswim/mcp/tools/meta.py
@@ -11,15 +11,17 @@ from canswim.run_triggers import runs_allowed
 
 
 # Always-registered tools (read path + start-date preview + job status)
+# get_chart_data / plot_chart listed early so connectors surface the chart tool.
 READ_TOOL_NAMES = [
     "health_check",
     "get_server_info",
     "list_tickers",
+    "get_chart_data",
+    "plot_chart",
+    "get_close_price",
     "get_forecast",
     "get_reward_risk",
     "scan_forecasts",
-    "get_close_price",
-    "get_chart_data",
     "get_backtest_error",
     "get_db_schema",
     "run_select",
@@ -42,9 +44,26 @@ CLIENT_ACCESS_BOUNDARY = (
     "All CANSWIM data is available only through this MCP server's tools. "
     "There is no client-accessible database file, no local DuckDB path, and no "
     "host filesystem for the remote client. Prefer purpose-built tools "
-    "(get_chart_data, get_forecast, get_close_price, …). Optional analytics: "
-    "get_db_schema + run_select only — still via MCP, never a separate DB connection."
+    "(get_chart_data / plot_chart, get_forecast, get_close_price, …). Optional "
+    "analytics: get_db_schema + run_select only — still via MCP, never a "
+    "separate DB connection."
 )
+
+CHART_GUIDANCE = {
+    "primary_tools": ["get_chart_data", "plot_chart"],
+    "alias_note": "plot_chart is the same as get_chart_data (same arguments and payload).",
+    "call": "get_chart_data(symbol) or plot_chart(symbol) — only symbol is required.",
+    "do_not": (
+        "Do not claim get_chart_data/plot_chart is unavailable if it appears in "
+        "tools/list or get_server_info.tools. Call it. Do not stitch "
+        "get_close_price + get_forecast for a dashboard chart."
+    ),
+    "fallback": (
+        "Only if tools/list truly omits both get_chart_data and plot_chart after "
+        "reconnecting the connector, use get_close_price + get_forecast "
+        "(latest only) — and say that backtest overlays are incomplete."
+    ),
+}
 
 
 def health_check_impl() -> dict[str, Any]:
@@ -87,13 +106,15 @@ def get_server_info_impl() -> dict[str, Any]:
             "access": CLIENT_ACCESS_BOUNDARY,
             "model": (
                 "TiDE precomputed forecasts via MCP read tools only. "
-                "Charts: prefer get_chart_data (one-shot). "
-                "Optional analytics: get_db_schema + run_select (SELECT/WITH only "
-                "through MCP — not a client-side database). "
+                "Charts: ALWAYS call get_chart_data or plot_chart (one-shot; "
+                "includes backtests). Do not use get_close_price+get_forecast "
+                "for full charts. Optional analytics: get_db_schema + run_select "
+                "(SELECT/WITH only through MCP — not a client-side database). "
                 "Write tools gather_tickers/forecast_tickers/refresh_tickers/"
                 "refresh_job_start require MCP_ALLOW_RUNS=1 on the server. "
                 "Prefer refresh_tickers + refresh_job_status for long refreshes."
             ),
+            "chart_guidance": CHART_GUIDANCE,
             "refresh_guidance": {
                 "preferred_tools": [
                     "refresh_tickers",

--- a/tests/canswim/test_mcp_chart_data.py
+++ b/tests/canswim/test_mcp_chart_data.py
@@ -224,13 +224,29 @@ def test_get_chart_data_registered_on_server_and_server_info(chart_env):
     tm = getattr(srv.mcp, "_tool_manager", None)
     assert tm is not None
     assert "get_chart_data" in tm._tools
+    assert "plot_chart" in tm._tools
     assert "get_chart_data" in TOOL_NAMES
     assert "get_chart_data" in READ_TOOL_NAMES
+    assert "plot_chart" in READ_TOOL_NAMES
 
     info = meta.get_server_info_impl()
     assert info["ok"] is True
     assert "get_chart_data" in info["data"]["tools"]
+    assert "plot_chart" in info["data"]["tools"]
     assert "get_chart_data" in info["data"]["read_tools"]
+    # Description must assert availability (counters SuperGrok "unavailable" claim)
+    desc = tm._tools["get_chart_data"].description or ""
+    assert "PRIMARY" in desc or "AVAILABLE" in desc
+
+
+def test_plot_chart_alias_same_payload(chart_env):
+    from canswim.mcp import server as srv
+
+    a = charts.get_chart_data_impl(symbol="TSM")
+    b = srv.plot_chart(symbol="TSM")
+    assert a["ok"] and b["ok"]
+    assert a["data"]["coverage"] == b["data"]["coverage"]
+    assert len(a["data"]["forecasts"]) == len(b["data"]["forecasts"])
 
 
 def test_get_chart_data_server_entrypoint_one_shot(chart_env):

--- a/tests/canswim/test_mcp_tools.py
+++ b/tests/canswim/test_mcp_tools.py
@@ -72,6 +72,7 @@ def test_tool_names_cover_surface():
         "scan_forecasts",
         "get_close_price",
         "get_chart_data",
+        "plot_chart",
         "get_backtest_error",
         "get_db_schema",
         "run_select",
@@ -93,6 +94,7 @@ def test_tool_names_cover_surface():
     assert "refresh_job_status" in READ_TOOL_NAMES
     assert "get_db_schema" in READ_TOOL_NAMES
     assert "get_chart_data" in READ_TOOL_NAMES
+    assert "plot_chart" in READ_TOOL_NAMES
 
 
 def test_health_and_info(mcp_env, monkeypatch):
@@ -119,6 +121,10 @@ def test_health_and_info(mcp_env, monkeypatch):
     assert "only" in access
     assert "duckdb" in access  # explicit: no client DuckDB access
     assert "no client" in access or "not" in access
+    cg = info["data"].get("chart_guidance") or {}
+    assert "get_chart_data" in (cg.get("primary_tools") or [])
+    assert "plot_chart" in (cg.get("primary_tools") or [])
+    assert "do not claim" in (cg.get("do_not") or "").lower()
 
 
 def test_schema_and_select_omit_host_paths(mcp_env):


### PR DESCRIPTION
## Summary
- SuperGrok still claimed `get_chart_data` unavailable → used `get_close_price` + `get_forecast` (no backtests).
- **`plot_chart`** alias (same as `get_chart_data`); descriptions assert **PRIMARY / AVAILABLE**.
- **`chart_guidance`** on `get_server_info`; `get_forecast`/`get_close_price` redirect to chart tools.
- **Version `0.0.20260721`** so clients rediscover tools after MCP restart.

## Test plan
- [x] Local CI 262 passed
- [x] Tests: plot_chart registered, alias payload, chart_guidance, tool-name set
- [ ] Remote CI green → merge → restart canswim-mcp