### PR TITLE
feat: weekend job for all DB symbols (live week forecast)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -29,6 +29,7 @@ Local work should keep **`hfhub_sync=False`** (default) unless you intentionally
 | `gatherdata` | Get market data (full universe or scoped) | `--tickers`, `--no_covariates` |
 | `forecast` | Run forecasts (full or scoped) | `--tickers`, `--forecast_start_date`, `--dry_run` |
 | `resolve_start` | Print which forecast start date would be used | `--forecast_start_date` |
+| `weekend` | Host job: gather + **live week** forecast for **all** DuckDB `stock_tickers` | `--dry_run`, `--catchup`, `--skip_gather`, `--batch_size`, `--no_covariates` |
 | `mcp` | MCP server for clients | env `MCP_ALLOW_RUNS=1` for writes; `--http --host --port` for Streamable HTTP |
 | `train` | Continuous model training (full history) | `--new_model` |
 | `modelsearch` | Hyperparameter search | — |
@@ -63,14 +64,35 @@ python -m canswim dashboard --same_data True
 
 Without `--tickers`, `gatherdata` / `forecast` keep **full-universe / train-style** behavior (longer history, not the lean 2y scoped path).
 
+### Weekend job (all symbols in the database)
+
+Uses the Charts/search universe (`stock_tickers` in DuckDB), not a CSV alone.
+Default forecast origin is the **live week start** (`resolve_start` with a blank date). Batches through gather + forecast so a full DB does not hit MCP-style 50-symbol caps.
+
+```bash
+# Plan only (start date + batch list)
+data_dir=$HOME/.canswim/data python -m canswim weekend --dry_run
+
+# Live run (host operator; long-running)
+data_dir=$HOME/.canswim/data python -m canswim weekend
+
+# Optional: monthly catch-up + live for the whole DB (much longer)
+data_dir=$HOME/.canswim/data python -m canswim weekend --catchup
+```
+
+Production timer: [deploy_service.md](deploy_service.md) (`canswim-weekend.timer`). Wrapper: `./weekend.sh`.
+
 ### Flags (scoped gather / forecast)
 
 | Flag | Tasks | Meaning |
 |------|-------|---------|
 | `--tickers "AAPL, MSFT"` | `gatherdata`, `forecast` | Scoped run via `run_triggers` (≤50 symbols) |
 | `--forecast_start_date YYYY-MM-DD` | `forecast`, `resolve_start` | Origin date; week-aligned per [run_triggers.md](run_triggers.md) |
-| `--dry_run` | `forecast --tickers` | Validate only (no torch) |
-| `--no_covariates` | `gatherdata --tickers` | Prices (+ broad market path) only; skip earnings, ownership, etc. |
+| `--dry_run` | `forecast --tickers`, `weekend` | Validate only (no torch / no gather writes for weekend) |
+| `--catchup` | `weekend` | Monthly catch-up + live (blank start); default is **live week only** |
+| `--skip_gather` | `weekend` | Forecast only |
+| `--batch_size N` | `weekend` | Symbols per batch (default `WEEKEND_BATCH_SIZE` or 25) |
+| `--no_covariates` | `gatherdata --tickers`, `weekend` | Prices only; skip earnings, ownership, etc. |
 | `--same_data True` | `dashboard` | Reuse DuckDB search DB (faster start) |
 | `--new_model True` | `train` | Train a new model instead of continuing |
 | `--http` | `mcp` | Streamable HTTP (gateway) instead of stdio |

--- a/docs/deploy_service.md
+++ b/docs/deploy_service.md
@@ -205,6 +205,33 @@ curl -sS -X POST "http://127.0.0.1:3472/mcp" \
 
 FastMCP serves the protocol at **`/mcp`** on that port. Details: [mcp.md](mcp.md).
 
+## 3b. Weekend timer (all DB symbols, live week forecast)
+
+Recurring **host** job (not MCP): load every symbol in DuckDB `stock_tickers`, update market data in batches, forecast the **live week start** (next market week open). Same policy as CLI `gather` / `forecast`.
+
+Templates in the checkout: `service/canswim-weekend.service` and `service/canswim-weekend.timer` (copy into `~/.canswim/service/` and/or `~/.config/systemd/user/`).
+
+```bash
+# From repo (or after copying units)
+cp service/canswim-weekend.service service/canswim-weekend.timer ~/.config/systemd/user/
+# Point PYTHON / CANSWIM_DIR at this host (edit unit or drop-in)
+systemctl --user daemon-reload
+systemctl --user enable --now canswim-weekend.timer
+systemctl --user list-timers 'canswim-weekend*' --no-pager
+# Manual one-shot:
+systemctl --user start canswim-weekend.service
+journalctl --user -u canswim-weekend -n 50 --no-pager
+```
+
+Dry-run without systemd:
+
+```bash
+data_dir=$HOME/.canswim/data python -m canswim weekend --dry_run
+# or: ./weekend.sh --dry_run
+```
+
+Default calendar: **Saturday 06:00** local (`OnCalendar=Sat *-*-* 06:00:00`). Adjust the timer for your timezone / market. Full catch-up is opt-in: `python -m canswim weekend --catchup` (edit `ExecStart` if you want the timer to catch up).
+
 ## 4. Public MCP via gateway + apikey
 
 Use one edge (e.g. **Tailscale Funnel → Caddy :8080**) for all MCPs. Pattern:

--- a/docs/run_triggers.md
+++ b/docs/run_triggers.md
@@ -19,6 +19,14 @@ MCP write tools need `MCP_ALLOW_RUNS=1`. CLI and dashboard do not.
 
 Without `--tickers`, CLI `gatherdata` / `forecast` keep **full-universe / train-style** behavior.
 
+## Weekend host job (all DB symbols)
+
+CLI task **`weekend`** (`./weekend.sh`, `canswim-weekend.timer`) loads every symbol
+from DuckDB **`stock_tickers`**, batches gather + forecast, and defaults to the
+**live week start** from blank `resolve_start`. Optional `--catchup` uses blank
+forecast start (monthly catch-up + live). Host operator path (`force_allow`), not
+an MCP tool. See [cli.md](cli.md) and [deploy_service.md](deploy_service.md).
+
 ## Get market data (lean & rate-limit aware)
 
 For scoped runs (`--tickers` / dashboard / MCP):

--- a/service/canswim-weekend.service
+++ b/service/canswim-weekend.service
@@ -1,0 +1,32 @@
+[Unit]
+Description=CANSWIM weekend gather + live-week forecast (all stock_tickers)
+Documentation=https://ivelin.github.io/canswim/deploy_service/
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+# Same layout as canswim-mcp / dashboard — override in drop-ins if needed.
+Environment=CANSWIM_DIR=%h/canswim
+Environment=CANSWIM_HOME=%h/.canswim
+Environment=data_dir=%h/.canswim/data
+Environment=db_file=canswim_local.duckdb
+Environment=hfhub_sync=False
+Environment=PYTHON=%h/.venvs/dgx-spark-cu130/bin/python
+WorkingDirectory=%h/canswim
+# Host operator job (not MCP-gated): force_allow is built into the weekend path.
+ExecStart=/bin/bash -lc 'set -euo pipefail; \
+  cd "${CANSWIM_DIR}"; \
+  export PYTHONPATH="${CANSWIM_DIR}/src${PYTHONPATH:+:$PYTHONPATH}"; \
+  export data_dir="${data_dir}"; \
+  export db_file="${db_file}"; \
+  export hfhub_sync="${hfhub_sync:-False}"; \
+  if [[ -r "${HOME}/.env" ]]; then set -a; source "${HOME}/.env"; set +a; \
+    export FMP_API_KEY="${FMP_API_KEY:-${FMP_API_Key:-}}"; fi; \
+  exec "${PYTHON:-python3}" -m canswim weekend'
+Nice=10
+# Long runs (full DB) can take hours
+TimeoutStartSec=12h
+
+[Install]
+WantedBy=default.target

--- a/service/canswim-weekend.timer
+++ b/service/canswim-weekend.timer
@@ -1,0 +1,13 @@
+[Unit]
+Description=Schedule CANSWIM weekend forecast (all DB symbols, live week start)
+Documentation=https://ivelin.github.io/canswim/deploy_service/
+
+[Timer]
+# Saturday 06:00 local (after Friday close / before Monday open in US-centric setups)
+OnCalendar=Sat *-*-* 06:00:00
+Persistent=true
+RandomizedDelaySec=15m
+Unit=canswim-weekend.service
+
+[Install]
+WantedBy=timers.target

--- a/src/canswim/__main__.py
+++ b/src/canswim/__main__.py
@@ -64,6 +64,8 @@ parser.add_argument(
         `mcp` — MCP server (read-only by default; write tools need MCP_ALLOW_RUNS=1).
           Use --http / --transport streamable-http --host/--port for gateway HTTP.
         `resolve_start` — show which forecast start date would be used.
+        `weekend` — host job: gather + live-week forecast for all DB symbols
+          (stock_tickers). Use with systemd timer or cron on weekends.
         """,
     choices=[
         "dashboard",
@@ -75,6 +77,7 @@ parser.add_argument(
         "forecast",
         "mcp",
         "resolve_start",
+        "weekend",
     ],
 )
 
@@ -103,7 +106,35 @@ parser.add_argument(
     action="store_true",
     default=False,
     help=(
-        "With `forecast --tickers`: only check symbols and start date (no model run)."
+        "With `forecast --tickers` or `weekend`: plan only (no model / no gather writes)."
+    ),
+)
+
+parser.add_argument(
+    "--catchup",
+    action="store_true",
+    default=False,
+    help=(
+        "With `weekend`: blank forecast start (monthly catch-up + live). "
+        "Default is live week start only."
+    ),
+)
+
+parser.add_argument(
+    "--skip_gather",
+    action="store_true",
+    default=False,
+    help="With `weekend`: forecast only (skip market-data update).",
+)
+
+parser.add_argument(
+    "--batch_size",
+    type=int,
+    required=False,
+    default=None,
+    help=(
+        "With `weekend`: symbols per gather/forecast batch "
+        "(default WEEKEND_BATCH_SIZE or 25)."
     ),
 )
 
@@ -268,6 +299,18 @@ match args.task:
         from canswim.cli_run import run_resolve_start
 
         sys.exit(run_resolve_start(args.forecast_start_date))
+    case "weekend":
+        from canswim.cli_run import run_weekend
+
+        sys.exit(
+            run_weekend(
+                dry_run=bool(args.dry_run),
+                catchup=bool(args.catchup),
+                include_covariates=not args.no_covariates,
+                batch_size=args.batch_size,
+                skip_gather=bool(args.skip_gather),
+            )
+        )
     case "mcp":
         from canswim.mcp.server import main as mcp_main
 

--- a/src/canswim/cli_run.py
+++ b/src/canswim/cli_run.py
@@ -61,3 +61,28 @@ def run_resolve_start(forecast_start_date: Optional[str] = None) -> int:
     """Preview week-aligned start (no gather/forecast)."""
     info = resolve_start_for_run(forecast_start_date or None)
     return _print_result(info)
+
+
+def run_weekend(
+    *,
+    dry_run: bool = False,
+    catchup: bool = False,
+    include_covariates: bool = True,
+    batch_size: int | None = None,
+    skip_gather: bool = False,
+) -> int:
+    """Weekend host job: gather + forecast for all DuckDB stock_tickers."""
+    from canswim.weekend import DEFAULT_WEEKEND_BATCH, run_weekend_all_db
+
+    logger.info(
+        f"CLI weekend: dry_run={dry_run} catchup={catchup} "
+        f"batch_size={batch_size or DEFAULT_WEEKEND_BATCH} skip_gather={skip_gather}"
+    )
+    result = run_weekend_all_db(
+        dry_run=dry_run,
+        catchup=catchup,
+        include_covariates=include_covariates,
+        batch_size=batch_size or DEFAULT_WEEKEND_BATCH,
+        skip_gather=skip_gather,
+    )
+    return _print_result(result)

--- a/src/canswim/weekend.py
+++ b/src/canswim/weekend.py
@@ -1,0 +1,248 @@
+"""Weekend routine: gather + live-week forecast for all DB symbols.
+
+Intended for a recurring systemd timer (or cron) on the host operator account.
+Uses the same ``gather_for_tickers`` / ``forecast_for_tickers`` paths as CLI/MCP
+so policy (price hard-fail, fund gates, skip-existing) stays DRY.
+
+Default: **live week start only** (next market week open after the latest close).
+Optional ``--catchup`` runs blank-start catch-up (~12 monthly origins + live).
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Optional, Sequence
+
+from loguru import logger
+
+from canswim.run_triggers import (
+    DEFAULT_MAX_TICKERS,
+    forecast_for_tickers,
+    gather_for_tickers,
+    resolve_start_for_run,
+)
+
+# Host weekend batches: keep GPU/RAM bounded; larger than MCP blocking max is OK
+# because we call run_triggers with force_allow and per-batch max_tickers.
+DEFAULT_WEEKEND_BATCH = int(os.getenv("WEEKEND_BATCH_SIZE", "25"))
+
+
+def list_db_symbols(*, db_path: Optional[str] = None) -> list[str]:
+    """Sorted symbols from the search DB ``stock_tickers`` table."""
+    from canswim.db import get_db_path, list_tickers
+
+    path = db_path or get_db_path()
+    syms = list_tickers(path)
+    out = sorted({str(s).strip().upper() for s in (syms or []) if str(s).strip()})
+    logger.info("Weekend universe from stock_tickers: {} symbol(s) ({})", len(out), path)
+    return out
+
+
+def _chunks(items: Sequence[str], size: int) -> list[list[str]]:
+    n = max(int(size), 1)
+    return [list(items[i : i + n]) for i in range(0, len(items), n)]
+
+
+def run_weekend_all_db(
+    *,
+    dry_run: bool = False,
+    catchup: bool = False,
+    include_covariates: bool = True,
+    batch_size: int = DEFAULT_WEEKEND_BATCH,
+    skip_gather: bool = False,
+    symbols: Optional[Sequence[str]] = None,
+    db_path: Optional[str] = None,
+) -> dict[str, Any]:
+    """Run weekend gather + forecast for all (or provided) DB symbols.
+
+    Parameters
+    ----------
+    dry_run
+        Plan only: resolve start, list batches, no gather/forecast model work.
+    catchup
+        If True, blank forecast start (monthly catch-up + live). If False
+        (default), only the resolved **live** week start.
+    include_covariates
+        Pass through to gather (fundamentals when provider allows).
+    batch_size
+        Symbols per gather/forecast batch (default WEEKEND_BATCH_SIZE or 25).
+    skip_gather
+        Forecast only (assumes prices already fresh).
+    symbols
+        Override universe (tests); default = DuckDB ``stock_tickers``.
+    """
+    messages: list[str] = []
+    universe = (
+        sorted({str(s).strip().upper() for s in symbols if str(s).strip()})
+        if symbols is not None
+        else list_db_symbols(db_path=db_path)
+    )
+    if not universe:
+        return {
+            "ok": False,
+            "error": "No symbols in stock_tickers (empty Charts universe).",
+            "symbols": [],
+            "messages": messages,
+            "dry_run": dry_run,
+        }
+
+    start_info = resolve_start_for_run(None)
+    if not start_info.get("ok"):
+        return {
+            "ok": False,
+            "error": start_info.get("error") or "Could not resolve live forecast start",
+            "resolved_start": start_info,
+            "symbols": universe,
+            "messages": messages,
+            "dry_run": dry_run,
+        }
+    live_start = start_info["start"]
+    forecast_start = None if catchup else live_start
+    mode = "catchup" if catchup else "live"
+    messages.append(
+        f"Weekend mode={mode}: universe={len(universe)} symbols; "
+        f"live_start={live_start}; "
+        f"forecast_start={'catch-up (blank)' if catchup else live_start}"
+    )
+
+    batches = _chunks(universe, batch_size)
+    messages.append(f"Batch plan: {len(batches)} batch(es) of up to {batch_size}")
+
+    plan = {
+        "ok": True,
+        "dry_run": True,
+        "mode": mode,
+        "live_start": live_start,
+        "forecast_start_date": forecast_start,
+        "resolved_start": start_info,
+        "symbols": universe,
+        "batch_size": batch_size,
+        "batch_count": len(batches),
+        "batches": [
+            {"index": i, "tickers": b, "n": len(b)} for i, b in enumerate(batches)
+        ],
+        "skip_gather": skip_gather,
+        "include_covariates": include_covariates,
+        "messages": messages,
+    }
+    if dry_run:
+        messages.append("Dry run only — no gather or forecast executed.")
+        return plan
+
+    # Live run
+    batch_results: list[dict[str, Any]] = []
+    all_forecasted: list[str] = []
+    all_incomplete: list[str] = []
+    any_fail = False
+
+    for i, batch in enumerate(batches):
+        ticker_csv = ",".join(batch)
+        logger.info(
+            "Weekend batch {}/{} ({} symbols): {}",
+            i + 1,
+            len(batches),
+            len(batch),
+            ticker_csv[:120] + ("…" if len(ticker_csv) > 120 else ""),
+        )
+        br: dict[str, Any] = {
+            "batch_index": i,
+            "tickers": batch,
+            "gather": None,
+            "forecast": None,
+        }
+        if not skip_gather:
+            g = gather_for_tickers(
+                ticker_csv,
+                include_covariates=include_covariates,
+                force_allow=True,
+                max_tickers=max(len(batch), DEFAULT_MAX_TICKERS),
+            )
+            br["gather"] = {
+                "ok": g.get("ok"),
+                "ready": g.get("ready"),
+                "incomplete": g.get("incomplete"),
+                "error": g.get("error"),
+            }
+            if not g.get("ok") and not g.get("ready"):
+                any_fail = True
+                all_incomplete.extend(batch)
+                batch_results.append(br)
+                messages.append(
+                    f"Batch {i + 1}: gather failed — {g.get('error')}; skipping forecast"
+                )
+                continue
+            # Prefer forecast-ready from gather when present
+            ready = list(g.get("ready") or batch)
+            incomplete_g = list(g.get("incomplete") or [])
+            all_incomplete.extend(incomplete_g)
+            if not ready:
+                any_fail = True
+                batch_results.append(br)
+                messages.append(f"Batch {i + 1}: no forecast-ready symbols after gather")
+                continue
+            fc_tickers = ",".join(ready)
+        else:
+            fc_tickers = ticker_csv
+            ready = list(batch)
+
+        fc = forecast_for_tickers(
+            fc_tickers,
+            forecast_start_date=forecast_start,
+            force_allow=True,
+            max_tickers=max(len(ready), DEFAULT_MAX_TICKERS),
+            dry_run=False,
+        )
+        br["forecast"] = {
+            "ok": fc.get("ok"),
+            "forecasted": fc.get("forecasted"),
+            "skipped": fc.get("skipped"),
+            "incomplete": fc.get("incomplete") or fc.get("incomplete_starts"),
+            "error": fc.get("error"),
+            "fail_reason": fc.get("fail_reason"),
+            "already_have_forecast": fc.get("already_have_forecast"),
+        }
+        forecasted = list(fc.get("forecasted") or [])
+        all_forecasted.extend(forecasted)
+        if fc.get("skipped"):
+            all_incomplete.extend(
+                [str(x).split("@")[0] for x in (fc.get("skipped") or [])]
+            )
+        if not fc.get("ok") and not forecasted and not fc.get("already_saved"):
+            any_fail = True
+        messages.append(
+            f"Batch {i + 1}/{len(batches)}: forecasted={len(forecasted)} "
+            f"ok={fc.get('ok')} err={fc.get('error')!r}"
+        )
+        batch_results.append(br)
+
+    # de-dupe incomplete while preserving order
+    seen: set[str] = set()
+    incomplete_u: list[str] = []
+    for s in all_incomplete:
+        u = str(s).strip().upper()
+        if u and u not in seen:
+            seen.add(u)
+            incomplete_u.append(u)
+    forecasted_u = sorted({str(s).upper() for s in all_forecasted})
+
+    ok = (not any_fail) or bool(forecasted_u)
+    return {
+        "ok": ok,
+        "dry_run": False,
+        "mode": mode,
+        "live_start": live_start,
+        "forecast_start_date": forecast_start,
+        "resolved_start": start_info,
+        "symbols": universe,
+        "batch_size": batch_size,
+        "batch_count": len(batches),
+        "batch_results": batch_results,
+        "forecasted": forecasted_u,
+        "incomplete": incomplete_u,
+        "skip_gather": skip_gather,
+        "include_covariates": include_covariates,
+        "messages": messages,
+        "error": None
+        if ok
+        else "Weekend run finished with failures; see batch_results and messages.",
+    }

--- a/src/canswim/weekend.py
+++ b/src/canswim/weekend.py
@@ -33,7 +33,18 @@ def list_db_symbols(*, db_path: Optional[str] = None) -> list[str]:
 
     path = db_path or get_db_path()
     syms = list_tickers(path)
-    out = sorted({str(s).strip().upper() for s in (syms or []) if str(s).strip()})
+    out: list[str] = []
+    seen: set[str] = set()
+    for s in syms or []:
+        if s is None:
+            continue
+        u = str(s).strip().upper()
+        if not u or u in {"NONE", "NAN", "NULL"}:
+            continue
+        if u not in seen:
+            seen.add(u)
+            out.append(u)
+    out.sort()
     logger.info("Weekend universe from stock_tickers: {} symbol(s) ({})", len(out), path)
     return out
 

--- a/tests/canswim/test_docs_sync.py
+++ b/tests/canswim/test_docs_sync.py
@@ -97,6 +97,8 @@ def test_deploy_service_doc_covers_gui_and_mcp_split():
         "CANSWIM_HOME",
         "~/.canswim/service",
         "~/.canswim/data",
+        "canswim-weekend",
+        "stock_tickers",
     ):
         assert needle in text, f"docs/deploy_service.md missing {needle!r}"
     # Legacy deploy path must not reappear as the documented primary layout

--- a/tests/canswim/test_weekend.py
+++ b/tests/canswim/test_weekend.py
@@ -1,0 +1,156 @@
+"""Weekend all-DB job planning and batch orchestration."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from canswim.weekend import _chunks, run_weekend_all_db
+
+
+def test_chunks():
+    assert _chunks(["A", "B", "C", "D", "E"], 2) == [
+        ["A", "B"],
+        ["C", "D"],
+        ["E"],
+    ]
+    assert _chunks([], 10) == []
+
+
+def test_weekend_dry_run_plans_batches_and_live_start(monkeypatch):
+    monkeypatch.setenv("MCP_ALLOW_RUNS", "0")  # force_allow path still used inside
+    with patch(
+        "canswim.weekend.list_db_symbols",
+        return_value=["AAPL", "MSFT", "NVDA", "AMD"],
+    ):
+        with patch(
+            "canswim.weekend.resolve_start_for_run",
+            return_value={
+                "ok": True,
+                "start": "2026-08-10",
+                "reason": "default_live",
+                "live_default": "2026-08-10",
+                "input": None,
+                "error": None,
+            },
+        ):
+            r = run_weekend_all_db(dry_run=True, batch_size=2)
+
+    assert r["ok"] is True
+    assert r["dry_run"] is True
+    assert r["mode"] == "live"
+    assert r["live_start"] == "2026-08-10"
+    assert r["forecast_start_date"] == "2026-08-10"
+    assert r["batch_count"] == 2
+    assert r["batches"][0]["tickers"] == ["AAPL", "MSFT"]
+    assert r["batches"][1]["tickers"] == ["NVDA", "AMD"]
+    assert "gather" not in r  # plan only
+
+
+def test_weekend_catchup_uses_blank_forecast_start():
+    with patch(
+        "canswim.weekend.list_db_symbols",
+        return_value=["AAPL"],
+    ):
+        with patch(
+            "canswim.weekend.resolve_start_for_run",
+            return_value={
+                "ok": True,
+                "start": "2026-08-10",
+                "reason": "default_live",
+                "live_default": "2026-08-10",
+                "input": None,
+                "error": None,
+            },
+        ):
+            r = run_weekend_all_db(dry_run=True, catchup=True, batch_size=10)
+    assert r["mode"] == "catchup"
+    assert r["forecast_start_date"] is None
+    assert r["live_start"] == "2026-08-10"
+
+
+def test_weekend_empty_universe():
+    with patch("canswim.weekend.list_db_symbols", return_value=[]):
+        r = run_weekend_all_db(dry_run=True)
+    assert r["ok"] is False
+    assert "No symbols" in (r.get("error") or "")
+
+
+def test_weekend_live_run_batches_gather_and_forecast():
+    gathers = []
+    forecasts = []
+
+    def fake_gather(tickers, **kwargs):
+        gathers.append(tickers)
+        syms = [s.strip() for s in tickers.split(",")]
+        return {"ok": True, "ready": syms, "incomplete": [], "tickers": syms}
+
+    def fake_forecast(tickers, forecast_start_date=None, **kwargs):
+        forecasts.append((tickers, forecast_start_date))
+        syms = [s.strip() for s in tickers.split(",")]
+        return {
+            "ok": True,
+            "forecasted": syms,
+            "skipped": [],
+            "already_have_forecast": [],
+        }
+
+    with patch(
+        "canswim.weekend.list_db_symbols",
+        return_value=["AAPL", "MSFT", "GOOGL"],
+    ):
+        with patch(
+            "canswim.weekend.resolve_start_for_run",
+            return_value={
+                "ok": True,
+                "start": "2026-08-10",
+                "reason": "default_live",
+                "live_default": "2026-08-10",
+                "input": None,
+                "error": None,
+            },
+        ):
+            with patch("canswim.weekend.gather_for_tickers", side_effect=fake_gather):
+                with patch(
+                    "canswim.weekend.forecast_for_tickers",
+                    side_effect=fake_forecast,
+                ):
+                    r = run_weekend_all_db(
+                        dry_run=False, batch_size=2, catchup=False
+                    )
+
+    assert r["ok"] is True
+    assert r["dry_run"] is False
+    assert len(gathers) == 2
+    assert gathers[0] == "AAPL,MSFT"
+    assert gathers[1] == "GOOGL"
+    assert all(fs == "2026-08-10" for _, fs in forecasts)
+    assert set(r["forecasted"]) == {"AAPL", "MSFT", "GOOGL"}
+
+
+def test_weekend_skip_gather():
+    with patch("canswim.weekend.list_db_symbols", return_value=["AAPL"]):
+        with patch(
+            "canswim.weekend.resolve_start_for_run",
+            return_value={
+                "ok": True,
+                "start": "2026-08-10",
+                "reason": "default_live",
+                "live_default": "2026-08-10",
+                "input": None,
+                "error": None,
+            },
+        ):
+            with patch("canswim.weekend.gather_for_tickers") as g:
+                with patch(
+                    "canswim.weekend.forecast_for_tickers",
+                    return_value={
+                        "ok": True,
+                        "forecasted": ["AAPL"],
+                        "skipped": [],
+                    },
+                ):
+                    r = run_weekend_all_db(
+                        dry_run=False, skip_gather=True, batch_size=10
+                    )
+    g.assert_not_called()
+    assert r["forecasted"] == ["AAPL"]

--- a/tests/canswim/test_weekend.py
+++ b/tests/canswim/test_weekend.py
@@ -154,3 +154,162 @@ def test_weekend_skip_gather():
                     )
     g.assert_not_called()
     assert r["forecasted"] == ["AAPL"]
+
+
+def test_weekend_resolve_start_failure():
+    with patch("canswim.weekend.list_db_symbols", return_value=["AAPL"]):
+        with patch(
+            "canswim.weekend.resolve_start_for_run",
+            return_value={"ok": False, "error": "no market calendar", "start": None},
+        ):
+            r = run_weekend_all_db(dry_run=False)
+    assert r["ok"] is False
+    assert "calendar" in (r.get("error") or "").lower() or "start" in (
+        r.get("error") or ""
+    ).lower()
+
+
+def test_weekend_gather_hard_fail_skips_forecast_for_batch():
+    """If gather returns no ready symbols, forecast is not called for that batch."""
+    with patch("canswim.weekend.list_db_symbols", return_value=["ZZZ"]):
+        with patch(
+            "canswim.weekend.resolve_start_for_run",
+            return_value={
+                "ok": True,
+                "start": "2026-08-10",
+                "reason": "default_live",
+                "live_default": "2026-08-10",
+                "input": None,
+                "error": None,
+            },
+        ):
+            with patch(
+                "canswim.weekend.gather_for_tickers",
+                return_value={
+                    "ok": False,
+                    "ready": [],
+                    "incomplete": ["ZZZ"],
+                    "error": "Market history incomplete",
+                },
+            ):
+                with patch("canswim.weekend.forecast_for_tickers") as fc:
+                    r = run_weekend_all_db(dry_run=False, batch_size=10)
+    fc.assert_not_called()
+    assert "ZZZ" in (r.get("incomplete") or [])
+    assert r.get("batch_results")
+
+
+def test_weekend_gather_partial_ready_forecasts_only_ready():
+    with patch("canswim.weekend.list_db_symbols", return_value=["AAPL", "IPO"]):
+        with patch(
+            "canswim.weekend.resolve_start_for_run",
+            return_value={
+                "ok": True,
+                "start": "2026-08-10",
+                "reason": "default_live",
+                "live_default": "2026-08-10",
+                "input": None,
+                "error": None,
+            },
+        ):
+            with patch(
+                "canswim.weekend.gather_for_tickers",
+                return_value={
+                    "ok": True,
+                    "ready": ["AAPL"],
+                    "incomplete": ["IPO"],
+                    "error": None,
+                },
+            ):
+                with patch(
+                    "canswim.weekend.forecast_for_tickers",
+                    return_value={
+                        "ok": True,
+                        "forecasted": ["AAPL"],
+                        "skipped": [],
+                    },
+                ) as fc:
+                    r = run_weekend_all_db(dry_run=False, batch_size=10)
+    assert fc.call_args[0][0] == "AAPL"
+    assert r["forecasted"] == ["AAPL"]
+    assert "IPO" in r["incomplete"]
+
+
+def test_weekend_explicit_symbols_override():
+    with patch("canswim.weekend.list_db_symbols") as ldb:
+        with patch(
+            "canswim.weekend.resolve_start_for_run",
+            return_value={
+                "ok": True,
+                "start": "2026-08-10",
+                "reason": "default_live",
+                "live_default": "2026-08-10",
+                "input": None,
+                "error": None,
+            },
+        ):
+            r = run_weekend_all_db(
+                dry_run=True, symbols=["msft", "aapl"], batch_size=10
+            )
+    ldb.assert_not_called()
+    assert r["symbols"] == ["AAPL", "MSFT"]
+
+
+def test_cli_run_weekend_dry_run():
+    from canswim.cli_run import run_weekend
+
+    with patch(
+        "canswim.weekend.run_weekend_all_db",
+        return_value={"ok": True, "dry_run": True, "symbols": ["AAPL"]},
+    ) as m:
+        code = run_weekend(dry_run=True, catchup=False)
+    assert code == 0
+    m.assert_called_once()
+    assert m.call_args.kwargs.get("dry_run") is True
+
+
+def test_list_db_symbols_normalizes_and_sorts():
+    from canswim.weekend import list_db_symbols
+
+    with patch("canswim.db.get_db_path", return_value="/tmp/x.duckdb"):
+        with patch(
+            "canswim.db.list_tickers",
+            return_value=["msft", "AAPL", " msft ", "", None],
+        ):
+            assert list_db_symbols() == ["AAPL", "MSFT"]
+
+
+def test_weekend_forecast_fail_records_batch_error():
+    with patch("canswim.weekend.list_db_symbols", return_value=["AAPL"]):
+        with patch(
+            "canswim.weekend.resolve_start_for_run",
+            return_value={
+                "ok": True,
+                "start": "2026-08-10",
+                "reason": "default_live",
+                "live_default": "2026-08-10",
+                "input": None,
+                "error": None,
+            },
+        ):
+            with patch(
+                "canswim.weekend.gather_for_tickers",
+                return_value={
+                    "ok": True,
+                    "ready": ["AAPL"],
+                    "incomplete": [],
+                },
+            ):
+                with patch(
+                    "canswim.weekend.forecast_for_tickers",
+                    return_value={
+                        "ok": False,
+                        "forecasted": [],
+                        "skipped": ["AAPL"],
+                        "error": "No real fundamentals",
+                        "fail_reason": "fundamentals",
+                    },
+                ):
+                    r = run_weekend_all_db(dry_run=False, batch_size=5)
+    assert r["batch_results"][0]["forecast"]["fail_reason"] == "fundamentals"
+    assert "AAPL" in r["incomplete"]

--- a/weekend.sh
+++ b/weekend.sh
@@ -1,29 +1,29 @@
-#!/usr/bin/bash
-#args=("$@")
+#!/usr/bin/env bash
+# CANSWIM weekend forecast — all symbols in the Charts/search DB (stock_tickers).
+# Prefer systemd: service/canswim-weekend.timer (see docs/deploy_service.md).
+# Cron example (Saturday 06:00):
+#   0 6 * * 6 /home/YOU/canswim/weekend.sh >> /tmp/canswim-weekend.log 2>&1
+set -euo pipefail
 
-# This script is intended to be executed by cron each weekend.
-# The goal is to pull latest market data for the week 
-# and run forecast for the following week.
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "${ROOT}"
 
-# stop on first error
-# print verbose messages
-set -ex
+export CANSWIM_DIR="${CANSWIM_DIR:-${ROOT}}"
+export CANSWIM_HOME="${CANSWIM_HOME:-${HOME}/.canswim}"
+export data_dir="${data_dir:-${CANSWIM_HOME}/data}"
+export db_file="${db_file:-canswim_local.duckdb}"
+export hfhub_sync="${hfhub_sync:-False}"
+export PYTHONPATH="${CANSWIM_DIR}/src${PYTHONPATH:+:$PYTHONPATH}"
 
-echo "CANSWIM Weekend Forecast Routine: Starting..."
+if [[ -r "${HOME}/.env" ]]; then
+  set -a
+  # shellcheck disable=SC1090
+  source "${HOME}/.env"
+  set +a
+  export FMP_API_KEY="${FMP_API_KEY:-${FMP_API_Key:-}}"
+fi
 
-conda activate canswim
-pip install -e ./
-
-#python -m canswim "${args[@]}"
-
-python -m canswim 
-
-# gather up to date market data
-##./canswim.sh gatherdata
-
-# run forecast and upload to hf hub
-##./canswim.sh forecast
-
-echo "CANSWIM Weekend Forecast Routine: Finished."
-
-
+PYTHON="${CANSWIM_PYTHON:-${PYTHON:-python3}}"
+echo "CANSWIM Weekend: Starting (data_dir=${data_dir}) …"
+# Live week start for all stock_tickers (add --catchup for monthly origins).
+exec "${PYTHON}" -m canswim weekend "$@"


### PR DESCRIPTION
## Summary

- New CLI task **`weekend`**: load all DuckDB **`stock_tickers`**, batch gather + forecast.
- Default origin = **live week start** (`resolve_start` blank); optional **`--catchup`** for monthly + live.
- Host operator path (`force_allow`), batched (default 25) — not MCP.
- **`service/canswim-weekend.timer`** (Sat 06:00) + oneshot service templates; **`./weekend.sh`**.
- Docs: `cli.md`, `deploy_service.md` §3b, `run_triggers.md`.

## Independent of #136

Branched from **main**. After #136 merges, weekend runs inherit fundamentals hard-fail automatically.

## Test plan

- [x] `./scripts/ci-local.sh` (284 passed)
- [x] Unit tests for dry-run plan, catchup blank start, batch gather/forecast mocks
- [x] Prod smoke: `data_dir=$HOME/.canswim/data python -m canswim weekend --dry_run`
- [ ] After merge: install timer on host (`cp service/canswim-weekend.* ~/.config/systemd/user/ && systemctl --user enable --now canswim-weekend.timer`)
- [ ] Optional one-shot: `systemctl --user start canswim-weekend.service`