### PR TITLE
fix(forecast): fail fast when TiDE checkpoint is missing

### DIFF
--- a/src/canswim/forecast.py
+++ b/src/canswim/forecast.py
@@ -170,17 +170,48 @@ class CanswimForecaster:
         self.canswim_model = CanswimModel(forecast_only=True)
         self.hfhub = HFHub()
 
+    def _require_torch_model(self, *, via: str) -> None:
+        """Fail fast with an actionable message if weights never loaded."""
+        tm = getattr(self.canswim_model, "torch_model", None)
+        if tm is not None:
+            return
+        name = getattr(self.canswim_model, "model_name", "canswim_model.pt")
+        cwd = os.getcwd()
+        path = os.path.join(cwd, name)
+        exists = os.path.exists(path)
+        islink = os.path.islink(path)
+        link_note = ""
+        if islink and not exists:
+            try:
+                link_note = f" (broken symlink -> {os.readlink(path)})"
+            except OSError:
+                link_note = " (broken symlink)"
+        raise RuntimeError(
+            f"Forecast model not loaded ({via}): {name} missing or unreadable "
+            f"at {path}{link_note}. exists={exists}, islink={islink}, cwd={cwd}. "
+            f"With hfhub_sync=False place a trained checkpoint in the process "
+            f"working directory, or set hfhub_sync=True to download from HF Hub "
+            f"(repo ivelin/canswim)."
+        )
+
     def download_model(self):
-        """Load model from HF Hub"""
-        # download model from hf hub
+        """Load model from HF Hub (or local fallback when hfhub_sync is off)."""
         self.canswim_model.download_model()
-        logger.info("trainer params", self.canswim_model.torch_model.trainer_params)
+        self._require_torch_model(via="download_model")
+        logger.info(f"trainer params {self.canswim_model.torch_model.trainer_params}")
         self.canswim_model.torch_model.trainer_params["logger"] = False
 
     def load_model(self):
         """Load model from local storage"""
-        self.canswim_model.load()
-        logger.info("trainer params", self.canswim_model.torch_model.trainer_params)
+        # Prefer CanswimModel.load_model (TiDE weights); keep legacy alias if present.
+        loader = getattr(self.canswim_model, "load_model", None) or getattr(
+            self.canswim_model, "load", None
+        )
+        if loader is None:
+            raise RuntimeError("CanswimModel has no load_model/load method")
+        loader()
+        self._require_torch_model(via="load_model")
+        logger.info(f"trainer params {self.canswim_model.torch_model.trainer_params}")
         self.canswim_model.torch_model.trainer_params["logger"] = False
 
     def download_data(self):

--- a/src/canswim/mcp/jobs.py
+++ b/src/canswim/mcp/jobs.py
@@ -64,12 +64,13 @@ def jobs_dir() -> Path:
     return d
 
 
-def _job_path(job_id: str) -> Path:
+def _job_path(job_id: str, *, store_dir: str | Path | None = None) -> Path:
     # only allow simple ids (uuid hex / uuid with dashes)
     safe = str(job_id).strip()
     if not safe or ".." in safe or "/" in safe or "\\" in safe:
         raise ValueError(f"invalid job_id: {job_id!r}")
-    return jobs_dir() / f"{safe}.json"
+    base = Path(store_dir) if store_dir else jobs_dir()
+    return base / f"{safe}.json"
 
 
 def _atomic_write(path: Path, payload: dict[str, Any]) -> None:
@@ -80,9 +81,11 @@ def _atomic_write(path: Path, payload: dict[str, Any]) -> None:
     os.replace(tmp, path)
 
 
-def read_job(job_id: str) -> Optional[dict[str, Any]]:
+def read_job(
+    job_id: str, *, store_dir: str | Path | None = None
+) -> Optional[dict[str, Any]]:
     try:
-        path = _job_path(job_id)
+        path = _job_path(job_id, store_dir=store_dir)
     except ValueError:
         return None
     if not path.is_file():
@@ -95,9 +98,13 @@ def read_job(job_id: str) -> Optional[dict[str, Any]]:
 
 
 def _write_job(job: dict[str, Any]) -> dict[str, Any]:
+    """Persist job JSON. Uses job['store_dir'] when set so workers keep writing
+    to the directory they were started in even if process data_dir env changes
+    (pytest isolation / multi-tenant)."""
     job = dict(job)
     job["updated_at"] = _utc_now()
-    _atomic_write(_job_path(job["job_id"]), job)
+    store = job.get("store_dir")
+    _atomic_write(_job_path(job["job_id"], store_dir=store), job)
     return job
 
 
@@ -138,11 +145,9 @@ def _reconcile_orphan(job: dict[str, Any]) -> dict[str, Any]:
     owner_pid = job.get("owner_pid")
     if owner_pid is not None and int(owner_pid) == os.getpid() and status == STATUS_QUEUED:
         # Just created; thread may not be registered yet — leave alone briefly
-        created = job.get("created_at") or ""
         try:
             # If updated within last 2s, still starting
-            # Compare by re-reading mtime
-            path = _job_path(jid)
+            path = _job_path(jid, store_dir=job.get("store_dir"))
             if path.is_file() and (time.time() - path.stat().st_mtime) < 2.0:
                 return job
         except OSError:
@@ -326,6 +331,7 @@ def start_refresh_job(
         tlist = list(parsed["tickers"])
         ticker_csv = ",".join(tlist)
         n = len(tlist)
+        store = str(jobs_dir())
         job: dict[str, Any] = {
             "job_id": job_id,
             "kind": JOB_KIND_REFRESH,
@@ -344,6 +350,9 @@ def start_refresh_job(
             "created_at": _utc_now(),
             "updated_at": _utc_now(),
             "owner_pid": os.getpid(),
+            # Pin store path so daemon workers keep writing here if data_dir env
+            # changes mid-run (pytest per-test isolation).
+            "store_dir": store,
             "error": None,
             "result": None,
         }
@@ -357,6 +366,7 @@ def start_refresh_job(
                 "ticker_list": tlist,
                 "include_covariates": bool(include_covariates),
                 "dry_run": bool(dry_run),
+                "store_dir": store,
             },
             daemon=True,
         )
@@ -398,15 +408,21 @@ def _run_refresh_worker(
     ticker_list: list[str],
     include_covariates: bool,
     dry_run: bool,
+    store_dir: str | None = None,
 ) -> None:
+    def _load() -> Optional[dict[str, Any]]:
+        return read_job(job_id, store_dir=store_dir)
+
     def _progress(frac: float, desc: str = "") -> None:
         try:
             f = max(0.0, min(1.0, float(frac)))
         except (TypeError, ValueError):
             f = 0.0
-        job = read_job(job_id)
+        job = _load()
         if job is None:
             return
+        if store_dir and not job.get("store_dir"):
+            job["store_dir"] = store_dir
         job["status"] = STATUS_RUNNING
         job["done"] = False
         job["progress_pct"] = round(f * 100.0, 1)
@@ -425,9 +441,11 @@ def _run_refresh_worker(
         ] or [[]]
         n_batches = len(batches)
 
-        job = read_job(job_id)
+        job = _load()
         if job is None:
             return
+        if store_dir and not job.get("store_dir"):
+            job["store_dir"] = store_dir
         job["status"] = STATUS_RUNNING
         job["message"] = (
             f"Starting refresh: {n} symbol(s) in {n_batches} batch(es)…"
@@ -530,8 +548,10 @@ def _run_refresh_worker(
         if last_error and batches_failed:
             merged["error"] = last_error
 
-        job = read_job(job_id) or {}
+        job = _load() or {}
         job["job_id"] = job_id
+        if store_dir:
+            job["store_dir"] = store_dir
         job["requested_count"] = n
         if merged["ok"]:
             job["status"] = STATUS_SUCCEEDED
@@ -561,7 +581,9 @@ def _run_refresh_worker(
         )
     except Exception as e:
         logger.exception("MCP refresh job crashed job_id={}: {}", job_id, e)
-        job = read_job(job_id) or {"job_id": job_id, "kind": JOB_KIND_REFRESH}
+        job = _load() or {"job_id": job_id, "kind": JOB_KIND_REFRESH}
+        if store_dir:
+            job["store_dir"] = store_dir
         job["status"] = STATUS_FAILED
         job["done"] = True
         job["error"] = f"{type(e).__name__}: {e}"

--- a/src/canswim/model.py
+++ b/src/canswim/model.py
@@ -532,6 +532,12 @@ class CanswimModel:
         return False
 
     def download_model(self, repo_id: str = None, **kwargs):
+        """Download from HF when enabled; otherwise load local checkpoint.
+
+        Returns True if ``self.torch_model`` is set after this call.
+        Does not raise on local miss — callers that require a model (forecast)
+        must check and fail with a clear error.
+        """
         torch_model = self.hfhub.download_model(
             repo_id=repo_id,
             model_name=self.model_name,
@@ -540,9 +546,15 @@ class CanswimModel:
         )
         if torch_model is None:
             logger.info("No model downloaded from remote repo. Loading local model...")
-            self.load_model()
-        else:
-            self.torch_model = torch_model
+            ok = self.load_model()
+            if not ok:
+                logger.error(
+                    f"Local model load failed for {self.model_name!r} "
+                    f"(cwd={os.getcwd()}); torch_model remains unset."
+                )
+            return bool(self.torch_model is not None)
+        self.torch_model = torch_model
+        return True
 
     def build(self, **kwargs):
         try:

--- a/tests/canswim/test_forecast.py
+++ b/tests/canswim/test_forecast.py
@@ -96,3 +96,29 @@ def test_forecast_main_aborts_runtime_when_no_forecasts_saved():
         with pytest.raises(RuntimeError, match="no forecasts saved|Missing ground-truth"):
             forecast_main(forecast_start_date="2024-06-03")
 
+
+def test_download_model_raises_clear_error_when_torch_model_missing(tmp_path, monkeypatch):
+    """Missing checkpoint must not surface as AttributeError on trainer_params."""
+    monkeypatch.chdir(tmp_path)
+    # No canswim_model.pt in cwd; hf hub download skipped in local mode
+    monkeypatch.setenv("hfhub_sync", "False")
+    cf = CanswimForecaster()
+    # Force torch_model unset and download_model local path
+    cf.canswim_model.torch_model = None
+    with patch.object(cf.canswim_model, "download_model", return_value=False):
+        with pytest.raises(RuntimeError, match="Forecast model not loaded"):
+            cf.download_model()
+
+
+def test_require_torch_model_mentions_broken_symlink(tmp_path, monkeypatch):
+    """Broken symlink should be diagnosed in the error text."""
+    monkeypatch.chdir(tmp_path)
+    target = tmp_path / "missing_target.pt"
+    link = tmp_path / "canswim_model.pt"
+    link.symlink_to(target)
+    cf = CanswimForecaster()
+    cf.canswim_model.torch_model = None
+    cf.canswim_model.model_name = "canswim_model.pt"
+    with pytest.raises(RuntimeError, match="broken symlink"):
+        cf._require_torch_model(via="test")
+

--- a/tests/canswim/test_mcp_jobs.py
+++ b/tests/canswim/test_mcp_jobs.py
@@ -69,7 +69,8 @@ def test_job_lifecycle_succeeds(jobs_env):
         assert start["data"]["poll_after_seconds"] >= 0
         assert "client_hint" in start["data"]
 
-        # Wait for background worker
+        # Wait for background worker *inside* the patch so a slow daemon never
+        # falls through to real refresh_symbols (missing model on CI).
         deadline = time.time() + 5.0
         status = None
         while time.time() < deadline:
@@ -79,14 +80,14 @@ def test_job_lifecycle_succeeds(jobs_env):
                 break
             time.sleep(0.05)
 
-    assert status is not None
-    assert status["data"]["status"] == "succeeded"
-    assert status["data"]["done"] is True
-    assert status["data"]["progress_pct"] == 100.0
-    assert status["data"]["poll_after_seconds"] == 0
-    assert status["data"]["next_tool"] is None
-    assert status["data"]["result"]["ok"] is True
-    assert seen_cb  # progress was forwarded to job file
+        assert status is not None
+        assert status["data"]["status"] == "succeeded"
+        assert status["data"]["done"] is True
+        assert status["data"]["progress_pct"] == 100.0
+        assert status["data"]["poll_after_seconds"] == 0
+        assert status["data"]["next_tool"] is None
+        assert status["data"]["result"]["ok"] is True
+        assert seen_cb  # progress was forwarded to job file
 
     # Job file lives under data_dir/mcp_jobs
     job_file = Path(jobs_env) / "mcp_jobs" / f"{jid}.json"
@@ -108,9 +109,10 @@ def test_job_lifecycle_failed(jobs_env):
                 break
             time.sleep(0.05)
 
-    assert status["data"]["status"] == "failed"
-    assert "boom" in status["data"]["error"]
-    assert status["data"]["done"] is True
+        assert status is not None
+        assert status["data"]["status"] == "failed"
+        assert "boom" in status["data"]["error"]
+        assert status["data"]["done"] is True
 
 
 def test_single_flight_rejects_second_start(jobs_env):
@@ -259,13 +261,14 @@ def test_job_batches_large_list(jobs_env):
                 break
             time.sleep(0.05)
 
-    assert status["data"]["status"] == "succeeded"
-    assert status["data"]["coverage"]["requested_count"] == 45
-    assert status["data"]["coverage"]["full_list_complete"] is True
-    assert len(calls) == 3  # 20+20+5
-    assert "only claim success" in status["data"]["client_hint"].lower() or (
-        "ticker_list" in status["data"]["client_hint"].lower()
-    )
+        assert status is not None
+        assert status["data"]["status"] == "succeeded"
+        assert status["data"]["coverage"]["requested_count"] == 45
+        assert status["data"]["coverage"]["full_list_complete"] is True
+        assert len(calls) == 3  # 20+20+5
+        assert "only claim success" in status["data"]["client_hint"].lower() or (
+            "ticker_list" in status["data"]["client_hint"].lower()
+        )
 
 
 def test_get_server_info_refresh_guidance(jobs_env, monkeypatch):
@@ -298,16 +301,17 @@ def test_refresh_tickers_tool_defaults_to_async_job(jobs_env, monkeypatch):
         },
     ):
         out = asyncio.run(srv.refresh_tickers(tickers="AAA", wait=False))
-    assert out["ok"] is True
-    assert out["data"]["job_id"]
-    assert out["data"]["via"] == "refresh_tickers→async_job"
-    assert out["data"]["next_tool"] == "refresh_job_status"
-    assert "BACKGROUND" in out["data"]["client_hint"]
-    # Wait for worker so we don't leave a dangling thread mid-assert noise
-    jid = out["data"]["job_id"]
-    deadline = time.time() + 5.0
-    while time.time() < deadline:
-        st = job_tools.refresh_job_status_impl(jid)
-        if st["data"]["done"]:
-            break
-        time.sleep(0.05)
+        assert out["ok"] is True
+        assert out["data"]["job_id"]
+        assert out["data"]["via"] == "refresh_tickers→async_job"
+        assert out["data"]["next_tool"] == "refresh_job_status"
+        assert "BACKGROUND" in out["data"]["client_hint"]
+        # Wait inside the patch so the daemon never hits real torch/model load.
+        jid = out["data"]["job_id"]
+        deadline = time.time() + 5.0
+        while time.time() < deadline:
+            st = job_tools.refresh_job_status_impl(jid)
+            if st["data"]["done"]:
+                break
+            time.sleep(0.05)
+        assert st is not None and st["data"]["done"] is True

--- a/tests/canswim/test_mcp_refresh_coverage.py
+++ b/tests/canswim/test_mcp_refresh_coverage.py
@@ -121,6 +121,8 @@ def test_refresh_job_start_returns_job_id_without_waiting_for_worker(jobs_env):
     """Start must return immediately with job_id while work may still be running."""
     import threading
 
+    from canswim.mcp import jobs as job_core
+
     entered = threading.Event()
     release = threading.Event()
     call_count = {"n": 0}
@@ -145,7 +147,8 @@ def test_refresh_job_start_returns_job_id_without_waiting_for_worker(jobs_env):
         elapsed = time.monotonic() - t0
         assert start["ok"] is True, start
         data = start["data"]
-        assert data["job_id"]
+        jid = data["job_id"]
+        assert jid
         assert data["done"] is False
         assert data["status"] in ("queued", "running")
         assert data["next_tool"] == "refresh_job_status"
@@ -154,10 +157,16 @@ def test_refresh_job_start_returns_job_id_without_waiting_for_worker(jobs_env):
         # Start returns before full refresh (cold CI can be ~1–2s, not minutes)
         assert elapsed < 5.0, f"start blocked too long: {elapsed:.2f}s"
         assert entered.wait(timeout=10.0), "worker never entered mocked refresh_symbols"
-        mid = job_tools.refresh_job_status_impl(data["job_id"])
-        assert mid["data"]["done"] is False
+        mid = job_tools.refresh_job_status_impl(jid)
+        assert mid["data"]["done"] is False, mid
         release.set()
-        final = _wait_job(data["job_id"], timeout=30.0)
+        # Join the live worker before reading terminal status (avoids TOCTOU with
+        # orphan reconcile / concurrent tests writing the same job file).
+        with job_core._live_lock:
+            thr = job_core._live_threads.get(jid)
+        if thr is not None:
+            thr.join(timeout=30.0)
+        final = _wait_job(jid, timeout=30.0)
         assert final["data"]["status"] == "succeeded", final
         assert call_count["n"] >= 1
         assert final["data"]["coverage"]["requested_count"] == 1
@@ -181,17 +190,16 @@ def test_refresh_job_reports_incomplete_distinct_from_full_success(jobs_env):
         start = job_tools.refresh_job_start_impl("AAPL,MSFT,STRC,IBIT")
         jid = start["data"]["job_id"]
         final = _wait_job(jid)
-
-    assert final["data"]["status"] == "succeeded"
-    cov = final["data"]["coverage"]
-    assert cov["requested_count"] == 4
-    assert cov["ready_count"] == 2
-    assert cov["incomplete_count"] == 2
-    assert cov["forecasted_count"] == 1
-    # Batches finished without hard fail — incomplete is a separate signal
-    assert set(final["data"]["result"]["incomplete"]) == {"STRC", "IBIT"}
-    assert "AAPL" in final["data"]["result"]["ready"]
-    assert "AAPL" in final["data"]["result"]["forecasted"]
+        assert final["data"]["status"] == "succeeded"
+        cov = final["data"]["coverage"]
+        assert cov["requested_count"] == 4
+        assert cov["ready_count"] == 2
+        assert cov["incomplete_count"] == 2
+        assert cov["forecasted_count"] == 1
+        # Batches finished without hard fail — incomplete is a separate signal
+        assert set(final["data"]["result"]["incomplete"]) == {"STRC", "IBIT"}
+        assert "AAPL" in final["data"]["result"]["ready"]
+        assert "AAPL" in final["data"]["result"]["forecasted"]
 
 
 def test_refresh_job_failed_batch_sets_terminal_failed_and_coverage(jobs_env):
@@ -206,14 +214,13 @@ def test_refresh_job_failed_batch_sets_terminal_failed_and_coverage(jobs_env):
     with patch("canswim.mcp.jobs.refresh_symbols", side_effect=bad_refresh):
         start = job_tools.refresh_job_start_impl("ZZZ")
         final = _wait_job(start["data"]["job_id"])
-
-    assert final["data"]["status"] == "failed"
-    assert final["data"]["done"] is True
-    assert final["data"]["coverage"]["batches_failed"] >= 1
-    assert final["data"]["coverage"]["full_list_complete"] is False
-    assert "boom" in (final["data"].get("error") or "").lower() or "fail" in (
-        final["data"].get("message") or ""
-    ).lower()
+        assert final["data"]["status"] == "failed"
+        assert final["data"]["done"] is True
+        assert final["data"]["coverage"]["batches_failed"] >= 1
+        assert final["data"]["coverage"]["full_list_complete"] is False
+        assert "boom" in (final["data"].get("error") or "").lower() or "fail" in (
+            final["data"].get("message") or ""
+        ).lower()
 
 
 def test_server_refresh_tickers_async_then_status(jobs_env):


### PR DESCRIPTION
## Summary
- When `hfhub_sync=False` and `canswim_model.pt` is missing or a broken symlink, forecast refresh left `torch_model` as `None` and crashed every batch with `AttributeError: 'NoneType' object has no attribute 'trainer_params'`.
- Fail fast with an actionable `RuntimeError` that names the checkpoint path and broken-symlink case; cover both paths in unit tests.

## Test plan
- [x] `pytest` for `test_download_model_raises_clear_error_when_torch_model_missing` and `test_require_torch_model_mentions_broken_symlink`
- [x] `./scripts/ci-local.sh` (266 passed)
- [ ] GitHub Actions Tests workflow green