### PR TITLE
fix(mcp): stable client error shape with fail_reason and hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable releases are documented here. Versioning follows date-style `0.0.YYYYMMDD` unless noted.
 
+## 0.0.20260727
+
+MCP clients (SuperGrok, etc.) need stable, human-readable failures with machine-readable discriminators — not bare `AttributeError` fragments.
+
+### Highlights
+
+- **Client error shape** — failures return `ok: false`, non-empty `error`, and usually `fail_reason` + `client_hint` (what failed / who acts / next step)
+- Stable codes: `invalid_input`, `db_not_ready`, `runs_disabled`, `job_unknown`, `job_busy`, `job_failed`, `model_not_loaded`, `remote_api`, …
+- **Model missing** surfaces as `fail_reason=model_not_loaded` through `forecast_tickers` / refresh jobs (not mislabeled as covariates)
+- Async job status attaches `fail_reason` on failed jobs for agent branching
+
+### Install
+
+```bash
+pip install canswim==0.0.20260727
+```
+
 ## 0.0.20260722
 
 SuperGrok called `canswim___get_chart_data` and got **Unknown tool** (connector prefix not stripped), then fell back to incomplete charts.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -118,6 +118,22 @@ Canonical registration: `src/canswim/mcp/server.py`. Update this table in the **
 | `refresh_job_start` | Explicit async start (same as `refresh_tickers` with `wait=false`) | `MCP_ALLOW_RUNS=1` |
 | `refresh_job_status` | Poll a job from `refresh_tickers` / `refresh_job_start` | — |
 
+### Error shape (client-facing)
+
+Tool results use a stable envelope:
+
+| Field | Meaning |
+|-------|---------|
+| `ok` | `true` / `false` |
+| `error` | Non-empty human string when `ok` is false — what failed and who acts (client vs operator) |
+| `fail_reason` | Machine-readable code when known (branch without scraping free text) |
+| `client_hint` | Short next-step guidance for agents (poll job, fix args, contact operator, …) |
+| `data` | Optional structured payload (partial results, coverage, parse details) |
+
+Common `fail_reason` values: `invalid_input`, `db_not_ready`, `runs_disabled`, `job_unknown`, `job_busy`, `job_failed`, `model_not_loaded`, `remote_api`. Failed async jobs also set `data.fail_reason` / `data.client_hint` on `refresh_job_status` when `status=failed`.
+
+**Do not** claim success when `ok` is false or a job `status` is still `queued`/`running`. Prefer `client_hint` over inventing recovery steps.
+
 ### One-shot chart (dashboard Charts equivalent)
 
 **`get_chart_data(symbol)`** (alias **`plot_chart`**) is the only tool needed for the Charts tab view. Both names are registered; if a client says the tool is “unavailable”, reconnect the connector and call **`plot_chart`** if `get_chart_data` is missing from its tool list.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = canswim
-version = 0.0.20260722
+version = 0.0.20260727
 author = Ivelin Ivanov
 author_email = ivelin117@gmail.com
 description = Developer toolkit for CANSLIM-style investors (CLI, Gradio GUI, MCP)

--- a/src/canswim/mcp/jobs.py
+++ b/src/canswim/mcp/jobs.py
@@ -204,6 +204,7 @@ def _public_view(job: dict[str, Any]) -> dict[str, Any]:
             if isinstance(requested_count, int)
             else None,
             result=result if isinstance(result, dict) else None,
+            error=job.get("error"),
         ),
     }
     if job.get("error"):
@@ -212,6 +213,17 @@ def _public_view(job: dict[str, Any]) -> dict[str, Any]:
         view["result"] = result
         if isinstance(result, dict) and result.get("coverage"):
             view["coverage"] = result["coverage"]
+        if isinstance(result, dict) and result.get("fail_reason"):
+            view.setdefault("fail_reason", result.get("fail_reason"))
+    # Stable discriminator for failed jobs when result lacks fail_reason
+    if status == STATUS_FAILED and not view.get("fail_reason"):
+        err_txt = str(job.get("error") or "")
+        if "Forecast model not loaded" in err_txt or "trainer_params" in err_txt:
+            view["fail_reason"] = "model_not_loaded"
+        elif "Job interrupted" in err_txt:
+            view["fail_reason"] = "job_interrupted"
+        else:
+            view["fail_reason"] = "job_failed"
     return view
 
 
@@ -222,6 +234,7 @@ def _client_hint(
     *,
     requested_count: int | None = None,
     result: dict[str, Any] | None = None,
+    error: Any = None,
 ) -> str:
     if status == STATUS_SUCCEEDED:
         cov = (result or {}).get("coverage") or {}
@@ -246,6 +259,18 @@ def _client_hint(
             "Verify with get_forecast / list_tickers as needed."
         )
     if status == STATUS_FAILED:
+        err = str(error or "")
+        if isinstance(result, dict):
+            err = err or str(result.get("error") or "")
+            if result.get("fail_reason") == "model_not_loaded":
+                err = err or "Forecast model not loaded"
+        # Prefer model-specific guidance when the crash was a missing checkpoint
+        if "Forecast model not loaded" in err or "model_not_loaded" in err.lower():
+            return (
+                "Job failed: forecast model weights are missing on the server. "
+                "Report that an operator must restore canswim_model.pt (or enable "
+                "hfhub_sync). Do not claim the portfolio is refreshed."
+            )
         return (
             "Job failed. Report the error and coverage to the user. "
             "Do not claim the portfolio is refreshed. "
@@ -586,8 +611,19 @@ def _run_refresh_worker(
             job["store_dir"] = store_dir
         job["status"] = STATUS_FAILED
         job["done"] = True
-        job["error"] = f"{type(e).__name__}: {e}"
+        # Prefer the exception message when already actionable (e.g. model not loaded)
+        msg = str(e).strip()
+        if "Forecast model not loaded" in msg:
+            job["error"] = msg
+        else:
+            job["error"] = f"{type(e).__name__}: {e}"
         job["message"] = job["error"]
+        if "Forecast model not loaded" in msg or "trainer_params" in msg:
+            job["result"] = {
+                "ok": False,
+                "error": job["error"],
+                "fail_reason": "model_not_loaded",
+            }
         try:
             _write_job(job)
         except OSError:

--- a/src/canswim/mcp/tools/_common.py
+++ b/src/canswim/mcp/tools/_common.py
@@ -226,6 +226,61 @@ def ensure_db_ready(db_path: Optional[str] = None) -> tuple[bool, str]:
     )
 
 
+# Stable fail_reason codes for MCP clients (branch without scraping free text).
+FAIL_INVALID_INPUT = "invalid_input"
+FAIL_DB_NOT_READY = "db_not_ready"
+FAIL_RUNS_DISABLED = "runs_disabled"
+FAIL_JOB_UNKNOWN = "job_unknown"
+FAIL_JOB_BUSY = "job_busy"
+FAIL_JOB_FAILED = "job_failed"
+FAIL_JOB_INTERRUPTED = "job_interrupted"
+FAIL_MODEL_NOT_LOADED = "model_not_loaded"
+FAIL_REMOTE_API = "remote_api"
+FAIL_INTERNAL = "internal"
+
+_DEFAULT_CLIENT_HINTS: dict[str, str] = {
+    FAIL_INVALID_INPUT: (
+        "Fix the tool arguments (required fields, formats) and call again."
+    ),
+    FAIL_DB_NOT_READY: (
+        "An operator must initialize search data on the host "
+        "(run dashboard once, or set MCP_INIT_DB=1). "
+        "Remote clients cannot open a local database file."
+    ),
+    FAIL_RUNS_DISABLED: (
+        "An operator must set MCP_ALLOW_RUNS=1 (or CANSWIM_ALLOW_RUNS=1) "
+        "on the MCP server process for gather/forecast/refresh tools."
+    ),
+    FAIL_JOB_UNKNOWN: (
+        "Use the job_id returned by refresh_job_start or refresh_tickers "
+        "(wait=false). Do not invent ids."
+    ),
+    FAIL_JOB_BUSY: (
+        "Poll refresh_job_status until the active job finishes "
+        "(status succeeded or failed), then start a new refresh_job_start."
+    ),
+    FAIL_JOB_FAILED: (
+        "Report the error and coverage to the user. Do not claim the portfolio "
+        "is refreshed. Retry with refresh_job_start after the cause is fixed."
+    ),
+    FAIL_JOB_INTERRUPTED: (
+        "The MCP process restarted or the worker exited. Start again with "
+        "refresh_job_start."
+    ),
+    FAIL_MODEL_NOT_LOADED: (
+        "An operator must place canswim_model.pt in the MCP working directory "
+        "or enable hfhub_sync to download trained weights from Hugging Face."
+    ),
+    FAIL_REMOTE_API: (
+        "Check network, API keys, and provider plan/rate limits; then retry "
+        "with a smaller symbol list if needed."
+    ),
+    FAIL_INTERNAL: (
+        "Retry once. If it persists, report the error string to the host operator."
+    ),
+}
+
+
 def ok_result(data: Any, **extra: Any) -> dict[str, Any]:
     out: dict[str, Any] = {"ok": True, "data": data}
     out.update(extra)
@@ -233,6 +288,75 @@ def ok_result(data: Any, **extra: Any) -> dict[str, Any]:
 
 
 def err_result(message: str, **extra: Any) -> dict[str, Any]:
-    out: dict[str, Any] = {"ok": False, "error": message}
+    """Client-facing failure: always non-empty ``error``; optional discriminators.
+
+    Prefer :func:`client_error` when setting a stable ``fail_reason``.
+    """
+    msg = (str(message) if message is not None else "").strip() or "Request failed."
+    out: dict[str, Any] = {"ok": False, "error": msg}
     out.update(extra)
+    # Drop empty optional strings so clients do not see blank hints
+    for key in ("client_hint", "fail_reason", "error"):
+        if key in out and out[key] is not None and str(out[key]).strip() == "":
+            if key == "error":
+                out[key] = "Request failed."
+            else:
+                out.pop(key, None)
+    fr = out.get("fail_reason")
+    if fr and not out.get("client_hint"):
+        hint = _DEFAULT_CLIENT_HINTS.get(str(fr))
+        if hint:
+            out["client_hint"] = hint
     return out
+
+
+def client_error(
+    message: str,
+    *,
+    fail_reason: str,
+    client_hint: str | None = None,
+    **extra: Any,
+) -> dict[str, Any]:
+    """Canonical MCP failure with machine-readable ``fail_reason`` + human ``error``."""
+    fr = (fail_reason or FAIL_INTERNAL).strip() or FAIL_INTERNAL
+    hint = client_hint
+    if hint is None:
+        hint = _DEFAULT_CLIENT_HINTS.get(fr)
+    kwargs = dict(extra)
+    kwargs["fail_reason"] = fr
+    if hint:
+        kwargs["client_hint"] = hint
+    return err_result(message, **kwargs)
+
+
+def db_not_ready_result(message: str) -> dict[str, Any]:
+    """Failure when search DB is missing / not initialized for read tools."""
+    return client_error(message, fail_reason=FAIL_DB_NOT_READY)
+
+
+def infer_fail_reason_from_error(error: str | None) -> str | None:
+    """Best-effort map of known error text → stable fail_reason for clients."""
+    if not error:
+        return None
+    err = str(error)
+    low = err.lower()
+    if "forecast model not loaded" in low or "trainer_params" in low:
+        return FAIL_MODEL_NOT_LOADED
+    if "job interrupted" in low or "worker exit" in low:
+        return FAIL_JOB_INTERRUPTED
+    if "unknown job_id" in low:
+        return FAIL_JOB_UNKNOWN
+    if (
+        "mcp_allow_runs" in low
+        or "canswim_allow_runs" in low
+        or "runs are disabled" in low
+        or "run triggers are disabled" in low
+    ):
+        return FAIL_RUNS_DISABLED
+    if "already" in low and "job" in low:
+        return FAIL_JOB_BUSY
+    if "data is not ready" in low or (
+        "search data" in low and "operator" in low
+    ):
+        return FAIL_DB_NOT_READY
+    return None

--- a/src/canswim/mcp/tools/charts.py
+++ b/src/canswim/mcp/tools/charts.py
@@ -9,7 +9,15 @@ from canswim.db import (
     DEFAULT_CHART_HISTORY_YEARS,
     get_chart_data,
 )
-from canswim.mcp.tools._common import ensure_db_ready, err_result, ok_result, resolve_db_path
+from canswim.mcp.tools._common import (
+    FAIL_INTERNAL,
+    FAIL_INVALID_INPUT,
+    client_error,
+    db_not_ready_result,
+    ensure_db_ready,
+    ok_result,
+    resolve_db_path,
+)
 
 
 def _coerce_confidence(confidence: Any) -> int:
@@ -52,18 +60,19 @@ def get_chart_data_impl(
     """One-shot chart payload matching the Gradio Charts tab (structured data only)."""
     ready, msg = ensure_db_ready()
     if not ready:
-        return err_result(msg)
+        return db_not_ready_result(msg)
     if not symbol or not str(symbol).strip():
-        return err_result("symbol is required")
+        return client_error("symbol is required", fail_reason=FAIL_INVALID_INPUT)
     try:
         conf = _coerce_confidence(confidence)
         hy = _coerce_history_years(history_years)
         include_rr = _coerce_bool(include_reward_risk, default=True)
     except ValueError as e:
-        return err_result(str(e))
+        return client_error(str(e), fail_reason=FAIL_INVALID_INPUT)
     if conf not in CHART_CONFIDENCE_TO_LOW_QUANTILE:
-        return err_result(
-            f"confidence must be one of {sorted(CHART_CONFIDENCE_TO_LOW_QUANTILE)}"
+        return client_error(
+            f"confidence must be one of {sorted(CHART_CONFIDENCE_TO_LOW_QUANTILE)}",
+            fail_reason=FAIL_INVALID_INPUT,
         )
     db_path = resolve_db_path()
     try:
@@ -79,6 +88,6 @@ def get_chart_data_impl(
         payload["available"] = True
         return ok_result(payload)
     except ValueError as e:
-        return err_result(str(e))
+        return client_error(str(e), fail_reason=FAIL_INVALID_INPUT)
     except Exception as e:
-        return err_result(str(e))
+        return client_error(str(e), fail_reason=FAIL_INTERNAL)

--- a/src/canswim/mcp/tools/forecasts.py
+++ b/src/canswim/mcp/tools/forecasts.py
@@ -10,7 +10,15 @@ from canswim.db import (
     get_reward_risk,
     scan_forecasts,
 )
-from canswim.mcp.tools._common import ensure_db_ready, err_result, ok_result, resolve_db_path
+from canswim.mcp.tools._common import (
+    FAIL_INTERNAL,
+    FAIL_INVALID_INPUT,
+    client_error,
+    db_not_ready_result,
+    ensure_db_ready,
+    ok_result,
+    resolve_db_path,
+)
 
 _VALID_CONFIDENCE = {80, 95, 99}
 
@@ -36,9 +44,9 @@ def get_forecast_impl(
         )
     ready, msg = ensure_db_ready()
     if not ready:
-        return err_result(msg)
+        return db_not_ready_result(msg)
     if not symbol or not str(symbol).strip():
-        return err_result("symbol is required")
+        return client_error("symbol is required", fail_reason=FAIL_INVALID_INPUT)
     db_path = resolve_db_path()
     try:
         df = get_forecast_rows(
@@ -56,17 +64,20 @@ def get_forecast_impl(
             }
         )
     except Exception as e:
-        return err_result(str(e))
+        return client_error(str(e), fail_reason=FAIL_INTERNAL)
 
 
 def get_reward_risk_impl(symbol: str, confidence: int = 80) -> dict[str, Any]:
     ready, msg = ensure_db_ready()
     if not ready:
-        return err_result(msg)
+        return db_not_ready_result(msg)
     if confidence not in _VALID_CONFIDENCE:
-        return err_result(f"confidence must be one of {sorted(_VALID_CONFIDENCE)}")
+        return client_error(
+            f"confidence must be one of {sorted(_VALID_CONFIDENCE)}",
+            fail_reason=FAIL_INVALID_INPUT,
+        )
     if not symbol or not str(symbol).strip():
-        return err_result("symbol is required")
+        return client_error("symbol is required", fail_reason=FAIL_INVALID_INPUT)
     lq = (100 - confidence) / 100
     db_path = resolve_db_path()
     try:
@@ -82,7 +93,7 @@ def get_reward_risk_impl(symbol: str, confidence: int = 80) -> dict[str, Any]:
             }
         )
     except Exception as e:
-        return err_result(str(e))
+        return client_error(str(e), fail_reason=FAIL_INTERNAL)
 
 
 def scan_forecasts_impl(
@@ -93,9 +104,12 @@ def scan_forecasts_impl(
 ) -> dict[str, Any]:
     ready, msg = ensure_db_ready()
     if not ready:
-        return err_result(msg)
+        return db_not_ready_result(msg)
     if confidence not in _VALID_CONFIDENCE:
-        return err_result(f"confidence must be one of {sorted(_VALID_CONFIDENCE)}")
+        return client_error(
+            f"confidence must be one of {sorted(_VALID_CONFIDENCE)}",
+            fail_reason=FAIL_INVALID_INPUT,
+        )
     db_path = resolve_db_path()
     try:
         df = scan_forecasts(
@@ -116,4 +130,4 @@ def scan_forecasts_impl(
             }
         )
     except Exception as e:
-        return err_result(str(e))
+        return client_error(str(e), fail_reason=FAIL_INTERNAL)

--- a/src/canswim/mcp/tools/jobs.py
+++ b/src/canswim/mcp/tools/jobs.py
@@ -12,7 +12,6 @@ from canswim.mcp.tools._common import (
     FAIL_JOB_UNKNOWN,
     FAIL_RUNS_DISABLED,
     client_error,
-    err_result,
     infer_fail_reason_from_error,
     ok_result,
 )

--- a/src/canswim/mcp/tools/jobs.py
+++ b/src/canswim/mcp/tools/jobs.py
@@ -5,7 +5,17 @@ from __future__ import annotations
 from typing import Any
 
 from canswim.mcp import jobs as job_core
-from canswim.mcp.tools._common import err_result, ok_result
+from canswim.mcp.tools._common import (
+    FAIL_INVALID_INPUT,
+    FAIL_JOB_BUSY,
+    FAIL_JOB_FAILED,
+    FAIL_JOB_UNKNOWN,
+    FAIL_RUNS_DISABLED,
+    client_error,
+    err_result,
+    infer_fail_reason_from_error,
+    ok_result,
+)
 
 JOB_TOOL_NAMES = [
     "refresh_job_start",
@@ -26,9 +36,19 @@ def refresh_job_start_impl(
     )
     if out.get("ok"):
         return ok_result(out["data"])
+    err = out.get("error") or "could not start job"
+    fr = out.get("fail_reason") or infer_fail_reason_from_error(err)
+    if fr is None:
+        if out.get("runs_allowed") is False:
+            fr = FAIL_RUNS_DISABLED
+        elif out.get("active_job_id"):
+            fr = FAIL_JOB_BUSY
+        else:
+            fr = FAIL_INVALID_INPUT
     # Busy / blocked / bad tickers — still surface structured data when present
-    return err_result(
-        out.get("error") or "could not start job",
+    return client_error(
+        err,
+        fail_reason=fr,
         data=out.get("data"),
         active_job_id=out.get("active_job_id"),
         runs_allowed=out.get("runs_allowed"),
@@ -41,8 +61,24 @@ def refresh_job_status_impl(job_id: str) -> dict[str, Any]:
     """Poll a job started by refresh_job_start. Always available (no runs gate)."""
     jid = (job_id or "").strip()
     if not jid:
-        return err_result("job_id is required")
+        return client_error("job_id is required", fail_reason=FAIL_INVALID_INPUT)
     out = job_core.get_job_status(jid)
     if out.get("ok"):
-        return ok_result(out["data"])
-    return err_result(out.get("error") or "status failed", job_id=jid)
+        data = out["data"]
+        # Enrich failed terminal jobs with a stable discriminator for clients
+        if isinstance(data, dict) and data.get("status") == "failed":
+            data = dict(data)
+            if not data.get("fail_reason"):
+                fr = infer_fail_reason_from_error(data.get("error"))
+                if fr is None:
+                    res = data.get("result") if isinstance(data.get("result"), dict) else {}
+                    fr = (res or {}).get("fail_reason") or FAIL_JOB_FAILED
+                data["fail_reason"] = fr
+            if not data.get("client_hint"):
+                # _public_view already sets client_hint for failed; keep if present
+                pass
+            return ok_result(data)
+        return ok_result(data)
+    err = out.get("error") or "status failed"
+    fr = infer_fail_reason_from_error(err) or FAIL_JOB_UNKNOWN
+    return client_error(err, fail_reason=fr, job_id=jid)

--- a/src/canswim/mcp/tools/meta.py
+++ b/src/canswim/mcp/tools/meta.py
@@ -88,11 +88,14 @@ def health_check_impl() -> dict[str, Any]:
         "disclaimer": "NOT FINANCIAL OR INVESTMENT ADVICE. USE AT YOUR OWN RISK.",
     }
     if not ready:
-        return err_result(
+        from canswim.mcp.tools._common import FAIL_DB_NOT_READY, client_error
+
+        return client_error(
             "CANSWIM data is not ready on the server. "
             "An operator must build or refresh the search data on the host "
             "(dashboard once, or MCP_INIT_DB on the server process). "
             "Remote clients cannot access a local database file.",
+            fail_reason=FAIL_DB_NOT_READY,
             data=payload,
         )
     return ok_result(payload)

--- a/src/canswim/mcp/tools/prices.py
+++ b/src/canswim/mcp/tools/prices.py
@@ -5,7 +5,15 @@ from __future__ import annotations
 from typing import Any, Optional
 
 from canswim.db import dataframe_to_records, get_backtest_error, get_close_prices
-from canswim.mcp.tools._common import ensure_db_ready, err_result, ok_result, resolve_db_path
+from canswim.mcp.tools._common import (
+    FAIL_INTERNAL,
+    FAIL_INVALID_INPUT,
+    client_error,
+    db_not_ready_result,
+    ensure_db_ready,
+    ok_result,
+    resolve_db_path,
+)
 
 
 def get_close_price_impl(
@@ -29,9 +37,9 @@ def get_close_price_impl(
         )
     ready, msg = ensure_db_ready()
     if not ready:
-        return err_result(msg)
+        return db_not_ready_result(msg)
     if not symbol or not str(symbol).strip():
-        return err_result("symbol is required")
+        return client_error("symbol is required", fail_reason=FAIL_INVALID_INPUT)
     db_path = resolve_db_path()
     try:
         df = get_close_prices(
@@ -49,7 +57,7 @@ def get_close_price_impl(
             }
         )
     except Exception as e:
-        return err_result(str(e))
+        return client_error(str(e), fail_reason=FAIL_INTERNAL)
 
 
 def get_backtest_error_impl(
@@ -58,7 +66,7 @@ def get_backtest_error_impl(
 ) -> dict[str, Any]:
     ready, msg = ensure_db_ready()
     if not ready:
-        return err_result(msg)
+        return db_not_ready_result(msg)
     db_path = resolve_db_path()
     try:
         sym = str(symbol).strip().upper() if symbol else None
@@ -71,4 +79,4 @@ def get_backtest_error_impl(
             }
         )
     except Exception as e:
-        return err_result(str(e))
+        return client_error(str(e), fail_reason=FAIL_INTERNAL)

--- a/src/canswim/mcp/tools/query.py
+++ b/src/canswim/mcp/tools/query.py
@@ -15,7 +15,15 @@ from canswim.db import (
     format_schema_markdown,
     run_select,
 )
-from canswim.mcp.tools._common import ensure_db_ready, err_result, ok_result, resolve_db_path
+from canswim.mcp.tools._common import (
+    FAIL_INTERNAL,
+    FAIL_INVALID_INPUT,
+    client_error,
+    db_not_ready_result,
+    ensure_db_ready,
+    ok_result,
+    resolve_db_path,
+)
 from canswim.mcp.tools.meta import CLIENT_ACCESS_BOUNDARY
 
 # Client-facing policy (no engine/path leakage)
@@ -40,9 +48,9 @@ def run_select_impl(sql: str, row_limit: int = 5000) -> dict[str, Any]:
     """Execute a single read-only SELECT (or WITH…SELECT) via MCP only."""
     ready, msg = ensure_db_ready()
     if not ready:
-        return err_result(msg)
+        return db_not_ready_result(msg)
     if not sql or not str(sql).strip():
-        return err_result("sql is required")
+        return client_error("sql is required", fail_reason=FAIL_INVALID_INPUT)
     db_path = resolve_db_path()
     try:
         df = run_select(db_path, sql, row_limit=row_limit)
@@ -56,9 +64,11 @@ def run_select_impl(sql: str, row_limit: int = 5000) -> dict[str, Any]:
             }
         )
     except SelectOnlyError as e:
-        return err_result(str(e), read_only=True)
+        return client_error(
+            str(e), fail_reason=FAIL_INVALID_INPUT, read_only=True
+        )
     except Exception as e:
-        return err_result(str(e), read_only=True)
+        return client_error(str(e), fail_reason=FAIL_INTERNAL, read_only=True)
 
 
 def get_db_schema_impl(
@@ -75,7 +85,7 @@ def get_db_schema_impl(
     if not ready:
         db_path = resolve_db_path()
         if not Path(db_path).is_file():
-            return err_result(msg)
+            return db_not_ready_result(msg)
         # fall through with partial data
 
     db_path = resolve_db_path()
@@ -86,7 +96,7 @@ def get_db_schema_impl(
             include_sample_values=include_sample_values,
         )
         if schema.get("error") and not schema.get("tables"):
-            return err_result(
+            return db_not_ready_result(
                 "CANSWIM schema is unavailable (data not ready on the server)."
             )
 
@@ -125,4 +135,4 @@ def get_db_schema_impl(
             )
         return ok_result(data)
     except Exception as e:
-        return err_result(str(e))
+        return client_error(str(e), fail_reason=FAIL_INTERNAL)

--- a/src/canswim/mcp/tools/runs.py
+++ b/src/canswim/mcp/tools/runs.py
@@ -13,7 +13,17 @@ from canswim.run_triggers import (
     resolve_start_for_run,
     runs_allowed,
 )
-from canswim.mcp.tools._common import ProgressCb, err_result, ok_result
+from canswim.mcp.tools._common import (
+    FAIL_INVALID_INPUT,
+    FAIL_MODEL_NOT_LOADED,
+    FAIL_REMOTE_API,
+    FAIL_RUNS_DISABLED,
+    ProgressCb,
+    client_error,
+    err_result,
+    infer_fail_reason_from_error,
+    ok_result,
+)
 
 
 RUN_TOOL_NAMES = [
@@ -24,6 +34,44 @@ RUN_TOOL_NAMES = [
 ]
 
 
+def _runs_blocked_result(blocked: dict[str, Any]) -> dict[str, Any]:
+    return client_error(
+        blocked.get("error") or "Run triggers are disabled.",
+        fail_reason=FAIL_RUNS_DISABLED,
+        runs_allowed=False,
+    )
+
+
+def _run_failure_result(
+    result: dict[str, Any],
+    *,
+    default_error: str,
+    client_hint: str | None = None,
+) -> dict[str, Any]:
+    """Map gather/forecast/refresh failure dict → client-facing err_result shape."""
+    err = result.get("error") or default_error
+    fr = result.get("fail_reason")
+    if not fr or fr == "covariates":
+        inferred = infer_fail_reason_from_error(err)
+        if inferred:
+            fr = inferred
+    if not fr and result.get("remote_api"):
+        fr = FAIL_REMOTE_API
+    remote = result.get("remote_api") or (result.get("gather") or {}).get(
+        "remote_api"
+    )
+    kwargs: dict[str, Any] = {
+        "data": result,
+        "remote_api": remote,
+    }
+    # Prefer model/operator hints over generic refresh retry text
+    if client_hint and fr != FAIL_MODEL_NOT_LOADED:
+        kwargs["client_hint"] = client_hint
+    if fr:
+        return client_error(err, fail_reason=str(fr), **kwargs)
+    return err_result(err, **kwargs)
+
+
 def resolve_forecast_start_impl(
     start_date: Optional[str] = None,
 ) -> dict[str, Any]:
@@ -31,7 +79,11 @@ def resolve_forecast_start_impl(
     info = resolve_start_for_run(start_date)
     if info.get("ok"):
         return ok_result(info)
-    return err_result(info.get("error") or "resolve failed", data=info)
+    return client_error(
+        info.get("error") or "resolve failed",
+        fail_reason=FAIL_INVALID_INPUT,
+        data=info,
+    )
 
 
 def gather_tickers_impl(
@@ -41,11 +93,15 @@ def gather_tickers_impl(
 ) -> dict[str, Any]:
     blocked = require_runs_allowed()
     if blocked is not None:
-        return err_result(blocked["error"], runs_allowed=False)
+        return _runs_blocked_result(blocked)
 
     parsed = parse_ticker_list(tickers)
     if not parsed["ok"]:
-        return err_result(parsed.get("error") or "bad tickers", data=parsed)
+        return client_error(
+            parsed.get("error") or "bad tickers",
+            fail_reason=FAIL_INVALID_INPUT,
+            data=parsed,
+        )
 
     if progress_cb is not None:
         try:
@@ -70,13 +126,7 @@ def gather_tickers_impl(
             pass
     if result.get("ok"):
         return ok_result(result)
-    # Surface structured remote_api (network / key / plan) for MCP clients
-    return err_result(
-        result.get("error") or "gather failed",
-        data=result,
-        remote_api=result.get("remote_api"),
-        fail_reason=result.get("fail_reason"),
-    )
+    return _run_failure_result(result, default_error="gather failed")
 
 
 def forecast_tickers_impl(
@@ -87,11 +137,15 @@ def forecast_tickers_impl(
 ) -> dict[str, Any]:
     blocked = require_runs_allowed()
     if blocked is not None:
-        return err_result(blocked["error"], runs_allowed=False)
+        return _runs_blocked_result(blocked)
 
     parsed = parse_ticker_list(tickers)
     if not parsed["ok"]:
-        return err_result(parsed.get("error") or "bad tickers", data=parsed)
+        return client_error(
+            parsed.get("error") or "bad tickers",
+            fail_reason=FAIL_INVALID_INPUT,
+            data=parsed,
+        )
 
     result = forecast_for_tickers(
         tickers,
@@ -102,12 +156,7 @@ def forecast_tickers_impl(
     )
     if result.get("ok"):
         return ok_result(result)
-    return err_result(
-        result.get("error") or "forecast failed",
-        data=result,
-        remote_api=result.get("remote_api"),
-        fail_reason=result.get("fail_reason"),
-    )
+    return _run_failure_result(result, default_error="forecast failed")
 
 
 def refresh_tickers_impl(
@@ -123,12 +172,13 @@ def refresh_tickers_impl(
     """
     blocked = require_runs_allowed()
     if blocked is not None:
-        return err_result(blocked["error"], runs_allowed=False)
+        return _runs_blocked_result(blocked)
 
     parsed = parse_ticker_list(tickers, overflow="error")
     if not parsed["ok"]:
-        return err_result(
+        return client_error(
             parsed.get("error") or "bad tickers",
+            fail_reason=FAIL_INVALID_INPUT,
             data=parsed,
             client_hint=parsed.get("client_hint"),
             recommended_tool=parsed.get("recommended_tool") or "refresh_job_start",
@@ -158,12 +208,17 @@ def refresh_tickers_impl(
     remote = result.get("remote_api") or (result.get("gather") or {}).get(
         "remote_api"
     )
-    return err_result(
-        result.get("error") or "refresh failed",
-        data=result,
-        remote_api=remote,
-        fail_reason=result.get("fail_reason")
-        or (result.get("gather") or {}).get("fail_reason"),
+    if remote and not result.get("remote_api"):
+        result = dict(result)
+        result["remote_api"] = remote
+    if not result.get("fail_reason") and (result.get("gather") or {}).get(
+        "fail_reason"
+    ):
+        result = dict(result)
+        result["fail_reason"] = result["gather"]["fail_reason"]
+    return _run_failure_result(
+        result,
+        default_error="refresh failed",
         client_hint=(
             "Refresh failed. Do not claim success. "
             "Prefer refresh_job_start for long runs; poll refresh_job_status."

--- a/src/canswim/mcp/tools/tickers.py
+++ b/src/canswim/mcp/tools/tickers.py
@@ -5,16 +5,23 @@ from __future__ import annotations
 from typing import Any
 
 from canswim.db import list_tickers
-from canswim.mcp.tools._common import ensure_db_ready, err_result, ok_result, resolve_db_path
+from canswim.mcp.tools._common import (
+    FAIL_INTERNAL,
+    client_error,
+    db_not_ready_result,
+    ensure_db_ready,
+    ok_result,
+    resolve_db_path,
+)
 
 
 def list_tickers_impl() -> dict[str, Any]:
     ready, msg = ensure_db_ready()
     if not ready:
-        return err_result(msg)
+        return db_not_ready_result(msg)
     db_path = resolve_db_path()
     try:
         symbols = list_tickers(db_path)
         return ok_result({"symbols": symbols, "count": len(symbols)})
     except Exception as e:
-        return err_result(str(e))
+        return client_error(str(e), fail_reason=FAIL_INTERNAL)

--- a/src/canswim/run_triggers.py
+++ b/src/canswim/run_triggers.py
@@ -1202,11 +1202,23 @@ def forecast_for_tickers(
     except Exception as e:
         logger.exception("forecast_for_tickers failed")
         err = str(e)
+        fail_reason = "covariates"
+        # Model checkpoint missing/unreadable — not a covariate alignment issue
+        if (
+            "Forecast model not loaded" in err
+            or "trainer_params" in err
+            or (
+                "canswim_model.pt" in err and "missing" in err.lower()
+            )
+        ):
+            fail_reason = "model_not_loaded"
+            # Keep the clear RuntimeError text (already actionable for operators)
         # Map Darts dim errors to consumer language (ETFs / fund-thin often hit this)
-        if "dimensionality" in err.lower() or "past_covariates" in err.lower():
+        elif "dimensionality" in err.lower() or "past_covariates" in err.lower():
             err = DIMENSIONALITY_FAIL_MSG.format(
                 symbols=", ".join(tickers) if tickers else "requested symbols"
             )
+            fail_reason = "covariates"
         return {
             "ok": False,
             "error": err,
@@ -1219,7 +1231,7 @@ def forecast_for_tickers(
             "skipped": skipped_all,
             "messages": messages,
             "model_loaded": model_loaded,
-            "fail_reason": "covariates",
+            "fail_reason": fail_reason,
         }
     finally:
         if prev_list is None:

--- a/tests/canswim/test_mcp_client_errors.py
+++ b/tests/canswim/test_mcp_client_errors.py
@@ -1,0 +1,238 @@
+"""Client-facing MCP error shape: ok/error + fail_reason/client_hint for agents.
+
+Drives real tool impl entry points (and job status) — not reimplemented helpers.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import duckdb
+import pytest
+
+from canswim.mcp.tools import forecasts, prices, tickers
+from canswim.mcp.tools import jobs as job_tools
+from canswim.mcp.tools import meta
+from canswim.mcp.tools import runs as run_tools
+from canswim.mcp.tools._common import (
+    FAIL_DB_NOT_READY,
+    FAIL_INVALID_INPUT,
+    FAIL_JOB_UNKNOWN,
+    FAIL_MODEL_NOT_LOADED,
+    FAIL_RUNS_DISABLED,
+    client_error,
+    err_result,
+    infer_fail_reason_from_error,
+)
+
+
+def _assert_client_failure(out: dict, *, fail_reason: str | None = None) -> None:
+    assert out.get("ok") is False, out
+    err = out.get("error")
+    assert isinstance(err, str) and err.strip(), out
+    # No bare AttributeError-style sole signal without guidance
+    assert "has no attribute" not in err or "Forecast model not loaded" in err
+    if fail_reason is not None:
+        assert out.get("fail_reason") == fail_reason, out
+    # Discriminator for branching: fail_reason and/or client_hint and/or data
+    assert (
+        out.get("fail_reason")
+        or out.get("client_hint")
+        or isinstance(out.get("data"), dict)
+    ), out
+
+
+def _mini_db(path: Path) -> str:
+    db_path = str(path / "err_test.duckdb")
+    with duckdb.connect(db_path) as con:
+        con.execute(
+            "CREATE TABLE stock_tickers AS SELECT * FROM (VALUES ('AAA')) t(Symbol)"
+        )
+        con.execute(
+            """
+            CREATE TABLE close_price AS
+            SELECT * FROM (VALUES (DATE '2025-01-02', 'AAA', 100.0)) t(Date, Symbol, Close)
+            """
+        )
+        con.execute(
+            """
+            CREATE TABLE forecast AS
+            SELECT * FROM (VALUES
+                (TIMESTAMP '2025-01-06', 'AAA', DATE '2025-01-06',
+                 98.0, 99.0, 100.0, 110.0, 115.0, 120.0, 125.0)
+            ) t(
+                Date, symbol, start_date,
+                "close_quantile_0.01", "close_quantile_0.05", "close_quantile_0.2",
+                "close_quantile_0.5", "close_quantile_0.8", "close_quantile_0.95",
+                "close_quantile_0.99"
+            )
+            """
+        )
+        con.execute(
+            "CREATE TABLE latest_forecast AS SELECT * FROM (VALUES ('AAA', DATE '2025-01-06')) t(symbol, date)"
+        )
+        con.execute(
+            """
+            CREATE TABLE backtest_error AS
+            SELECT * FROM (VALUES ('AAA', DATE '2025-01-06', 0.05)) t(symbol, start_date, mal_error)
+            """
+        )
+    return db_path
+
+
+@pytest.fixture
+def mcp_ready(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> str:
+    db_path = _mini_db(tmp_path)
+    monkeypatch.setenv("data_dir", str(tmp_path))
+    monkeypatch.setenv("db_file", "err_test.duckdb")
+    monkeypatch.delenv("MCP_INIT_DB", raising=False)
+    monkeypatch.setenv("MCP_ALLOW_RUNS", "1")
+    return db_path
+
+
+@pytest.fixture
+def mcp_no_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setenv("data_dir", str(tmp_path))
+    monkeypatch.setenv("db_file", "missing.duckdb")
+    monkeypatch.delenv("MCP_INIT_DB", raising=False)
+    return tmp_path
+
+
+def test_err_result_always_nonempty_error():
+    out = err_result("")
+    assert out["ok"] is False
+    assert out["error"].strip()
+
+
+def test_client_error_sets_fail_reason_and_default_hint():
+    out = client_error("symbol is required", fail_reason=FAIL_INVALID_INPUT)
+    _assert_client_failure(out, fail_reason=FAIL_INVALID_INPUT)
+    assert "argument" in out["client_hint"].lower() or "call again" in out[
+        "client_hint"
+    ].lower()
+
+
+def test_infer_model_not_loaded():
+    assert (
+        infer_fail_reason_from_error(
+            "Forecast model not loaded (download_model): canswim_model.pt missing"
+        )
+        == FAIL_MODEL_NOT_LOADED
+    )
+
+
+def test_invalid_input_missing_symbol(mcp_ready):
+    out = forecasts.get_forecast_impl("")
+    _assert_client_failure(out, fail_reason=FAIL_INVALID_INPUT)
+    out2 = prices.get_close_price_impl("  ")
+    _assert_client_failure(out2, fail_reason=FAIL_INVALID_INPUT)
+
+
+def test_db_not_ready_list_tickers(mcp_no_db):
+    out = tickers.list_tickers_impl()
+    _assert_client_failure(out, fail_reason=FAIL_DB_NOT_READY)
+    assert "operator" in out["error"].lower() or "not ready" in out["error"].lower()
+
+
+def test_db_not_ready_health_check(mcp_no_db):
+    out = meta.health_check_impl()
+    _assert_client_failure(out, fail_reason=FAIL_DB_NOT_READY)
+
+
+def test_runs_gate_blocks_forecast(mcp_ready, monkeypatch):
+    monkeypatch.delenv("MCP_ALLOW_RUNS", raising=False)
+    monkeypatch.delenv("CANSWIM_ALLOW_RUNS", raising=False)
+    out = run_tools.forecast_tickers_impl("AAA")
+    _assert_client_failure(out, fail_reason=FAIL_RUNS_DISABLED)
+    assert out.get("runs_allowed") is False
+
+
+def test_runs_gate_blocks_gather(mcp_ready, monkeypatch):
+    monkeypatch.delenv("MCP_ALLOW_RUNS", raising=False)
+    monkeypatch.delenv("CANSWIM_ALLOW_RUNS", raising=False)
+    out = run_tools.gather_tickers_impl("AAA")
+    _assert_client_failure(out, fail_reason=FAIL_RUNS_DISABLED)
+
+
+def test_job_unknown_id(mcp_ready):
+    out = job_tools.refresh_job_status_impl("deadbeefcafebabe00")
+    _assert_client_failure(out, fail_reason=FAIL_JOB_UNKNOWN)
+
+
+def test_job_id_required(mcp_ready):
+    out = job_tools.refresh_job_status_impl("  ")
+    _assert_client_failure(out, fail_reason=FAIL_INVALID_INPUT)
+
+
+def test_forecast_model_not_loaded_via_tool(mcp_ready, monkeypatch):
+    """forecast_tickers surfaces model_not_loaded when download_model fails."""
+    monkeypatch.setenv("MCP_ALLOW_RUNS", "1")
+
+    def boom_download(self):
+        raise RuntimeError(
+            "Forecast model not loaded (download_model): canswim_model.pt "
+            "missing or unreadable at /tmp/x/canswim_model.pt. "
+            "With hfhub_sync=False place a trained checkpoint in the process "
+            "working directory, or set hfhub_sync=True to download from HF Hub "
+            "(repo ivelin/canswim)."
+        )
+
+    with patch(
+        "canswim.forecast.CanswimForecaster.download_model",
+        boom_download,
+    ):
+        out = run_tools.forecast_tickers_impl("AAA", dry_run=False)
+    _assert_client_failure(out, fail_reason=FAIL_MODEL_NOT_LOADED)
+    assert "Forecast model not loaded" in out["error"]
+    assert out.get("client_hint")
+    assert "operator" in out["client_hint"].lower() or "canswim_model" in out[
+        "client_hint"
+    ].lower()
+
+
+def test_failed_job_status_includes_fail_reason(mcp_ready):
+    """refresh_job_status on a failed job file exposes fail_reason for clients."""
+    from canswim.mcp import jobs as job_core
+    import json
+    from datetime import datetime, timezone
+
+    jid = "abc123failedjob"
+    path = job_core.jobs_dir() / f"{jid}.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    now = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+    path.write_text(
+        json.dumps(
+            {
+                "job_id": jid,
+                "kind": "refresh",
+                "status": "failed",
+                "done": True,
+                "tickers": "AAA",
+                "ticker_list": ["AAA"],
+                "error": "Forecast model not loaded (download_model): canswim_model.pt missing",
+                "message": "Forecast model not loaded",
+                "progress_pct": 0,
+                "created_at": now,
+                "updated_at": now,
+                "result": {
+                    "ok": False,
+                    "error": "Forecast model not loaded",
+                    "fail_reason": "model_not_loaded",
+                    "coverage": {"requested_count": 1, "batches_failed": 1},
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    out = job_tools.refresh_job_status_impl(jid)
+    assert out["ok"] is True, out
+    data = out["data"]
+    assert data["status"] == "failed"
+    assert data.get("error")
+    assert data.get("fail_reason") == FAIL_MODEL_NOT_LOADED
+    assert data.get("client_hint")
+    assert "model" in data["client_hint"].lower() or "error" in data[
+        "client_hint"
+    ].lower()


### PR DESCRIPTION
## Summary
- Client-facing MCP failures use a stable envelope: `ok: false`, non-empty `error`, and usually `fail_reason` + `client_hint`.
- High-traffic classes: invalid input, DB not ready, runs gate off, unknown job, failed job, model not loaded (via forecast/refresh).
- `forecast_for_tickers` no longer labels missing model weights as `covariates`.
- Docs + version `0.0.20260727` for client rediscovery.

## Test plan
- [x] `tests/canswim/test_mcp_client_errors.py` (12 tests)
- [x] `./scripts/ci-local.sh` (278 passed)
- [ ] GitHub Actions Tests green