### PR TITLE
fix: hard-fail forecast without real fundamentals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable releases are documented here. Versioning follows date-style `0.0.YYYYMMDD` unless noted.
 
+## 0.0.20260806
+
+Forecast/backtest must not invent fundamentals (zero-filled earnings, key metrics, or estimates).
+
+### Highlights
+
+- **Hard rule** — forecast/catch-up/refresh skip symbols without real local
+  earnings + key metrics + analyst estimates (`fail_reason=fundamentals`)
+- **No forecast-time fund zero-fill** — train may still impute (#33) via
+  `allow_fundamentals_imputation=True`; inference refuses placeholders
+- **Operator purge** — `scripts/purge_forecasts_without_fundamentals.py` removes
+  hive partitions that lack fund data; rebuild DuckDB after
+
+### Install
+
+```bash
+pip install canswim==0.0.20260806
+```
+
 ## 0.0.20260727
 
 MCP clients (SuperGrok, etc.) need stable, human-readable failures with machine-readable discriminators — not bare `AttributeError` fragments.

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Two separate steps, same backend (`canswim.run_triggers`). Details: **[docs/run_
 
 \*MCP write tools need `MCP_ALLOW_RUNS=1`. Full MCP guide: **[docs/mcp.md](docs/mcp.md)**.
 
-Scoped get-market-data uses **~3 years** of history (lookback + catch-up), **fundamentals** (unless `--no_covariates`), and **skips downloads** when local files are already complete. Forecasts **stop** if data is incomplete (no invented prices).
+Scoped get-market-data uses **~3 years** of history (lookback + catch-up), **fundamentals** (unless `--no_covariates`), and **skips downloads** when local files are already complete. Forecasts **stop** if data is incomplete (no invented prices or zero-filled fundamentals).
 
 ```bash
 python -m canswim gatherdata --tickers "AAPL, MSFT"

--- a/docs/run_triggers.md
+++ b/docs/run_triggers.md
@@ -134,13 +134,14 @@ and what we **impute** so the tensor width still matches training.
 | Layer | Role | Always required? |
 |-------|------|------------------|
 | **Target** | Stock/ETF **Close** (or configured target column) | **Yes** — ground-truth bars only (no invented OHLCV) |
-| **Past covariates** | Own OHLC+volume, earnings, key metrics, ownership, splits, broad market / sectors / industry funds | **Yes as a block** — missing *fund* slices are zero-/sentinel-filled |
-| **Future covariates** | Dividends, analyst estimate paths, holidays | **Yes as a block** — missing estimates zero-filled |
+| **Past covariates** | Own OHLC+volume, earnings, key metrics, ownership, splits, broad market / sectors / industry funds | **Forecast:** real fund rows required (earnings + key metrics + estimates). **Train only:** missing fund slices may be zero-filled (#33) so feature width matches the checkpoint. |
+| **Future covariates** | Dividends, analyst estimate paths, holidays | **Forecast:** real analyst estimates required. **Train only:** may zero-fill missing estimates. |
 
 Training and forecast both call the same covariate stack (`canswim.covariates`).
 If a column that existed at train is missing at forecast, Darts raises a
-**dimensionality** error. That is why fund-thin names must **impute columns**,
-not drop them.
+**dimensionality** error. **Forecast/backtest never invent fundamentals** —
+symbols without real local fund data are skipped (`fail_reason=fundamentals`).
+Train may still impute fund-thin names so one checkpoint trains on mixed batches.
 
 ### Three operator-facing classes (MECE)
 
@@ -162,42 +163,43 @@ Same rules on both paths unless noted.
 |-------------|--------------------|-----------------|------------------|
 | **OHLCV history** | Full train window or ~3y scoped | Must eventually reach ~**3 years of sessions** for forecast-scoped readiness | Same price floor as stocks (~3y scoped) |
 | **Own OHLC+volume as past covs** | Real | Real when listed | Real (ETF prints) |
-| **Earnings / key metrics / ownership** | Real when present | **Zero-fill** missing (#33) | **Zero-fill** missing (same mechanism; expected permanent) |
-| **Analyst estimates (future)** | Real when present | **Zero-fill** missing | **Zero-fill** missing |
+| **Earnings / key metrics / ownership** | Real on disk for forecast | **Forecast:** hard-fail if missing. **Train:** may zero-fill (#33) | **Forecast:** hard-fail if no real fund rows (typical for pure ETFs until data exists). **Train:** may zero-fill |
+| **Analyst estimates (future)** | Real on disk for forecast | Same as above | Same as above |
 | **Broad / sector / industry funds** | Shared series (all symbols) | Shared series | Shared series (often the informative path for ETFs) |
 | **Dividends / splits / holidays** | Real or empty-padded | Same | Same |
 | **Train inclusion** | Preferred “rich” examples | Included if prices + imputed fund dims work | Can be included the same way; model still learns price+market features |
-| **Forecast / Refresh** | Default path | Fail **history** if too short; else impute fund | Fail **history** if too short; else impute fund (empty batch OK) |
+| **Forecast / Refresh** | Real prices **and** real fund files | Fail if **history** short **or** fund files missing | Fail if fund files missing (no invented estimates) |
 
-**Hard fail (cannot invent):** insufficient **price** history for the forecast
-window / min samples. Status talks about short history / IPOs.
+**Hard fail (cannot invent) — forecast/backtest:**
 
-**Soft gap (impute, do not drop columns):** missing earnings, key metrics,
-ownership, estimates — whether temporary (IPO) or structural (ETF).
+1. Insufficient **price** history (ground-truth OHLCV only; no synthetic bars).
+2. Missing **real fundamentals** on disk: earnings calendar, key metrics, and
+   analyst estimates (annual **or** quarterly). Zero-filled placeholders are
+   **not** accepted for inference.
 
-### How imputation works (train + inference)
+**Train-only soft gap (impute, do not drop columns):** missing earnings, key
+metrics, ownership, estimates — temporary (IPO) or structural (ETF) — so the
+feature width still matches the checkpoint. Controlled by
+`allow_fundamentals_imputation=True` on the train path only.
+
+### How train imputation works (not used for forecast)
 
 1. Build real series per symbol when parquet has rows.
-2. If some symbols in the batch lack a block, **copy the column template** from a
-   peer that has it and fill with `0` (ownership) or `-1` / zeros (earn, kms,
-   estimates), aligned to that symbol’s **price calendar**.
-3. If the **entire batch** has no fund rows (e.g. refresh **XLF** alone), there is
-   no peer template:
-   - **Earnings:** fixed train schema columns (always emit the same names/order).
-   - **Key metrics / analyst estimates:** load a **disk template** from covered
-     large caps (e.g. AAPL family) and zero-fill those columns for the thin name.
-4. Stack into past/future covariates with the **same width** as training so one
-   checkpoint works for A/B/C.
+2. If some symbols in the batch lack a block **and** train imputation is on,
+   **copy the column template** from a peer and fill with `0` / `-1`.
+3. Forecast path **refuses** that step and skips the symbol instead.
 
-Implementation: `canswim.covariates` (issue #33 for IPOs; empty-batch / ETF path
-extends the same idea).
+Implementation: `canswim.eligibility` (`fundamentals_are_ready`,
+`partition_by_fundamentals`) + `canswim.covariates` +
+`forecast_for_tickers` gate. Operator cleanup:
+`scripts/purge_forecasts_without_fundamentals.py`.
 
 ### What this means for operators
 
 | You want to… | Expectation |
 |--------------|-------------|
 | Refresh **LLY / AAPL** | Market data + real fundamentals when APIs have them; catch-up forecasts as usual |
-| Refresh a **new IPO** | May **stop** until enough sessions (~3y floor for catch-up); fundamentals imputed once prices are ready |
+| Refresh a **new IPO** | May **stop** until enough sessions (~3y floor for catch-up) **and** real fund rows exist on disk |
 | Refresh **XLF** or a sector ETF | Prices + market funds load; **no corporate fund rows** — imputed automatically; forecast should not fail on dimensionality alone |
 | Mix ETF + stocks in one list | Peers can supply templates; still fine if only ETFs (empty-batch path) |
 
@@ -211,8 +213,8 @@ intentional with a single shared head—not a second “ETF model.”
 
 1. One orchestration for CLI / GUI / MCP.
 2. Missing-only remote calls for forecast-scoped gather; train stays full-history.
-3. Fail closed on incomplete **price** history; **impute** optional fundamentals so feature width stays fixed.
+3. Fail closed on incomplete **price** history; **forecast** fails closed without real fundamentals; **train** may impute fund width only.
 4. Consumer copy in the product; policy detail in this doc.
 5. Parquet is the system of record; DuckDB is the search/UI cache ([data_store.md](data_store.md)).
 6. Same model for covered stocks, IPOs, and ETFs — different real-data density, same tensor schema.
-7. Impute missing optional fundamentals rather than excluding symbols (train + forecast).
+7. Impute missing optional fundamentals only on **train**; **forecast** excludes symbols without real fund data.

--- a/scripts/purge_forecasts_without_fundamentals.py
+++ b/scripts/purge_forecasts_without_fundamentals.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Delete forecast hive partitions for symbols lacking real fundamentals.
+
+Hard rule: forecasts/backtests require real local earnings + key metrics +
+analyst estimates (not zero-filled placeholders). Run after policy change or
+when FMP fund endpoints failed during a bulk refresh.
+
+Usage (prod home layout)::
+
+    data_dir=$HOME/.canswim/data \\
+      python scripts/purge_forecasts_without_fundamentals.py [--dry-run]
+
+Then rebuild the DuckDB search cache::
+
+    data_dir=$HOME/.canswim/data python scripts/rebuild_search_db.py
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import sys
+from pathlib import Path
+
+# Allow running from repo root without install
+_REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_REPO / "src"))
+
+from canswim.eligibility import (  # noqa: E402
+    fundamentals_are_ready,
+    load_fundamentals_symbol_sets,
+)
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--data-dir",
+        default=os.getenv("data_dir", str(Path.home() / ".canswim" / "data")),
+        help="canswim data_dir (default: env data_dir or ~/.canswim/data)",
+    )
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="List symbols that would be purged; do not delete",
+    )
+    args = p.parse_args()
+    data_dir = Path(args.data_dir).expanduser().resolve()
+    forecast_root = data_dir / "forecast"
+    if not forecast_root.is_dir():
+        print(f"No forecast dir at {forecast_root}", file=sys.stderr)
+        return 1
+
+    fund_sets = load_fundamentals_symbol_sets(data_dir)
+    dirs = sorted(forecast_root.glob("symbol=*"))
+    purge: list[str] = []
+    keep: list[str] = []
+    for d in dirs:
+        sym = d.name.split("=", 1)[-1].strip().upper()
+        ok, reason = fundamentals_are_ready(sym, fund_sets=fund_sets)
+        if ok:
+            keep.append(sym)
+        else:
+            purge.append(sym)
+            print(f"{'WOULD PURGE' if args.dry_run else 'PURGE'} {sym}: {reason}")
+            if not args.dry_run:
+                shutil.rmtree(d)
+
+    print(
+        f"done: keep={len(keep)} purge={len(purge)} dry_run={args.dry_run} "
+        f"data_dir={data_dir}"
+    )
+    if purge and not args.dry_run:
+        print(
+            "Next: rebuild search DB, e.g.\n"
+            f"  data_dir={data_dir} python scripts/rebuild_search_db.py"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = canswim
-version = 0.0.20260727
+version = 0.0.20260806
 author = Ivelin Ivanov
 author_email = ivelin117@gmail.com
 description = Developer toolkit for CANSLIM-style investors (CLI, Gradio GUI, MCP)

--- a/src/canswim/covariates.py
+++ b/src/canswim/covariates.py
@@ -57,6 +57,28 @@ class Covariates:
         self.future_covariates = {}
         self.data_dir = os.getenv("data_dir", "data")
         self.data_3rd_party = os.getenv("data-3rd-party", "data-3rd-party")
+        # Forecast/backtest: False → never invent fund rows (hard rule).
+        # Train may set True so #33 IPO / fund-thin dim padding still works.
+        self.allow_fundamentals_imputation = False
+        self.last_fundamentals_skipped: list[str] = []
+
+    def _impute_fund_or_skip(
+        self,
+        *,
+        symbol: str,
+        build_fn,
+        what: str,
+    ):
+        """Zero-fill only when imputation allowed; else record skip and return None."""
+        if self.allow_fundamentals_imputation:
+            logger.info(f"Zero-filling {what} for {symbol} (train imputation allowed)")
+            return build_fn()
+        logger.warning(
+            f"No real {what} for {symbol}; refusing zero-fill "
+            "(forecast requires real fundamentals)"
+        )
+        self.last_fundamentals_skipped.append(str(symbol).upper())
+        return None
 
     @property
     def pyarrow_filters(self):
@@ -98,10 +120,11 @@ class Covariates:
         return t_earn
 
     def prepare_earn_series(self, tickers=None, stock_price_series: dict = None):
-        """Earnings past-covs; missing names (IPOs, ETFs, thin coverage) are zero-filled.
+        """Earnings past-covs.
 
-        Fund-thin symbols never have EPS/revenue history; we still emit the train
-        schema so past_covariates dim matches the checkpoint (same idea as #33).
+        Train (``allow_fundamentals_imputation=True``): missing names may be
+        zero-filled so feature dim matches the checkpoint (#33).
+        Forecast (default False): missing names are **skipped** — never invented.
         """
         logger.info("preparing past covariates: earnings estimates ")
         price_map = stock_price_series if isinstance(stock_price_series, dict) else {}
@@ -110,16 +133,22 @@ class Covariates:
 
         earn_src = getattr(self, "earnings_loaded_df", None)
         if earn_src is None or (hasattr(earn_src, "empty") and earn_src.empty):
-            # No earnings in this batch (e.g. sector ETF alone) — fixed schema
-            if price_map:
+            if price_map and self.allow_fundamentals_imputation:
                 logger.info(
-                    "No earnings loaded for this batch (common for ETFs / fund-thin "
-                    f"names); zero-filling {len(_EARN_FEATURE_COLS)} earn columns"
+                    "No earnings loaded for this batch; zero-filling "
+                    f"{len(_EARN_FEATURE_COLS)} earn columns (train imputation)"
                 )
                 for t, prices in price_map.items():
                     t_earn_series[t] = self._zero_cov_from_columns(
                         _EARN_FEATURE_COLS, prices, fillna_value=-1
                     )
+            elif price_map:
+                for t in price_map:
+                    self.last_fundamentals_skipped.append(str(t).upper())
+                logger.warning(
+                    "No earnings loaded for this batch; refusing zero-fill for "
+                    f"{list(price_map.keys())} (forecast requires real fundamentals)"
+                )
             return t_earn_series
 
         # convert date strings to numerical representation
@@ -176,29 +205,32 @@ class Covariates:
                 t_earn_series[t] = tes
             except (KeyError, AssertionError, ValueError) as e:
                 logger.warning(
-                    f"No earnings series for {t} ({type(e)}: {e}); will zero-fill"
+                    f"No earnings series for {t} ({type(e)}: {e})"
                 )
 
-        # Issue #33 / fund-thin (ETF, IPO): impute missing earn covs so dim matches train
+        # Train-only: impute missing earn covs so dim matches checkpoint (#33).
+        # Forecast: leave missing symbols out (hard rule — no invented fundamentals).
         if price_map:
             template = next(iter(t_earn_series.values()), None)
-            if template is None:
-                logger.info(
-                    "No earnings in batch; zero-filling "
-                    f"{len(_EARN_FEATURE_COLS)} columns for all requested symbols"
-                )
-                for t, prices in price_map.items():
-                    t_earn_series[t] = self._zero_cov_from_columns(
-                        _EARN_FEATURE_COLS, prices, fillna_value=-1
-                    )
-            else:
-                for t, prices in price_map.items():
-                    if t not in t_earn_series:
-                        logger.info(
-                            f"Zero-filling earnings covariates for {t} "
-                            f"({len(template.components)} columns)"
+            for t, prices in price_map.items():
+                if t in t_earn_series:
+                    continue
+                if self.allow_fundamentals_imputation:
+                    if template is None:
+                        t_earn_series[t] = self._zero_cov_from_columns(
+                            _EARN_FEATURE_COLS, prices, fillna_value=-1
                         )
+                    else:
                         t_earn_series[t] = self._zero_cov_like(template, prices)
+                    logger.info(
+                        f"Zero-filling earnings covariates for {t} (train imputation)"
+                    )
+                else:
+                    logger.warning(
+                        f"No real earnings for {t}; refusing zero-fill "
+                        "(forecast requires real fundamentals)"
+                    )
+                    self.last_fundamentals_skipped.append(str(t).upper())
 
         return t_earn_series
 
@@ -312,17 +344,32 @@ class Covariates:
                 ), f"found gaps in series: \n{ts_padded.gaps()}"
                 t_inst_ownership_series[t] = ts_padded
             except KeyError as e:
-                # Do not drop the symbol: model was trained with ownership columns.
-                logger.info(
-                    f"No institutional ownership rows for {t} ({e}); zero-filling "
-                    f"{len(self.INST_OWNERSHIP_COLS)} ownership columns"
-                )
-                t_inst_ownership_series[t] = self._zero_ownership_series(prices)
+                if self.allow_fundamentals_imputation:
+                    logger.info(
+                        f"No institutional ownership rows for {t} ({e}); "
+                        f"zero-filling {len(self.INST_OWNERSHIP_COLS)} columns "
+                        "(train imputation)"
+                    )
+                    t_inst_ownership_series[t] = self._zero_ownership_series(prices)
+                else:
+                    logger.warning(
+                        f"No real institutional ownership for {t} ({e}); "
+                        "refusing zero-fill (forecast requires real fundamentals)"
+                    )
+                    self.last_fundamentals_skipped.append(str(t).upper())
             except AssertionError as e:
-                logger.warning(
-                    f"Ownership series invalid for {t} ({type(e)}: {e}); zero-filling"
-                )
-                t_inst_ownership_series[t] = self._zero_ownership_series(prices)
+                if self.allow_fundamentals_imputation:
+                    logger.warning(
+                        f"Ownership series invalid for {t} ({type(e)}: {e}); "
+                        "zero-filling (train imputation)"
+                    )
+                    t_inst_ownership_series[t] = self._zero_ownership_series(prices)
+                else:
+                    logger.warning(
+                        f"Ownership series invalid for {t} ({type(e)}: {e}); "
+                        "refusing zero-fill"
+                    )
+                    self.last_fundamentals_skipped.append(str(t).upper())
 
         return t_inst_ownership_series
 
@@ -340,10 +387,15 @@ class Covariates:
         new_covs = new_covs or {}
         # Nothing new to stack — keep existing (do not wipe symbols)
         if not new_covs:
-            if column_template is not None and old_covs:
+            if (
+                column_template is not None
+                and old_covs
+                and self.allow_fundamentals_imputation
+            ):
                 logger.warning(
                     "No new covariates for this stack step; zero-filling "
-                    f"{len(column_template.components)} template columns"
+                    f"{len(column_template.components)} template columns "
+                    "(train imputation)"
                 )
                 stacked = {}
                 for t, covs in old_covs.items():
@@ -358,9 +410,15 @@ class Covariates:
                             f"Skipping {t} while zero-fill stacking: {type(e)}: {e}"
                         )
                 return stacked if stacked else old_covs
-            logger.warning(
-                "No new covariates for this stack step; keeping prior covariates"
-            )
+            if not new_covs and old_covs and not self.allow_fundamentals_imputation:
+                logger.warning(
+                    "No new covariates for this stack step and imputation disabled; "
+                    "keeping prior covariates without invented fund columns"
+                )
+            else:
+                logger.warning(
+                    "No new covariates for this stack step; keeping prior covariates"
+                )
             return old_covs
         # stack sales and earnings to past covariates
         stacked_covs = {}
@@ -368,13 +426,19 @@ class Covariates:
         for t, covs in list(old_covs.items()):
             try:
                 if t not in new_covs:
-                    # Missing optional cov for this ticker: zero-fill columns so
-                    # feature dim stays consistent and we do not drop the symbol.
-                    logger.info(
-                        f"No new covariates for {t}; zero-filling "
-                        f"{len(template.components)} columns"
-                    )
-                    new_ts = self._zero_cov_like(template, covs)
+                    if self.allow_fundamentals_imputation:
+                        logger.info(
+                            f"No new covariates for {t}; zero-filling "
+                            f"{len(template.components)} columns (train imputation)"
+                        )
+                        new_ts = self._zero_cov_like(template, covs)
+                    else:
+                        logger.warning(
+                            f"Dropping {t} from covariate stack: missing fund block "
+                            "(forecast requires real fundamentals; no zero-fill)"
+                        )
+                        self.last_fundamentals_skipped.append(str(t).upper())
+                        continue
                 else:
                     new_ts = new_covs[t]
                 assert (
@@ -489,22 +553,32 @@ class Covariates:
         return timeseries_from_observed_df(aligned)
 
     def prepare_key_metrics(self, stock_price_series=None):
-        """Key metrics past-covs; missing names (IPOs, ETFs) are zero-filled to train dim."""
+        """Key metrics past-covs.
+
+        Train may zero-fill missing names; forecast skips them (no invented fund data).
+        """
         logger.info("preparing past covariates: key metrics")
         t_kms_series = {}
         stock_price_series = stock_price_series or {}
         kms_src = getattr(self, "kms_loaded_df", None)
         if kms_src is None or (hasattr(kms_src, "empty") and kms_src.empty):
             cols = self._key_metrics_template_columns()
-            if cols and stock_price_series:
+            if cols and stock_price_series and self.allow_fundamentals_imputation:
                 logger.info(
-                    "No key metrics loaded for this batch (common for ETFs / "
-                    f"fund-thin names); zero-filling {len(cols)} columns"
+                    "No key metrics loaded for this batch; zero-filling "
+                    f"{len(cols)} columns (train imputation)"
                 )
                 for t, prices in stock_price_series.items():
                     t_kms_series[t] = self._zero_cov_from_columns(
                         cols, prices, fillna_value=-1
                     )
+            elif stock_price_series:
+                for t in stock_price_series:
+                    self.last_fundamentals_skipped.append(str(t).upper())
+                logger.warning(
+                    "No key metrics loaded for this batch; refusing zero-fill "
+                    f"for {list(stock_price_series.keys())}"
+                )
             return t_kms_series
 
         kms_loaded_df = kms_src.copy()
@@ -553,35 +627,35 @@ class Covariates:
                 ), f"found gaps in tmks series: \n{kms_ser_padded.gaps()}"
                 t_kms_series[t] = kms_ser_padded
             except (KeyError, AssertionError, ValueError) as e:
-                logger.warning(
-                    f"No key metrics for {t} ({type(e)}: {e}); will zero-fill"
-                )
-        # Issue #33 / fund-thin (ETF, IPO): impute missing key metrics so dim matches
+                logger.warning(f"No key metrics for {t} ({type(e)}: {e})")
+        # Train-only impute; forecast skips missing symbols.
         if stock_price_series:
             template = next(iter(t_kms_series.values()), None)
-            if template is None:
-                cols = self._key_metrics_template_columns()
-                if cols:
-                    logger.info(
-                        f"No key metrics in batch; zero-filling {len(cols)} columns "
-                        "for all requested symbols"
-                    )
-                    for t, prices in stock_price_series.items():
+            cols = self._key_metrics_template_columns() if template is None else None
+            for t, prices in stock_price_series.items():
+                if t in t_kms_series:
+                    continue
+                if self.allow_fundamentals_imputation:
+                    if template is not None:
+                        t_kms_series[t] = self._zero_cov_like(template, prices)
+                    elif cols:
                         t_kms_series[t] = self._zero_cov_from_columns(
                             cols, prices, fillna_value=-1
                         )
+                    else:
+                        logger.warning(
+                            "No key-metrics template available; stack will omit this block"
+                        )
+                        break
+                    logger.info(
+                        f"Zero-filling key metrics for {t} (train imputation)"
+                    )
                 else:
                     logger.warning(
-                        "No key-metrics template available; stack will omit this block"
+                        f"No real key metrics for {t}; refusing zero-fill "
+                        "(forecast requires real fundamentals)"
                     )
-            else:
-                for t, prices in stock_price_series.items():
-                    if t not in t_kms_series:
-                        logger.info(
-                            f"Zero-filling key metrics for {t} "
-                            f"({len(template.components)} columns)"
-                        )
-                        t_kms_series[t] = self._zero_cov_like(template, prices)
+                    self.last_fundamentals_skipped.append(str(t).upper())
         return t_kms_series
 
     def _key_metrics_template_columns(self) -> list[str]:
@@ -884,35 +958,36 @@ class Covariates:
 
                 except (KeyError, AssertionError, ValueError) as e:
                     logger.info(
-                        f"No analyst estimates[{period}] for {t} ({type(e)}: {e}); "
-                        "will zero-fill"
+                        f"No analyst estimates[{period}] for {t} ({type(e)}: {e})"
                     )
-        # Issue #33 / fund-thin (ETF, IPO): impute so future_cov dim matches train
+        # Train-only impute; forecast skips missing symbols.
         if stock_price_series:
             template = next(iter(t_est_series.values()), None)
-            if template is None:
+            if template is None and self.allow_fundamentals_imputation:
                 logger.info(
-                    f"No analyst estimates[{period}] in batch "
-                    "(common for ETFs / fund-thin names); loading disk template"
+                    f"No analyst estimates[{period}] in batch; "
+                    "loading disk template (train imputation)"
                 )
                 template = self._build_est_template_from_disk(
                     period=period,
                     n_future_periods=n_future_periods,
                     price_like=next(iter(stock_price_series.values())),
                 )
-            if template is not None:
-                for t, prices in stock_price_series.items():
-                    if t not in t_est_series:
-                        logger.info(
-                            f"Zero-filling analyst estimates[{period}] for {t} "
-                            f"({len(template.components)} columns)"
-                        )
-                        t_est_series[t] = self._zero_cov_like(template, prices)
-            else:
-                logger.warning(
-                    f"No analyst estimates[{period}] template; "
-                    "stack may omit this block (dim risk)"
-                )
+            for t, prices in stock_price_series.items():
+                if t in t_est_series:
+                    continue
+                if self.allow_fundamentals_imputation and template is not None:
+                    logger.info(
+                        f"Zero-filling analyst estimates[{period}] for {t} "
+                        f"(train imputation, {len(template.components)} columns)"
+                    )
+                    t_est_series[t] = self._zero_cov_like(template, prices)
+                else:
+                    logger.warning(
+                        f"No real analyst estimates[{period}] for {t}; "
+                        "refusing zero-fill (forecast requires real fundamentals)"
+                    )
+                    self.last_fundamentals_skipped.append(str(t).upper())
         return t_est_series
 
     def _build_est_template_from_disk(

--- a/src/canswim/dashboard/run_tab.py
+++ b/src/canswim/dashboard/run_tab.py
@@ -460,8 +460,9 @@ def _refresh_summary(result: dict) -> str:
         if is_cov:
             lines.append(
                 "1. **Recommended:** Try again after **Update market data** "
-                "(fundamentals). ETFs and other fund-thin names use zero-filled "
-                "fund inputs like IPOs—if it still fails, open **Technical log**."
+                "(fundamentals). Forecast never invents fundamentals — names without "
+                "real earnings/key metrics/estimates are skipped. "
+                "If it still fails, open **Technical log**."
             )
             lines.append(
                 "2. Or forecast a regular stock (e.g. LLY) to confirm the model path."

--- a/src/canswim/eligibility.py
+++ b/src/canswim/eligibility.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import re
-from typing import Sequence, Tuple
+from pathlib import Path
+from typing import Optional, Sequence, Tuple
 
 import pandas as pd
 from loguru import logger
@@ -126,6 +127,127 @@ def assert_no_invented_ohlc(price_df: pd.DataFrame) -> None:
 
 class GroundTruthDataError(RuntimeError):
     """Raised when train/forecast cannot proceed without inventing market data."""
+
+
+# --- Real fundamentals (forecast hard rule: no zero-filled fund covariates) ---
+
+_FUND_EARNINGS = "earnings_calendar.parquet"
+_FUND_KEY_METRICS = "keymetrics_history.parquet"
+_FUND_EST_ANNUAL = "analyst_estimates_annual.parquet"
+_FUND_EST_QUARTER = "analyst_estimates_quarter.parquet"
+
+
+def data_3rd_party_root(
+    data_dir: Optional[str | Path] = None,
+    third: Optional[str] = None,
+) -> Path:
+    import os
+
+    root = Path(data_dir or os.getenv("data_dir", "data"))
+    sub = third or os.getenv("data-3rd-party", "data-3rd-party")
+    return root / sub
+
+
+def _symbols_in_parquet(path: Path) -> set[str]:
+    """Uppercase symbols present as MultiIndex level 0 or a symbol column."""
+    if not path.is_file():
+        return set()
+    try:
+        df = pd.read_parquet(path)
+    except Exception as e:
+        logger.warning("Could not read {}: {}", path, e)
+        return set()
+    if df is None or df.empty:
+        return set()
+    if isinstance(df.index, pd.MultiIndex) and df.index.nlevels >= 1:
+        return {str(s).upper() for s in df.index.get_level_values(0).unique()}
+    for col in ("Symbol", "symbol"):
+        if col in df.columns:
+            return {str(s).upper() for s in df[col].dropna().unique()}
+    return set()
+
+
+def load_fundamentals_symbol_sets(
+    data_dir: Optional[str | Path] = None,
+    third: Optional[str] = None,
+) -> dict[str, set[str]]:
+    """Load symbol sets for each required fund parquet (cached by caller if needed)."""
+    root = data_3rd_party_root(data_dir, third)
+    return {
+        "earnings": _symbols_in_parquet(root / _FUND_EARNINGS),
+        "key_metrics": _symbols_in_parquet(root / _FUND_KEY_METRICS),
+        "est_annual": _symbols_in_parquet(root / _FUND_EST_ANNUAL),
+        "est_quarter": _symbols_in_parquet(root / _FUND_EST_QUARTER),
+    }
+
+
+def symbols_with_real_fundamentals(
+    data_dir: Optional[str | Path] = None,
+    third: Optional[str] = None,
+    *,
+    fund_sets: Optional[dict[str, set[str]]] = None,
+) -> set[str]:
+    """Symbols that have real local earnings + key metrics + estimates.
+
+    Requires non-empty rows for:
+    - earnings calendar
+    - key metrics
+    - analyst estimates (annual **or** quarterly)
+
+    Used as a hard gate for forecast/backtest (no zero-filled fund placeholders).
+    """
+    sets = fund_sets or load_fundamentals_symbol_sets(data_dir, third)
+    estimates = sets.get("est_annual", set()) | sets.get("est_quarter", set())
+    return (
+        sets.get("earnings", set())
+        & sets.get("key_metrics", set())
+        & estimates
+    )
+
+
+def fundamentals_are_ready(
+    symbol: str,
+    *,
+    data_dir: Optional[str | Path] = None,
+    third: Optional[str] = None,
+    fund_sets: Optional[dict[str, set[str]]] = None,
+) -> Tuple[bool, str]:
+    """Return (ok, reason) for a single symbol's real fundamentals on disk."""
+    sym = str(symbol or "").strip().upper()
+    if not sym:
+        return False, "empty symbol"
+    sets = fund_sets or load_fundamentals_symbol_sets(data_dir, third)
+    missing: list[str] = []
+    if sym not in sets.get("earnings", set()):
+        missing.append("earnings")
+    if sym not in sets.get("key_metrics", set()):
+        missing.append("key_metrics")
+    est = sets.get("est_annual", set()) | sets.get("est_quarter", set())
+    if sym not in est:
+        missing.append("analyst_estimates")
+    if missing:
+        return False, "missing real " + ", ".join(missing)
+    return True, "ok"
+
+
+def partition_by_fundamentals(
+    symbols: Sequence[str],
+    *,
+    data_dir: Optional[str | Path] = None,
+    third: Optional[str] = None,
+    fund_sets: Optional[dict[str, set[str]]] = None,
+) -> Tuple[list[str], list[str]]:
+    """Split symbols into (ready, missing_fundamentals), preserving order."""
+    sets = fund_sets or load_fundamentals_symbol_sets(data_dir, third)
+    ready: list[str] = []
+    missing: list[str] = []
+    for s in symbols:
+        ok, _ = fundamentals_are_ready(s, fund_sets=sets)
+        if ok:
+            ready.append(str(s).strip().upper())
+        else:
+            missing.append(str(s).strip().upper())
+    return ready, missing
 
 
 def observed_trading_day_freq(index: pd.DatetimeIndex) -> pd.offsets.CustomBusinessDay:

--- a/src/canswim/mcp/tools/_common.py
+++ b/src/canswim/mcp/tools/_common.py
@@ -236,6 +236,7 @@ FAIL_JOB_FAILED = "job_failed"
 FAIL_JOB_INTERRUPTED = "job_interrupted"
 FAIL_MODEL_NOT_LOADED = "model_not_loaded"
 FAIL_REMOTE_API = "remote_api"
+FAIL_FUNDAMENTALS = "fundamentals"
 FAIL_INTERNAL = "internal"
 
 _DEFAULT_CLIENT_HINTS: dict[str, str] = {
@@ -274,6 +275,12 @@ _DEFAULT_CLIENT_HINTS: dict[str, str] = {
     FAIL_REMOTE_API: (
         "Check network, API keys, and provider plan/rate limits; then retry "
         "with a smaller symbol list if needed."
+    ),
+    FAIL_FUNDAMENTALS: (
+        "These symbols lack real local earnings, key metrics, and/or analyst "
+        "estimates. Run Update market data / gather when the data provider plan "
+        "includes those endpoints; do not claim a forecast was produced. "
+        "Forecast never invents fundamentals (no zero-fill placeholders)."
     ),
     FAIL_INTERNAL: (
         "Retry once. If it persists, report the error string to the host operator."
@@ -359,4 +366,11 @@ def infer_fail_reason_from_error(error: str | None) -> str | None:
         "search data" in low and "operator" in low
     ):
         return FAIL_DB_NOT_READY
+    if (
+        "real fundamentals" in low
+        or "no real fundamentals" in low
+        or "zero-filled placeholder" in low
+        or ("earnings" in low and "key metrics" in low and "estimates" in low)
+    ):
+        return FAIL_FUNDAMENTALS
     return None

--- a/src/canswim/model.py
+++ b/src/canswim/model.py
@@ -427,9 +427,20 @@ class CanswimModel:
         )
         logger.info(f"Prepared {len(self.targets.target_series)} stock targets")
 
-    def prepare_forecast_data(self, start_date: pd.Timestamp = None):
+    def prepare_forecast_data(
+        self,
+        start_date: pd.Timestamp = None,
+        *,
+        allow_fundamentals_imputation: bool = False,
+    ):
         # prepare stock price time series
         ## ticker_train_dict = dict((k, self.ticker_dict[k]) for k in self.stock_tickers)
+        # Forecast/backtest hard rule: never invent fund covariates.
+        # Train sets allow_fundamentals_imputation=True via prepare_data().
+        self.covariates.allow_fundamentals_imputation = bool(
+            allow_fundamentals_imputation
+        )
+        self.covariates.last_fundamentals_skipped = []
         self.prepare_stock_price_data(start_date=start_date)
         self.covariates.prepare_data(
             stock_price_series=self.stock_price_series,
@@ -486,7 +497,10 @@ class CanswimModel:
         logger.info("Forecasting data prepared")
 
     def prepare_data(self):
-        self.prepare_forecast_data(self.train_date_start)
+        # Train may impute fund-thin symbols so feature dim matches checkpoint (#33).
+        self.prepare_forecast_data(
+            self.train_date_start, allow_fundamentals_imputation=True
+        )
         logger.info("Preparing train, val, test splits")
         self.__prepare_data_splits()
 

--- a/src/canswim/run_triggers.py
+++ b/src/canswim/run_triggers.py
@@ -109,8 +109,15 @@ COVARIATE_FAIL_MSG = (
     "Prices may be fine, but model inputs (ownership, estimates, or other fundamentals) "
     "are missing or could not be aligned. "
     "Try Update market data again (includes fundamentals), then re-run the forecast. "
-    "ETFs and other fund-thin names use zero-filled fund covariates (like IPOs); "
-    "if this still fails, see Technical log for a feature-dimension mismatch."
+    "Forecast never invents fundamentals (no zero-filled fund placeholders). "
+    "If this still fails, see Technical log for a feature-dimension mismatch."
+)
+
+MISSING_FUNDAMENTALS_MSG = (
+    "No real fundamentals on file for: {symbols}. "
+    "Forecasts and backtests require local earnings, key metrics, and analyst estimates "
+    "(not zero-filled placeholders). "
+    "Update market data when your FMP plan includes those endpoints, then retry."
 )
 
 # Catch-up as-of origins need full model lookback *before* the origin date.
@@ -787,6 +794,36 @@ def forecast_for_tickers(
 
     tickers: list[str] = parsed["tickers"]
     messages: list[str] = list(parsed.get("messages") or [])
+
+    # Hard rule: do not forecast/backtest without real fund data on disk.
+    from canswim.eligibility import partition_by_fundamentals
+
+    fund_ready, fund_missing = partition_by_fundamentals(tickers)
+    if fund_missing:
+        messages.append(
+            "Skipped (no real fundamentals — earnings + key metrics + estimates): "
+            + ", ".join(fund_missing)
+        )
+    if not fund_ready:
+        return {
+            "ok": False,
+            "error": MISSING_FUNDAMENTALS_MSG.format(
+                symbols=", ".join(fund_missing) or "requested symbols"
+            ),
+            "tickers": tickers,
+            "rejected": parsed.get("rejected", []),
+            "resolved_start": None,
+            "forecasted": [],
+            "skipped": fund_missing,
+            "incomplete": fund_missing,
+            "need_gather": True,
+            "need_covariates": True,
+            "fail_reason": "fundamentals",
+            "messages": messages,
+        }
+    if fund_missing:
+        tickers = fund_ready
+
     blank = forecast_start_date is None or not str(forecast_start_date).strip()
     months = (
         catchup_months
@@ -971,10 +1008,12 @@ def forecast_for_tickers(
                 symbols=", ".join(incomplete_syms) or "requested symbols",
                 need=need_bars or 336,
             )
-        elif reason == "covariates":
-            err = COVARIATE_FAIL_MSG.format(
-                symbols=", ".join(incomplete_syms) or "requested symbols"
-            )
+        elif reason in ("covariates", "fundamentals"):
+            err = (
+                MISSING_FUNDAMENTALS_MSG
+                if reason == "fundamentals"
+                else COVARIATE_FAIL_MSG
+            ).format(symbols=", ".join(incomplete_syms) or "requested symbols")
         else:
             err = INCOMPLETE_DATA_MSG.format(
                 symbols=", ".join(incomplete_syms) or "requested symbols"
@@ -992,8 +1031,8 @@ def forecast_for_tickers(
             "skipped": incomplete_syms,
             "already_have_forecast": sorted(all_already),
             "messages": messages,
-            "need_gather": reason in ("prices", "short_history"),
-            "need_covariates": reason == "covariates",
+            "need_gather": reason in ("prices", "short_history", "fundamentals"),
+            "need_covariates": reason in ("covariates", "fundamentals"),
             "model_loaded": model_loaded,
             "fail_reason": reason,
             "skip_details": list(skip_details or []),

--- a/tests/canswim/test_cov_imputation.py
+++ b/tests/canswim/test_cov_imputation.py
@@ -24,8 +24,9 @@ def _price_ts(n: int = 30, start: str = "2024-01-02") -> TimeSeries:
     return timeseries_from_observed_df(df)
 
 
-def test_prepare_earn_zero_fills_missing_ticker():
+def test_prepare_earn_zero_fills_missing_ticker_when_train_imputation_allowed():
     c = Covariates()
+    c.allow_fundamentals_imputation = True
     # Only COVERED has earnings rows
     idx = pd.MultiIndex.from_tuples(
         [
@@ -56,8 +57,38 @@ def test_prepare_earn_zero_fills_missing_ticker():
     assert out["IPO"].pd_dataframe().notna().all().all()
 
 
+def test_prepare_earn_refuses_zero_fill_on_forecast_path():
+    """Forecast hard rule: missing earnings → skip, never invent fund rows."""
+    c = Covariates()
+    assert c.allow_fundamentals_imputation is False
+    idx = pd.MultiIndex.from_tuples(
+        [("COVERED", pd.Timestamp("2024-01-15"))],
+        names=["Symbol", "Date"],
+    )
+    c.earnings_loaded_df = pd.DataFrame(
+        {
+            "eps": [1.0],
+            "epsEstimated": [0.9],
+            "time": ["amc"],
+            "revenue": [1e6],
+            "revenueEstimated": [9e5],
+            "updatedFromDate": pd.to_datetime(["2024-01-10"]),
+            "fiscalDateEnding": pd.to_datetime(["2023-12-31"]),
+        },
+        index=idx,
+    )
+    prices = {"COVERED": _price_ts(), "IPO": _price_ts()}
+    out = c.prepare_earn_series(
+        tickers=prices.keys(), stock_price_series=prices
+    )
+    assert "COVERED" in out
+    assert "IPO" not in out
+    assert "IPO" in c.last_fundamentals_skipped
+
+
 def test_prepare_est_zero_fills_missing_ticker():
     c = Covariates()
+    c.allow_fundamentals_imputation = True
     # Minimal annual estimates for one symbol only
     idx = pd.MultiIndex.from_tuples(
         [
@@ -106,6 +137,7 @@ def test_prepare_est_zero_fills_missing_ticker():
 
 def test_prepare_key_metrics_zero_fills_missing():
     c = Covariates()
+    c.allow_fundamentals_imputation = True
     idx = pd.MultiIndex.from_tuples(
         [
             ("HAS", pd.Timestamp("2024-03-31")),
@@ -128,10 +160,11 @@ def test_prepare_key_metrics_zero_fills_missing():
 
 
 def test_fund_thin_empty_batch_zero_fills_earn_like_etf():
-    """ETF-style batch: no earnings rows at all still gets train-shaped columns."""
+    """ETF-style batch: train imputation still pads empty earnings loads."""
     from canswim.covariates import _EARN_FEATURE_COLS
 
     c = Covariates()
+    c.allow_fundamentals_imputation = True
     c.earnings_loaded_df = pd.DataFrame()  # empty load (XLF-only filter)
     prices = {"XLF": _price_ts()}
     out = c.prepare_earn_series(stock_price_series=prices)
@@ -141,6 +174,7 @@ def test_fund_thin_empty_batch_zero_fills_earn_like_etf():
 
 def test_fund_thin_empty_batch_zero_fills_key_metrics():
     c = Covariates()
+    c.allow_fundamentals_imputation = True
     c.kms_loaded_df = pd.DataFrame()
     # Provide columns via mock of disk template path
     c._key_metrics_template_columns = lambda: [  # type: ignore[method-assign]
@@ -160,6 +194,7 @@ def test_fund_thin_empty_batch_zero_fills_key_metrics():
 
 def test_fund_thin_empty_batch_zero_fills_estimates():
     c = Covariates()
+    c.allow_fundamentals_imputation = True
     prices = {"XLF": _price_ts(n=60, start="2023-06-01")}
     # Disk template via stub
     tmpl = c._zero_cov_from_columns(

--- a/tests/canswim/test_covariates_stack.py
+++ b/tests/canswim/test_covariates_stack.py
@@ -42,6 +42,7 @@ def test_prepare_ownership_zero_fills_missing_ticker():
     c.inst_symbol_ownership_df = pd.DataFrame(columns=cols, index=idx)
 
     prices = _price_ts()
+    c.allow_fundamentals_imputation = True
     out = c.prepare_institutional_symbol_ownership_series(
         stock_price_series={"QLYS": prices}
     )
@@ -51,6 +52,7 @@ def test_prepare_ownership_zero_fills_missing_ticker():
 
 def test_stack_zero_fills_missing_ticker_not_drop():
     c = Covariates()
+    c.allow_fundamentals_imputation = True
     base = _price_ts().drop_columns(["Close"])  # Open/High/Low/Volume
     # Only AAPL has new covs; QLYS should be zero-filled not dropped
     new_aapl = timeseries_from_observed_df(
@@ -72,6 +74,7 @@ def test_stack_zero_fills_missing_ticker_not_drop():
 
 def test_stack_empty_new_with_column_template():
     c = Covariates()
+    c.allow_fundamentals_imputation = True
     base = _price_ts().drop_columns(["Close"])
     template = timeseries_from_observed_df(
         pd.DataFrame(

--- a/tests/canswim/test_forecast_hard_fail.py
+++ b/tests/canswim/test_forecast_hard_fail.py
@@ -24,23 +24,27 @@ def test_forecast_hard_fail_when_no_groups(monkeypatch):
     cf.prep_next_stock_group.return_value = iter([])
 
     with patch(
-        "canswim.run_triggers.resolve_start_for_run",
-        return_value={
-            "ok": True,
-            "start": "2026-03-02",
-            "reason": "snapped_week_start",
-            "live_default": "2026-07-13",
-            "input": None,
-            "error": None,
-            "latest_close_used": None,
-        },
+        "canswim.eligibility.partition_by_fundamentals",
+        return_value=(["AAPL"], []),
     ):
         with patch(
-            "canswim.run_triggers.list_symbols_with_saved_forecast",
-            return_value=set(),
+            "canswim.run_triggers.resolve_start_for_run",
+            return_value={
+                "ok": True,
+                "start": "2026-03-02",
+                "reason": "snapped_week_start",
+                "live_default": "2026-07-13",
+                "input": None,
+                "error": None,
+                "latest_close_used": None,
+            },
         ):
-            with patch("canswim.forecast.CanswimForecaster", return_value=cf):
-                r = forecast_for_tickers("AAPL", forecast_start_date="2026-03-02")
+            with patch(
+                "canswim.run_triggers.list_symbols_with_saved_forecast",
+                return_value=set(),
+            ):
+                with patch("canswim.forecast.CanswimForecaster", return_value=cf):
+                    r = forecast_for_tickers("AAPL", forecast_start_date="2026-03-02")
 
     assert r["ok"] is False
     # no groups prepared → covariate/align failure path (not pure price gap)
@@ -63,25 +67,29 @@ def test_forecast_hard_fail_when_partial_skip(monkeypatch):
     cf.get_forecast.return_value = {"AAPL": mock_ts}
 
     with patch(
-        "canswim.run_triggers.resolve_start_for_run",
-        return_value={
-            "ok": True,
-            "start": "2026-03-02",
-            "reason": "snapped_week_start",
-            "live_default": "2026-07-13",
-            "input": None,
-            "error": None,
-            "latest_close_used": None,
-        },
+        "canswim.eligibility.partition_by_fundamentals",
+        return_value=(["AAPL", "MSFT"], []),
     ):
         with patch(
-            "canswim.run_triggers.list_symbols_with_saved_forecast",
-            return_value=set(),
+            "canswim.run_triggers.resolve_start_for_run",
+            return_value={
+                "ok": True,
+                "start": "2026-03-02",
+                "reason": "snapped_week_start",
+                "live_default": "2026-07-13",
+                "input": None,
+                "error": None,
+                "latest_close_used": None,
+            },
         ):
-            with patch("canswim.forecast.CanswimForecaster", return_value=cf):
-                r = forecast_for_tickers(
-                    "AAPL,MSFT", forecast_start_date="2026-03-02"
-                )
+            with patch(
+                "canswim.run_triggers.list_symbols_with_saved_forecast",
+                return_value=set(),
+            ):
+                with patch("canswim.forecast.CanswimForecaster", return_value=cf):
+                    r = forecast_for_tickers(
+                        "AAPL,MSFT", forecast_start_date="2026-03-02"
+                    )
 
     assert r["ok"] is False
     assert r.get("need_gather") or r.get("need_covariates")

--- a/tests/canswim/test_forecast_skip_existing.py
+++ b/tests/canswim/test_forecast_skip_existing.py
@@ -106,28 +106,36 @@ def test_get_stocks_without_forecast_subtracts_already_saved():
     assert out == ["AMD"]
 
 
+def _fund_all_ready(symbols, **kwargs):
+    return [str(s).strip().upper() for s in symbols], []
+
+
 def test_forecast_skips_model_when_all_already_saved(monkeypatch):
     monkeypatch.setenv("MCP_ALLOW_RUNS", "1")
     with patch(
-        "canswim.run_triggers.resolve_start_for_run",
-        return_value={
-            "ok": True,
-            "start": "2026-03-02",
-            "reason": "snapped_week_start",
-            "live_default": "2026-07-13",
-            "input": None,
-            "error": None,
-            "latest_close_used": None,
-        },
+        "canswim.eligibility.partition_by_fundamentals",
+        side_effect=_fund_all_ready,
     ):
         with patch(
-            "canswim.run_triggers.list_symbols_with_saved_forecast",
-            return_value={"AAPL", "MSFT"},
+            "canswim.run_triggers.resolve_start_for_run",
+            return_value={
+                "ok": True,
+                "start": "2026-03-02",
+                "reason": "snapped_week_start",
+                "live_default": "2026-07-13",
+                "input": None,
+                "error": None,
+                "latest_close_used": None,
+            },
         ):
-            with patch("canswim.forecast.CanswimForecaster") as CF:
-                r = forecast_for_tickers(
-                    "AAPL,MSFT", forecast_start_date="2026-03-02"
-                )
+            with patch(
+                "canswim.run_triggers.list_symbols_with_saved_forecast",
+                return_value={"AAPL", "MSFT"},
+            ):
+                with patch("canswim.forecast.CanswimForecaster") as CF:
+                    r = forecast_for_tickers(
+                        "AAPL,MSFT", forecast_start_date="2026-03-02"
+                    )
     assert r["ok"] is True
     assert r.get("already_saved") is True
     assert r.get("model_loaded") is False
@@ -153,25 +161,29 @@ def test_forecast_only_runs_missing_symbols(monkeypatch):
     cf.get_forecast.return_value = {"MSFT": mock_ts}
 
     with patch(
-        "canswim.run_triggers.resolve_start_for_run",
-        return_value={
-            "ok": True,
-            "start": "2026-03-02",
-            "reason": "snapped_week_start",
-            "live_default": "2026-07-13",
-            "input": None,
-            "error": None,
-            "latest_close_used": None,
-        },
+        "canswim.eligibility.partition_by_fundamentals",
+        side_effect=_fund_all_ready,
     ):
         with patch(
-            "canswim.run_triggers.list_symbols_with_saved_forecast",
-            return_value={"AAPL"},  # AAPL done; only MSFT needs work
+            "canswim.run_triggers.resolve_start_for_run",
+            return_value={
+                "ok": True,
+                "start": "2026-03-02",
+                "reason": "snapped_week_start",
+                "live_default": "2026-07-13",
+                "input": None,
+                "error": None,
+                "latest_close_used": None,
+            },
         ):
-            with patch("canswim.forecast.CanswimForecaster", return_value=cf):
-                r = forecast_for_tickers(
-                    "AAPL,MSFT", forecast_start_date="2026-03-02"
-                )
+            with patch(
+                "canswim.run_triggers.list_symbols_with_saved_forecast",
+                return_value={"AAPL"},  # AAPL done; only MSFT needs work
+            ):
+                with patch("canswim.forecast.CanswimForecaster", return_value=cf):
+                    r = forecast_for_tickers(
+                        "AAPL,MSFT", forecast_start_date="2026-03-02"
+                    )
 
     assert r["ok"] is True
     assert r.get("model_loaded") is True

--- a/tests/canswim/test_fundamentals_hard_rule.py
+++ b/tests/canswim/test_fundamentals_hard_rule.py
@@ -135,3 +135,180 @@ def test_stack_drops_missing_when_imputation_disabled():
     assert "AAPL" in stacked
     assert "QLYS" not in stacked
     assert "QLYS" in c.last_fundamentals_skipped
+
+
+def test_symbols_with_real_fundamentals_intersection(tmp_path, monkeypatch):
+    monkeypatch.setenv("data_dir", str(tmp_path))
+    _write_fund_parquets(tmp_path, good=["AAPL"], partial=["MSFT"])
+    got = symbols_with_real_fundamentals(data_dir=tmp_path)
+    assert got == {"AAPL"}
+
+
+def test_forecast_partial_list_keeps_fund_ready_only(tmp_path, monkeypatch):
+    """Mixed list: only symbols with full fund files stay in the run set."""
+    monkeypatch.setenv("data_dir", str(tmp_path))
+    monkeypatch.setenv("MCP_ALLOW_RUNS", "1")
+    _write_fund_parquets(tmp_path, good=["AAPL"], partial=["SPY"])
+    r = forecast_for_tickers(
+        "AAPL,SPY", forecast_start_date="2026-03-02", dry_run=True, force_allow=True
+    )
+    assert r["ok"] is True
+    assert r["dry_run"] is True
+    assert r["tickers"] == ["AAPL"]
+    assert any("SPY" in m for m in (r.get("messages") or []))
+
+
+def test_prepare_key_metrics_refuses_zero_fill_on_forecast_path():
+    c = Covariates()
+    idx = pd.MultiIndex.from_tuples(
+        [("HAS", pd.Timestamp("2024-03-31"))],
+        names=["Symbol", "Date"],
+    )
+    c.kms_loaded_df = pd.DataFrame(
+        {
+            "period": ["Q1"],
+            "revenuePerShare": [1.0],
+            "netIncomePerShare": [0.1],
+        },
+        index=idx,
+    )
+    idx_p = pd.bdate_range("2024-01-02", periods=30)
+    prices = {
+        "HAS": timeseries_from_observed_df(
+            pd.DataFrame(
+                {
+                    "Open": range(30),
+                    "High": range(1, 31),
+                    "Low": range(30),
+                    "Close": range(30),
+                    "Volume": [1e6] * 30,
+                },
+                index=idx_p,
+            )
+        ),
+        "MISS": timeseries_from_observed_df(
+            pd.DataFrame(
+                {
+                    "Open": range(30),
+                    "High": range(1, 31),
+                    "Low": range(30),
+                    "Close": range(30),
+                    "Volume": [1e6] * 30,
+                },
+                index=idx_p,
+            )
+        ),
+    }
+    out = c.prepare_key_metrics(stock_price_series=prices)
+    assert "HAS" in out
+    assert "MISS" not in out
+    assert "MISS" in c.last_fundamentals_skipped
+
+
+def test_ownership_refuses_zero_fill_on_forecast_path():
+    c = Covariates()
+    cols = list(Covariates.INST_OWNERSHIP_COLS)
+    c.inst_symbol_ownership_df = pd.DataFrame(
+        columns=cols,
+        index=pd.MultiIndex.from_tuples([], names=["Symbol", "Date"]),
+    )
+    idx = pd.bdate_range("2024-01-02", periods=20)
+    prices = timeseries_from_observed_df(
+        pd.DataFrame(
+            {
+                "Open": range(20),
+                "High": range(1, 21),
+                "Low": range(20),
+                "Close": range(20),
+                "Volume": [1e6] * 20,
+            },
+            index=idx,
+        )
+    )
+    out = c.prepare_institutional_symbol_ownership_series(
+        stock_price_series={"ETF": prices}
+    )
+    assert out == {} or "ETF" not in out
+    assert "ETF" in c.last_fundamentals_skipped
+
+
+def test_mcp_forecast_surfaces_fundamentals_fail_reason(monkeypatch):
+    from canswim.mcp.tools import runs as run_tools
+    from canswim.mcp.tools._common import FAIL_FUNDAMENTALS
+
+    monkeypatch.setenv("MCP_ALLOW_RUNS", "1")
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(
+            "canswim.run_triggers.forecast_for_tickers",
+            lambda *a, **k: {
+                "ok": False,
+                "error": MISSING_FUNDAMENTALS_MSG.format(symbols="SPY"),
+                "fail_reason": "fundamentals",
+                "need_covariates": True,
+                "tickers": ["SPY"],
+            },
+        )
+        out = run_tools.forecast_tickers_impl("SPY", dry_run=False)
+    assert out["ok"] is False
+    assert out.get("fail_reason") == FAIL_FUNDAMENTALS
+    assert out.get("client_hint")
+    assert "fundamentals" in out["client_hint"].lower() or "earnings" in out[
+        "client_hint"
+    ].lower()
+
+
+def test_infer_fail_reason_fundamentals():
+    from canswim.mcp.tools._common import (
+        FAIL_FUNDAMENTALS,
+        infer_fail_reason_from_error,
+    )
+
+    assert (
+        infer_fail_reason_from_error(
+            MISSING_FUNDAMENTALS_MSG.format(symbols="X")
+        )
+        == FAIL_FUNDAMENTALS
+    )
+
+
+def test_purge_script_dry_run(tmp_path, monkeypatch):
+    """Purge script removes only symbols lacking fund files."""
+    import subprocess
+    import sys
+
+    monkeypatch.setenv("data_dir", str(tmp_path))
+    _write_fund_parquets(tmp_path, good=["AAPL"], partial=["SPY"])
+    fc = tmp_path / "forecast"
+    for sym in ("AAPL", "SPY"):
+        d = fc / f"symbol={sym}" / "forecast_start_year=2026" / "forecast_start_month=3"
+        d.mkdir(parents=True)
+        (d / "part.parquet").write_bytes(b"x")
+
+    script = Path(__file__).resolve().parents[2] / "scripts" / "purge_forecasts_without_fundamentals.py"
+    r = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "--data-dir",
+            str(tmp_path),
+            "--dry-run",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert r.returncode == 0
+    assert "WOULD PURGE SPY" in r.stdout
+    assert "keep=1 purge=1" in r.stdout
+    # dry-run does not delete
+    assert (fc / "symbol=SPY").is_dir()
+
+    r2 = subprocess.run(
+        [sys.executable, str(script), "--data-dir", str(tmp_path)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert r2.returncode == 0
+    assert (fc / "symbol=AAPL").is_dir()
+    assert not (fc / "symbol=SPY").exists()

--- a/tests/canswim/test_fundamentals_hard_rule.py
+++ b/tests/canswim/test_fundamentals_hard_rule.py
@@ -1,0 +1,137 @@
+"""Forecast hard rule: real fundamentals required; no zero-filled fund placeholders."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from canswim.eligibility import (
+    fundamentals_are_ready,
+    partition_by_fundamentals,
+    symbols_with_real_fundamentals,
+)
+from canswim.run_triggers import MISSING_FUNDAMENTALS_MSG, forecast_for_tickers
+from canswim.covariates import Covariates
+from canswim.eligibility import timeseries_from_observed_df
+
+
+def _write_fund_parquets(root: Path, *, good: list[str], partial: list[str] | None = None):
+    """Write minimal earn/kms/est parquet under data-3rd-party."""
+    third = root / "data-3rd-party"
+    third.mkdir(parents=True, exist_ok=True)
+    partial = partial or []
+
+    def mi(syms, n=2):
+        rows = []
+        for s in syms:
+            for i in range(n):
+                rows.append((s, pd.Timestamp("2024-01-15") + pd.Timedelta(days=90 * i)))
+        return pd.MultiIndex.from_tuples(rows, names=["Symbol", "Date"])
+
+    earn_syms = good + partial
+    pd.DataFrame(
+        {
+            "eps": [1.0] * (len(earn_syms) * 2),
+            "epsEstimated": [0.9] * (len(earn_syms) * 2),
+            "time": ["amc"] * (len(earn_syms) * 2),
+            "revenue": [1e6] * (len(earn_syms) * 2),
+            "revenueEstimated": [9e5] * (len(earn_syms) * 2),
+            "updatedFromDate": pd.to_datetime(["2024-01-10"] * (len(earn_syms) * 2)),
+            "fiscalDateEnding": pd.to_datetime(["2023-12-31"] * (len(earn_syms) * 2)),
+        },
+        index=mi(earn_syms),
+    ).to_parquet(third / "earnings_calendar.parquet")
+
+    kms_syms = list(good)  # partial missing key metrics
+    if kms_syms:
+        pd.DataFrame(
+            {
+                "period": ["Q1", "Q2"] * len(kms_syms),
+                "revenuePerShare": [1.0, 1.1] * len(kms_syms),
+                "netIncomePerShare": [0.1, 0.11] * len(kms_syms),
+            },
+            index=mi(kms_syms),
+        ).to_parquet(third / "keymetrics_history.parquet")
+    else:
+        pd.DataFrame(
+            {"period": [], "revenuePerShare": [], "netIncomePerShare": []},
+            index=pd.MultiIndex.from_tuples([], names=["Symbol", "Date"]),
+        ).to_parquet(third / "keymetrics_history.parquet")
+
+    est_syms = list(good)
+    if est_syms:
+        pd.DataFrame(
+            {
+                "estimatedRevenueAvg": [1e9, 1.1e9] * len(est_syms),
+                "estimatedEpsAvg": [2.0, 2.2] * len(est_syms),
+            },
+            index=mi(est_syms),
+        ).to_parquet(third / "analyst_estimates_annual.parquet")
+    else:
+        pd.DataFrame(
+            {"estimatedRevenueAvg": [], "estimatedEpsAvg": []},
+            index=pd.MultiIndex.from_tuples([], names=["Symbol", "Date"]),
+        ).to_parquet(third / "analyst_estimates_annual.parquet")
+
+    # empty quarter file still ok
+    pd.DataFrame(
+        {"estimatedRevenueAvg": [], "estimatedEpsAvg": []},
+        index=pd.MultiIndex.from_tuples([], names=["Symbol", "Date"]),
+    ).to_parquet(third / "analyst_estimates_quarter.parquet")
+
+
+def test_partition_by_fundamentals(tmp_path, monkeypatch):
+    monkeypatch.setenv("data_dir", str(tmp_path))
+    _write_fund_parquets(tmp_path, good=["AAPL", "MSFT"], partial=["ETF1"])
+    ready, missing = partition_by_fundamentals(
+        ["AAPL", "ETF1", "MSFT", "NONE"], data_dir=tmp_path
+    )
+    assert ready == ["AAPL", "MSFT"]
+    assert set(missing) == {"ETF1", "NONE"}
+    ok, reason = fundamentals_are_ready("ETF1", data_dir=tmp_path)
+    assert not ok
+    assert "key_metrics" in reason or "analyst" in reason
+
+
+def test_forecast_for_tickers_hard_fails_without_fundamentals(tmp_path, monkeypatch):
+    monkeypatch.setenv("data_dir", str(tmp_path))
+    monkeypatch.setenv("MCP_ALLOW_RUNS", "1")
+    _write_fund_parquets(tmp_path, good=[], partial=["SPY"])
+    r = forecast_for_tickers("SPY", forecast_start_date="2026-03-02", force_allow=True)
+    assert r["ok"] is False
+    assert r.get("fail_reason") == "fundamentals"
+    assert r.get("need_covariates") is True
+    assert "SPY" in (r.get("error") or "")
+    assert "real fundamentals" in (r.get("error") or "").lower() or "fundamentals" in (
+        r.get("error") or ""
+    ).lower()
+    assert MISSING_FUNDAMENTALS_MSG.format(symbols="X").startswith("No real")
+
+
+def test_stack_drops_missing_when_imputation_disabled():
+    c = Covariates()
+    assert c.allow_fundamentals_imputation is False
+    idx = pd.bdate_range("2024-01-02", periods=20)
+    base = timeseries_from_observed_df(
+        pd.DataFrame(
+            {
+                "Open": range(20),
+                "High": range(1, 21),
+                "Low": range(20),
+                "Volume": [1e6] * 20,
+            },
+            index=idx,
+        )
+    )
+    new_aapl = timeseries_from_observed_df(
+        pd.DataFrame({"feat_a": 1.0}, index=idx)
+    )
+    stacked = c.stack_covariates(
+        old_covs={"AAPL": base, "QLYS": base},
+        new_covs={"AAPL": new_aapl},
+    )
+    assert "AAPL" in stacked
+    assert "QLYS" not in stacked
+    assert "QLYS" in c.last_fundamentals_skipped

--- a/tests/canswim/test_key_metrics_dedupe.py
+++ b/tests/canswim/test_key_metrics_dedupe.py
@@ -92,8 +92,9 @@ def test_prepare_key_metrics_collapses_biz_day_collision():
 
 
 def test_prepare_key_metrics_imputes_missing_symbol_without_aborting():
-    """Missing KMS for one ticker is zero-filled (#33); others still prepare."""
+    """Missing KMS for one ticker is zero-filled (#33 train); others still prepare."""
     c = Covariates()
+    c.allow_fundamentals_imputation = True
     idx = pd.MultiIndex.from_tuples(
         [
             ("OK", pd.Timestamp("2023-06-30")),

--- a/tests/canswim/test_mcp_client_errors.py
+++ b/tests/canswim/test_mcp_client_errors.py
@@ -180,10 +180,17 @@ def test_forecast_model_not_loaded_via_tool(mcp_ready, monkeypatch):
         )
 
     with patch(
-        "canswim.forecast.CanswimForecaster.download_model",
-        boom_download,
+        "canswim.eligibility.partition_by_fundamentals",
+        side_effect=lambda symbols, **kw: (
+            [str(s).strip().upper() for s in symbols],
+            [],
+        ),
     ):
-        out = run_tools.forecast_tickers_impl("AAA", dry_run=False)
+        with patch(
+            "canswim.forecast.CanswimForecaster.download_model",
+            boom_download,
+        ):
+            out = run_tools.forecast_tickers_impl("AAA", dry_run=False)
     _assert_client_failure(out, fail_reason=FAIL_MODEL_NOT_LOADED)
     assert "Forecast model not loaded" in out["error"]
     assert out.get("client_hint")

--- a/tests/canswim/test_run_triggers.py
+++ b/tests/canswim/test_run_triggers.py
@@ -115,25 +115,33 @@ def test_gather_force_allow_skips_gate(monkeypatch):
     assert r["tickers"] == ["AAPL"]
 
 
+def _fund_all_ready(symbols, **kwargs):
+    return [str(s).strip().upper() for s in symbols], []
+
+
 def test_forecast_dry_run_resolves_start(monkeypatch):
     monkeypatch.setenv("MCP_ALLOW_RUNS", "1")
     with patch(
-        "canswim.run_triggers.resolve_start_for_run",
-        return_value={
-            "ok": True,
-            "start": "2026-03-02",
-            "reason": "snapped_week_start",
-            "live_default": "2026-07-13",
-            "input": "2026-03-05",
-            "error": None,
-            "latest_close_used": "2026-07-10",
-        },
+        "canswim.eligibility.partition_by_fundamentals",
+        side_effect=_fund_all_ready,
     ):
-        r = forecast_for_tickers(
-            "AAPL,MSFT",
-            forecast_start_date="2026-03-05",
-            dry_run=True,
-        )
+        with patch(
+            "canswim.run_triggers.resolve_start_for_run",
+            return_value={
+                "ok": True,
+                "start": "2026-03-02",
+                "reason": "snapped_week_start",
+                "live_default": "2026-07-13",
+                "input": "2026-03-05",
+                "error": None,
+                "latest_close_used": "2026-07-10",
+            },
+        ):
+            r = forecast_for_tickers(
+                "AAPL,MSFT",
+                forecast_start_date="2026-03-05",
+                dry_run=True,
+            )
     assert r["ok"] is True
     assert r["dry_run"] is True
     assert r["mode"] == "single"
@@ -145,33 +153,37 @@ def test_forecast_blank_start_is_catchup_dry_run(monkeypatch):
     monkeypatch.setenv("MCP_ALLOW_RUNS", "1")
     monkeypatch.setenv("CATCHUP_MONTHS", "6")
     with patch(
-        "canswim.run_triggers.list_monthly_catchup_origins",
-        return_value=[
-            "2026-01-02",
-            "2026-02-02",
-            "2026-03-02",
-            "2026-04-01",
-            "2026-05-01",
-            "2026-06-01",
-            "2026-07-13",
-        ],
+        "canswim.eligibility.partition_by_fundamentals",
+        side_effect=_fund_all_ready,
     ):
         with patch(
-            "canswim.run_triggers.resolve_start_for_run",
-            return_value={
-                "ok": True,
-                "start": "2026-07-13",
-                "reason": "default_live",
-                "live_default": "2026-07-13",
-                "input": None,
-                "error": None,
-            },
+            "canswim.run_triggers.list_monthly_catchup_origins",
+            return_value=[
+                "2026-01-02",
+                "2026-02-02",
+                "2026-03-02",
+                "2026-04-01",
+                "2026-05-01",
+                "2026-06-01",
+                "2026-07-13",
+            ],
         ):
             with patch(
-                "canswim.run_triggers.list_symbols_with_saved_forecast",
-                return_value=[],
+                "canswim.run_triggers.resolve_start_for_run",
+                return_value={
+                    "ok": True,
+                    "start": "2026-07-13",
+                    "reason": "default_live",
+                    "live_default": "2026-07-13",
+                    "input": None,
+                    "error": None,
+                },
             ):
-                r = forecast_for_tickers("AAPL", dry_run=True)
+                with patch(
+                    "canswim.run_triggers.list_symbols_with_saved_forecast",
+                    return_value=[],
+                ):
+                    r = forecast_for_tickers("AAPL", dry_run=True)
     assert r["ok"] is True
     assert r["mode"] == "catchup"
     assert r["dry_run"] is True
@@ -269,24 +281,28 @@ def test_forecast_passes_resolved_start_to_forecaster(monkeypatch):
     cf.get_forecast.return_value = {"AAPL": mock_ts}
 
     with patch(
-        "canswim.run_triggers.resolve_start_for_run",
-        return_value={
-            "ok": True,
-            "start": "2026-03-02",
-            "reason": "snapped_week_start",
-            "live_default": "2026-07-13",
-            "input": "2026-03-05",
-            "error": None,
-            "latest_close_used": None,
-        },
+        "canswim.eligibility.partition_by_fundamentals",
+        side_effect=_fund_all_ready,
     ):
-        with patch("canswim.forecast.CanswimForecaster", return_value=cf):
-            with patch("canswim.forecast.get_next_open_market_day"):
-                r = forecast_for_tickers(
-                    "AAPL",
-                    forecast_start_date="2026-03-05",
-                    dry_run=False,
-                )
+        with patch(
+            "canswim.run_triggers.resolve_start_for_run",
+            return_value={
+                "ok": True,
+                "start": "2026-03-02",
+                "reason": "snapped_week_start",
+                "live_default": "2026-07-13",
+                "input": "2026-03-05",
+                "error": None,
+                "latest_close_used": None,
+            },
+        ):
+            with patch("canswim.forecast.CanswimForecaster", return_value=cf):
+                with patch("canswim.forecast.get_next_open_market_day"):
+                    r = forecast_for_tickers(
+                        "AAPL",
+                        forecast_start_date="2026-03-05",
+                        dry_run=False,
+                    )
 
     assert r["ok"] is True
     assert r["forecasted"] == ["AAPL"]


### PR DESCRIPTION
## Summary

- **Hard rule for forecast/backtest:** require real local **earnings + key metrics + analyst estimates** (annual or quarterly). No zero-filled fund placeholders at inference.
- **Train path unchanged for #33:** `allow_fundamentals_imputation=True` still pads fund-thin symbols during training so feature width matches the checkpoint.
- **Gate:** `forecast_for_tickers` / refresh skip symbols lacking fund data (`fail_reason=fundamentals`).
- **Operator cleanup:** `scripts/purge_forecasts_without_fundamentals.py`; already run on prod `~/.canswim/data` (**43** hive trees removed; **168** kept; DuckDB rebuilt).
- **Docs / MCP version** `0.0.20260806` + CHANGELOG.

## Prod cleanup (already applied on this host)

```text
keep=168 purge=43  (mostly ETFs / fund-thin names without real earn/kms/estimates)
forecast symbols in DuckDB: 168
```

Re-run purge after other hosts if needed:

```bash
data_dir=$HOME/.canswim/data python scripts/purge_forecasts_without_fundamentals.py
data_dir=$HOME/.canswim/data python scripts/rebuild_search_db.py
```

## Test plan

- [x] `./scripts/ci-local.sh` (282 passed)
- [x] Unit tests for eligibility partition, refuse zero-fill on forecast path, stack drop
- [ ] After merge: restart `canswim-mcp` so clients see version `0.0.20260806`
- [ ] Refresh a stock with full fund files (e.g. AAPL) → should still work when FMP/local data ok
- [ ] Refresh an ETF without fund rows (e.g. SPY) → `fail_reason=fundamentals`, no new forecast files