### PR TITLE
fix(mcp): SuperGrok chart CallTool prefix + as_chart (0.0.20260722)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable releases are documented here. Versioning follows date-style `0.0.YYYYMMDD` unless noted.
 
+## 0.0.20260722
+
+SuperGrok called `canswim___get_chart_data` and got **Unknown tool** (connector prefix not stripped), then fell back to incomplete charts.
+
+### Highlights
+
+- **Connector prefix aliases** — CallTool names `canswim___…` / `canswim/…` resolve to bare tool names
+- **`get_forecast(as_chart=true)`** and **`get_close_price(as_chart=true)`** return the same full chart payload as `get_chart_data` (works when chart tools are missing from a stale connector list)
+- `chart_guidance` documents the as_chart fallback
+
+### Install
+
+```bash
+pip install canswim==0.0.20260722
+```
+
 ## 0.0.20260721
 
 SuperGrok kept claiming `get_chart_data` was unavailable and fell back to `get_close_price` + `get_forecast` (latest-only, no backtests).

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -127,7 +127,7 @@ Canonical registration: `src/canswim/mcp/server.py`. Update this table in the **
 3. For **each** entry in `data.forecasts` (monthly backtests + latest live): plot `median` **dashed** and **fill** between `low` and `high`. Do **not** drop to latest-only.
 4. Optional table: `data.reward_risk`.
 
-**Do not** use `get_close_price` + `get_forecast` for a full chart (that is latest-only and omits backtests). See `get_server_info.chart_guidance`. Restart `canswim-mcp` after deploy so clients rediscover tools (version bump).
+**Do not** use raw `get_close_price` rows + latest-only `get_forecast` for a full chart. If `get_chart_data` / `plot_chart` are missing from the connector list, call **`get_forecast(symbol, as_chart=true)`** or **`get_close_price(symbol, as_chart=true)`** (same full payload). The server also accepts connector-prefixed names like `canswim___get_chart_data`. See `get_server_info.chart_guidance`. Restart `canswim-mcp` after deploy so clients rediscover tools (version bump).
 
 ### Async refresh (default — SuperGrok / short tool timeouts)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = canswim
-version = 0.0.20260721
+version = 0.0.20260722
 author = Ivelin Ivanov
 author_email = ivelin117@gmail.com
 description = Developer toolkit for CANSLIM-style investors (CLI, Gradio GUI, MCP)

--- a/src/canswim/mcp/server.py
+++ b/src/canswim/mcp/server.py
@@ -128,10 +128,12 @@ def plot_chart(
 @mcp.tool(
     name="get_forecast",
     description=(
-        "Return precomputed TiDE forecast quantile rows for a symbol. "
-        "By default returns only the latest forecast start_date "
-        "(NOT a full chart with backtests — use get_chart_data / plot_chart). "
-        "Optional start_date (YYYY-MM-DD) returns forecasts from that date onward."
+        "Forecast data for a symbol. "
+        "Default: latest-only quantile rows. "
+        "Set as_chart=true for the FULL dashboard chart payload (actual closes + "
+        "all in-window backtest/live forecast overlays) — same as get_chart_data. "
+        "Prefer as_chart=true (or get_chart_data/plot_chart) for plots; "
+        "do not stitch get_close_price + latest-only forecasts for full charts."
     ),
 )
 def get_forecast(
@@ -139,12 +141,18 @@ def get_forecast(
     start_date: Optional[str] = None,
     latest_only: bool = True,
     row_limit: int = 5000,
+    as_chart: bool = False,
+    confidence: int = 80,
+    history_years: float = 2.0,
 ) -> dict[str, Any]:
     return forecasts.get_forecast_impl(
         symbol=symbol,
         start_date=start_date,
         latest_only=latest_only,
         row_limit=row_limit,
+        as_chart=as_chart,
+        confidence=confidence,
+        history_years=history_years,
     )
 
 
@@ -186,8 +194,8 @@ def scan_forecasts(
     name="get_close_price",
     description=(
         "Historical close prices for a symbol via MCP (optional ISO date range). "
-        "Prices only — for a full chart with forecast/backtest overlays call "
-        "get_chart_data or plot_chart instead."
+        "Prices only by default. Set as_chart=true for the FULL dashboard chart "
+        "payload (same as get_chart_data / plot_chart), including backtest overlays."
     ),
 )
 def get_close_price(
@@ -195,9 +203,18 @@ def get_close_price(
     start: Optional[str] = None,
     end: Optional[str] = None,
     row_limit: int = 5000,
+    as_chart: bool = False,
+    confidence: int = 80,
+    history_years: float = 2.0,
 ) -> dict[str, Any]:
     return prices.get_close_price_impl(
-        symbol=symbol, start=start, end=end, row_limit=row_limit
+        symbol=symbol,
+        start=start,
+        end=end,
+        row_limit=row_limit,
+        as_chart=as_chart,
+        confidence=confidence,
+        history_years=history_years,
     )
 
 
@@ -403,6 +420,47 @@ def refresh_job_start(
 )
 def refresh_job_status(job_id: str) -> dict[str, Any]:
     return job_tools.refresh_job_status_impl(job_id=job_id)
+
+
+# SuperGrok / connector clients often send CallTool names as
+# ``canswim___get_chart_data`` (server prefix not stripped). Bare names work;
+# prefixed names used to fail with "Unknown tool". Resolve by stripping known
+# connector prefixes before tool lookup.
+_CONNECTOR_TOOL_PREFIXES = (
+    "canswim___",
+    "canswim/",
+    "canswim_",
+    "canswim-",
+)
+
+
+def _install_connector_tool_name_aliases(server: FastMCP) -> None:
+    tm = server._tool_manager
+    orig_get = tm.get_tool
+
+    def get_tool(name: str):  # type: ignore[no-untyped-def]
+        tool = orig_get(name)
+        if tool is not None:
+            return tool
+        raw = str(name or "")
+        for prefix in _CONNECTOR_TOOL_PREFIXES:
+            if raw.startswith(prefix):
+                bare = raw[len(prefix) :]
+                if bare:
+                    tool = orig_get(bare)
+                    if tool is not None:
+                        logger.info(
+                            "MCP tool name alias: {!r} → {!r}",
+                            raw,
+                            bare,
+                        )
+                        return tool
+        return None
+
+    tm.get_tool = get_tool  # type: ignore[method-assign]
+
+
+_install_connector_tool_name_aliases(mcp)
 
 
 def _resolve_transport(

--- a/src/canswim/mcp/tools/forecasts.py
+++ b/src/canswim/mcp/tools/forecasts.py
@@ -20,7 +20,20 @@ def get_forecast_impl(
     start_date: Optional[str] = None,
     latest_only: bool = True,
     row_limit: int = 5000,
+    as_chart: bool = False,
+    confidence: int = 80,
+    history_years: float = 2.0,
 ) -> dict[str, Any]:
+    # SuperGrok fallback path when get_chart_data is missing from connector list
+    if as_chart:
+        from canswim.mcp.tools.charts import get_chart_data_impl
+
+        return get_chart_data_impl(
+            symbol=symbol,
+            confidence=confidence,
+            history_years=history_years,
+            include_reward_risk=True,
+        )
     ready, msg = ensure_db_ready()
     if not ready:
         return err_result(msg)

--- a/src/canswim/mcp/tools/meta.py
+++ b/src/canswim/mcp/tools/meta.py
@@ -51,17 +51,24 @@ CLIENT_ACCESS_BOUNDARY = (
 
 CHART_GUIDANCE = {
     "primary_tools": ["get_chart_data", "plot_chart"],
-    "alias_note": "plot_chart is the same as get_chart_data (same arguments and payload).",
-    "call": "get_chart_data(symbol) or plot_chart(symbol) — only symbol is required.",
+    "alias_note": (
+        "plot_chart ≡ get_chart_data. Server also accepts connector-prefixed "
+        "names (canswim___get_chart_data) by stripping the prefix."
+    ),
+    "call": (
+        "get_chart_data(symbol) or plot_chart(symbol). "
+        "If the connector rejects those names, call get_forecast(symbol, as_chart=true) "
+        "or get_close_price(symbol, as_chart=true) — same full chart payload."
+    ),
     "do_not": (
-        "Do not claim get_chart_data/plot_chart is unavailable if it appears in "
-        "tools/list or get_server_info.tools. Call it. Do not stitch "
-        "get_close_price + get_forecast for a dashboard chart."
+        "Do not claim get_chart_data is unavailable without trying as_chart=true "
+        "on get_forecast/get_close_price. Do not stitch raw get_close_price rows "
+        "with latest-only get_forecast for a dashboard chart."
     ),
     "fallback": (
-        "Only if tools/list truly omits both get_chart_data and plot_chart after "
-        "reconnecting the connector, use get_close_price + get_forecast "
-        "(latest only) — and say that backtest overlays are incomplete."
+        "get_forecast(symbol, as_chart=true) or get_close_price(symbol, as_chart=true). "
+        "Only if as_chart also fails, use latest-only rows and state that "
+        "backtest overlays are incomplete."
     ),
 }
 

--- a/src/canswim/mcp/tools/prices.py
+++ b/src/canswim/mcp/tools/prices.py
@@ -13,7 +13,20 @@ def get_close_price_impl(
     start: Optional[str] = None,
     end: Optional[str] = None,
     row_limit: int = 5000,
+    as_chart: bool = False,
+    confidence: int = 80,
+    history_years: float = 2.0,
 ) -> dict[str, Any]:
+    # SuperGrok fallback when chart tools are missing from connector list
+    if as_chart:
+        from canswim.mcp.tools.charts import get_chart_data_impl
+
+        return get_chart_data_impl(
+            symbol=symbol,
+            confidence=confidence,
+            history_years=history_years,
+            include_reward_risk=True,
+        )
     ready, msg = ensure_db_ready()
     if not ready:
         return err_result(msg)

--- a/tests/canswim/test_mcp_chart_data.py
+++ b/tests/canswim/test_mcp_chart_data.py
@@ -249,6 +249,40 @@ def test_plot_chart_alias_same_payload(chart_env):
     assert len(a["data"]["forecasts"]) == len(b["data"]["forecasts"])
 
 
+def test_connector_prefixed_tool_name_resolves(chart_env):
+    """SuperGrok sends canswim___get_chart_data; server must not Unknown tool."""
+    import asyncio
+
+    from canswim.mcp import server as srv
+
+    async def _call(name: str):
+        return await srv.mcp._tool_manager.call_tool(
+            name, {"symbol": "TSM"}, convert_result=False
+        )
+
+    bare = asyncio.run(_call("get_chart_data"))
+    pref = asyncio.run(_call("canswim___get_chart_data"))
+    slash = asyncio.run(_call("canswim/get_chart_data"))
+    # Tool.run returns the function result (dict envelope)
+    for out in (bare, pref, slash):
+        assert isinstance(out, dict)
+        assert out.get("ok") is True
+        assert out["data"]["coverage"]["forecast_start_count"] == 3
+
+
+def test_get_forecast_as_chart_and_get_close_as_chart(chart_env):
+    from canswim.mcp.tools import forecasts, prices
+
+    fc = forecasts.get_forecast_impl(symbol="TSM", as_chart=True)
+    assert fc["ok"] is True
+    assert fc["data"]["coverage"]["backtest_count"] == 2
+    assert len(fc["data"]["forecasts"]) == 3
+
+    cl = prices.get_close_price_impl(symbol="TSM", as_chart=True)
+    assert cl["ok"] is True
+    assert cl["data"]["coverage"]["live_count"] == 1
+
+
 def test_get_chart_data_server_entrypoint_one_shot(chart_env):
     """End-to-end client perspective: call registered server tool with only symbol."""
     from canswim.mcp import server as srv


### PR DESCRIPTION
## Root cause
SuperGrok calls tools as `canswim___get_chart_data`. Server registered only `get_chart_data` → **Unknown tool**. Client then used incomplete get_close_price + get_forecast.

## Fix
- Strip connector prefixes (`canswim___`, `canswim/`, …) on CallTool lookup
- `get_forecast(as_chart=true)` / `get_close_price(as_chart=true)` → full `get_chart_data` payload
- Version **0.0.20260722**

## Test plan
- [x] Prefixed CallTool resolves
- [x] as_chart paths return multi-origin overlays
- [x] Local CI 264 passed
- [ ] Remote CI → merge → restart canswim-mcp