### PR TITLE
feat: in-process weekend scheduler (APScheduler)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Weekend all-DB forecast runs **inside** the long-lived canswim process (APSchedu
 - **APScheduler** in-process cron (default Sat 06:00 local) on MCP when `MCP_ALLOW_RUNS=1`
 - **Weekend catch-up ON by default** (monthly ~12 backtest origins + live); set `CANSWIM_WEEKEND_CATCHUP=0` for live-only
 - **Multi-client dedupe** — second `refresh_job_start` / async `refresh_tickers` whose symbols are a subset of an in-flight job returns the same `job_id` with `coalesced=true` (no duplicate gather/forecast work)
-- **Shared data-run lock** (`data_dir/canswim_data_run.lock`) serializes MCP refresh batches, weekend scheduler, and CLI `weekend` so they do not stomp parquet/DuckDB or run two heavy pipelines at once
+- **Shared data-run lock** (`fcntl.flock` on `data_dir/canswim_data_run.lock`) serializes MCP refresh batches, weekend scheduler, and CLI `weekend` so they do not stomp parquet/DuckDB or run two heavy pipelines at once — **not** a sticky pidfile; kernel frees the lock on process exit/crash/reboot (leftover file never blocks)
 - Forecast path still **skips symbols that already have a saved partition** for the origin (refresh/backtest re-runs stay cheap)
 - `get_server_info` exposes `weekend_scheduler` status
 - Prefer this over `canswim-weekend.timer` (templates kept for reference only)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@ Weekend all-DB forecast runs **inside** the long-lived canswim process (APSchedu
 ### Highlights
 
 - **APScheduler** in-process cron (default Sat 06:00 local) on MCP when `MCP_ALLOW_RUNS=1`
-- File lock under `data_dir/weekend_job.lock` so MCP + dashboard do not double-run
+- **Weekend catch-up ON by default** (monthly ~12 backtest origins + live); set `CANSWIM_WEEKEND_CATCHUP=0` for live-only
+- **Multi-client dedupe** — second `refresh_job_start` / async `refresh_tickers` whose symbols are a subset of an in-flight job returns the same `job_id` with `coalesced=true` (no duplicate gather/forecast work)
+- **Shared data-run lock** (`data_dir/canswim_data_run.lock`) serializes MCP refresh batches, weekend scheduler, and CLI `weekend` so they do not stomp parquet/DuckDB or run two heavy pipelines at once
+- Forecast path still **skips symbols that already have a saved partition** for the origin (refresh/backtest re-runs stay cheap)
 - `get_server_info` exposes `weekend_scheduler` status
 - Prefer this over `canswim-weekend.timer` (templates kept for reference only)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable releases are documented here. Versioning follows date-style `0.0.YYYYMMDD` unless noted.
 
+## 0.0.20260807
+
+Weekend all-DB forecast runs **inside** the long-lived canswim process (APScheduler), not a separate systemd timer.
+
+### Highlights
+
+- **APScheduler** in-process cron (default Sat 06:00 local) on MCP when `MCP_ALLOW_RUNS=1`
+- File lock under `data_dir/weekend_job.lock` so MCP + dashboard do not double-run
+- `get_server_info` exposes `weekend_scheduler` status
+- Prefer this over `canswim-weekend.timer` (templates kept for reference only)
+
+### Install
+
+```bash
+pip install canswim==0.0.20260807
+```
+
 ## 0.0.20260806
 
 Forecast/backtest must not invent fundamentals (zero-filled earnings, key metrics, or estimates).

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -71,7 +71,9 @@ Default forecast origin is the **live week start** (`resolve_start` with a blank
 
 **Scheduled production path:** in-process **APScheduler** inside `canswim-mcp` when
 `MCP_ALLOW_RUNS=1` (see [deploy_service.md](deploy_service.md) §3b). No separate
-systemd timer. CLI below is for manual/one-shot runs.
+systemd timer. **Service default = monthly catch-up + live**
+(`CANSWIM_WEEKEND_CATCHUP=1`). CLI below is for manual/one-shot runs (live-only
+unless `--catchup`).
 
 ```bash
 # Plan only (start date + batch list)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -69,6 +69,10 @@ Without `--tickers`, `gatherdata` / `forecast` keep **full-universe / train-styl
 Uses the Charts/search universe (`stock_tickers` in DuckDB), not a CSV alone.
 Default forecast origin is the **live week start** (`resolve_start` with a blank date). Batches through gather + forecast so a full DB does not hit MCP-style 50-symbol caps.
 
+**Scheduled production path:** in-process **APScheduler** inside `canswim-mcp` when
+`MCP_ALLOW_RUNS=1` (see [deploy_service.md](deploy_service.md) §3b). No separate
+systemd timer. CLI below is for manual/one-shot runs.
+
 ```bash
 # Plan only (start date + batch list)
 data_dir=$HOME/.canswim/data python -m canswim weekend --dry_run
@@ -80,7 +84,7 @@ data_dir=$HOME/.canswim/data python -m canswim weekend
 data_dir=$HOME/.canswim/data python -m canswim weekend --catchup
 ```
 
-Production timer: [deploy_service.md](deploy_service.md) (`canswim-weekend.timer`). Wrapper: `./weekend.sh`.
+Wrapper: `./weekend.sh`. Env: `CANSWIM_WEEKEND_SCHEDULER`, `CANSWIM_WEEKEND_DOW/HOUR/MINUTE`.
 
 ### Flags (scoped gather / forecast)
 

--- a/docs/deploy_service.md
+++ b/docs/deploy_service.md
@@ -216,7 +216,7 @@ canswim process via **[APScheduler](https://apscheduler.readthedocs.io/)**
 |---------|---------|
 | **MCP** with `MCP_ALLOW_RUNS=1` | Scheduler **on** (Sat 06:00 local) |
 | **Dashboard** | Scheduler **off** unless `CANSWIM_WEEKEND_SCHEDULER=1` |
-| Concurrent heavy work | Shared lock `data_dir/canswim_data_run.lock` — MCP refresh, weekend scheduler, and CLI `weekend` take turns (no parallel stomps) |
+| Concurrent heavy work | Shared **`fcntl.flock`** on `data_dir/canswim_data_run.lock` — MCP refresh, weekend scheduler, and CLI `weekend` take turns. Kernel-released on crash/reboot (leftover file is not a lock) |
 | Multi-client refresh | Same/subset ticker list while a job runs → coalesce to one `job_id` (no duplicate work) |
 
 ```bash

--- a/docs/deploy_service.md
+++ b/docs/deploy_service.md
@@ -205,32 +205,42 @@ curl -sS -X POST "http://127.0.0.1:3472/mcp" \
 
 FastMCP serves the protocol at **`/mcp`** on that port. Details: [mcp.md](mcp.md).
 
-## 3b. Weekend timer (all DB symbols, live week forecast)
+## 3b. Weekend job (in-process — no extra systemd unit)
 
-Recurring **host** job (not MCP): load every symbol in DuckDB `stock_tickers`, update market data in batches, forecast the **live week start** (next market week open). Same policy as CLI `gather` / `forecast`.
+Recurring **all-DB** gather + **live week** forecast for every DuckDB
+`stock_tickers` symbol runs **inside** the long-lived canswim process via
+**[APScheduler](https://apscheduler.readthedocs.io/)** (`BackgroundScheduler` +
+`CronTrigger`). Do **not** add a separate timer service.
 
-Templates in the checkout: `service/canswim-weekend.service` and `service/canswim-weekend.timer` (copy into `~/.canswim/service/` and/or `~/.config/systemd/user/`).
+| Process | Default |
+|---------|---------|
+| **MCP** with `MCP_ALLOW_RUNS=1` | Scheduler **on** (Sat 06:00 local) |
+| **Dashboard** | Scheduler **off** unless `CANSWIM_WEEKEND_SCHEDULER=1` |
+| Both | File lock `data_dir/weekend_job.lock` — only one process runs the job |
 
 ```bash
-# From repo (or after copying units)
-cp service/canswim-weekend.service service/canswim-weekend.timer ~/.config/systemd/user/
-# Point PYTHON / CANSWIM_DIR at this host (edit unit or drop-in)
-systemctl --user daemon-reload
-systemctl --user enable --now canswim-weekend.timer
-systemctl --user list-timers 'canswim-weekend*' --no-pager
-# Manual one-shot:
-systemctl --user start canswim-weekend.service
-journalctl --user -u canswim-weekend -n 50 --no-pager
+# MCP unit already has MCP_ALLOW_RUNS=1 on this host → weekend cron is active after restart
+systemctl --user restart canswim-mcp
+# Confirm: get_server_info → weekend_scheduler.running true; next_run_time set
+
+# Force on/off
+Environment=CANSWIM_WEEKEND_SCHEDULER=1   # or 0
+# Cron (local TZ): day-of-week, hour, minute
+Environment=CANSWIM_WEEKEND_DOW=sat
+Environment=CANSWIM_WEEKEND_HOUR=6
+Environment=CANSWIM_WEEKEND_MINUTE=0
+# Optional: Environment=CANSWIM_WEEKEND_CATCHUP=1
 ```
 
-Dry-run without systemd:
+Manual one-shot (same code path, no schedule):
 
 ```bash
 data_dir=$HOME/.canswim/data python -m canswim weekend --dry_run
+data_dir=$HOME/.canswim/data python -m canswim weekend
 # or: ./weekend.sh --dry_run
 ```
 
-Default calendar: **Saturday 06:00** local (`OnCalendar=Sat *-*-* 06:00:00`). Adjust the timer for your timezone / market. Full catch-up is opt-in: `python -m canswim weekend --catchup` (edit `ExecStart` if you want the timer to catch up).
+Legacy `service/canswim-weekend.timer` templates are **not recommended** (extra unit to operate). Prefer in-process scheduling.
 
 ## 4. Public MCP via gateway + apikey
 

--- a/docs/deploy_service.md
+++ b/docs/deploy_service.md
@@ -207,16 +207,17 @@ FastMCP serves the protocol at **`/mcp`** on that port. Details: [mcp.md](mcp.md
 
 ## 3b. Weekend job (in-process — no extra systemd unit)
 
-Recurring **all-DB** gather + **live week** forecast for every DuckDB
-`stock_tickers` symbol runs **inside** the long-lived canswim process via
-**[APScheduler](https://apscheduler.readthedocs.io/)** (`BackgroundScheduler` +
-`CronTrigger`). Do **not** add a separate timer service.
+Recurring **all-DB** gather + **monthly catch-up (~12 origins) + live week**
+forecast for every DuckDB `stock_tickers` symbol runs **inside** the long-lived
+canswim process via **[APScheduler](https://apscheduler.readthedocs.io/)**
+(`BackgroundScheduler` + `CronTrigger`). Do **not** add a separate timer service.
 
 | Process | Default |
 |---------|---------|
 | **MCP** with `MCP_ALLOW_RUNS=1` | Scheduler **on** (Sat 06:00 local) |
 | **Dashboard** | Scheduler **off** unless `CANSWIM_WEEKEND_SCHEDULER=1` |
-| Both | File lock `data_dir/weekend_job.lock` — only one process runs the job |
+| Concurrent heavy work | Shared lock `data_dir/canswim_data_run.lock` — MCP refresh, weekend scheduler, and CLI `weekend` take turns (no parallel stomps) |
+| Multi-client refresh | Same/subset ticker list while a job runs → coalesce to one `job_id` (no duplicate work) |
 
 ```bash
 # MCP unit already has MCP_ALLOW_RUNS=1 on this host → weekend cron is active after restart
@@ -229,7 +230,8 @@ Environment=CANSWIM_WEEKEND_SCHEDULER=1   # or 0
 Environment=CANSWIM_WEEKEND_DOW=sat
 Environment=CANSWIM_WEEKEND_HOUR=6
 Environment=CANSWIM_WEEKEND_MINUTE=0
-# Optional: Environment=CANSWIM_WEEKEND_CATCHUP=1
+# Catch-up is ON by default (monthly backtests + live). Live-only:
+# Environment=CANSWIM_WEEKEND_CATCHUP=0
 ```
 
 Manual one-shot (same code path, no schedule):

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -159,6 +159,10 @@ Optional: `wait=true` on `refresh_tickers` forces the old blocking path (max ~50
 
 Workers batch symbols (~20). Job state is under `{data_dir}/mcp_jobs/`. Only **one** refresh job at a time.
 
+**Multi-client dedupe:** if client B starts a refresh whose ticker list is a **subset** of an already queued/running job (same `dry_run` / `include_covariates`), the server **coalesces** — `ok=true`, same `job_id`, `coalesced=true`. Poll `refresh_job_status`; do **not** start a second job. If the active job does **not** cover the full request, response is `ok=false` / `fail_reason=job_busy` with `active_job_id` — poll until done, then start only remaining symbols.
+
+Heavy gather/forecast work also takes a process-wide file lock (`data_dir/canswim_data_run.lock`) so MCP refresh does not race the in-process weekend job or CLI `weekend`. Within a job, symbols that already have a complete forecast partition for an origin are skipped (no re-inference).
+
 **Do not** claim portfolio-wide success after a tool timeout, a `dry_run`, a subset list, or while status is still `queued`/`running`.
 
 ### Progress streaming (blocking long runs)

--- a/docs/run_triggers.md
+++ b/docs/run_triggers.md
@@ -28,12 +28,15 @@ Loads every symbol from DuckDB **`stock_tickers`**, batches gather + forecast.
 | **In-process (MCP with `MCP_ALLOW_RUNS=1`)** | **Monthly catch-up (~12) + live** (`CANSWIM_WEEKEND_CATCHUP` defaults **on**) |
 | **CLI one-shot** `python -m canswim weekend` | Live week only (pass **`--catchup`** for monthly + live) |
 
-Host path uses `force_allow` (not gated by MCP_ALLOW_RUNS for CLI). Shared file
-lock `data_dir/canswim_data_run.lock` serializes weekend with MCP async refresh
-(one heavy pipeline at a time). MCP clients that request the same/subset refresh
-while a job is in flight **coalesce** onto that `job_id` (see [mcp.md](mcp.md)).
-Forecast skips origins that already have a saved partition. See [cli.md](cli.md)
-and [deploy_service.md](deploy_service.md).
+Host path uses `force_allow` (not gated by MCP_ALLOW_RUNS for CLI). Shared
+**`fcntl.flock`** on `data_dir/canswim_data_run.lock` serializes weekend with MCP
+async refresh (one heavy pipeline at a time). This is **not** a sticky pidfile:
+the kernel releases the lock when the holding process exits, crashes, or the host
+reboots. A leftover `.lock` file on disk does **not** block future runs (file
+presence ≠ locked). MCP clients that request the same/subset refresh while a job
+is in flight **coalesce** onto that `job_id` (see [mcp.md](mcp.md)). Forecast
+skips origins that already have a saved partition. See [cli.md](cli.md) and
+[deploy_service.md](deploy_service.md).
 
 ## Get market data (lean & rate-limit aware)
 

--- a/docs/run_triggers.md
+++ b/docs/run_triggers.md
@@ -21,16 +21,19 @@ Without `--tickers`, CLI `gatherdata` / `forecast` keep **full-universe / train-
 
 ## Weekend job (all DB symbols)
 
-Loads every symbol from DuckDB **`stock_tickers`**, batches gather + forecast,
-default origin = **live week start**. Optional catch-up (monthly + live).
+Loads every symbol from DuckDB **`stock_tickers`**, batches gather + forecast.
 
-| How | When |
-|-----|------|
-| **In-process (preferred)** | APScheduler inside MCP (`MCP_ALLOW_RUNS=1`) or dashboard if `CANSWIM_WEEKEND_SCHEDULER=1` |
-| **CLI one-shot** | `python -m canswim weekend` / `./weekend.sh` |
+| How | Default origins |
+|-----|-----------------|
+| **In-process (MCP with `MCP_ALLOW_RUNS=1`)** | **Monthly catch-up (~12) + live** (`CANSWIM_WEEKEND_CATCHUP` defaults **on**) |
+| **CLI one-shot** `python -m canswim weekend` | Live week only (pass **`--catchup`** for monthly + live) |
 
-Host path uses `force_allow` (not gated by MCP_ALLOW_RUNS for CLI). File lock
-avoids double runs. See [cli.md](cli.md) and [deploy_service.md](deploy_service.md).
+Host path uses `force_allow` (not gated by MCP_ALLOW_RUNS for CLI). Shared file
+lock `data_dir/canswim_data_run.lock` serializes weekend with MCP async refresh
+(one heavy pipeline at a time). MCP clients that request the same/subset refresh
+while a job is in flight **coalesce** onto that `job_id` (see [mcp.md](mcp.md)).
+Forecast skips origins that already have a saved partition. See [cli.md](cli.md)
+and [deploy_service.md](deploy_service.md).
 
 ## Get market data (lean & rate-limit aware)
 

--- a/docs/run_triggers.md
+++ b/docs/run_triggers.md
@@ -19,13 +19,18 @@ MCP write tools need `MCP_ALLOW_RUNS=1`. CLI and dashboard do not.
 
 Without `--tickers`, CLI `gatherdata` / `forecast` keep **full-universe / train-style** behavior.
 
-## Weekend host job (all DB symbols)
+## Weekend job (all DB symbols)
 
-CLI task **`weekend`** (`./weekend.sh`, `canswim-weekend.timer`) loads every symbol
-from DuckDB **`stock_tickers`**, batches gather + forecast, and defaults to the
-**live week start** from blank `resolve_start`. Optional `--catchup` uses blank
-forecast start (monthly catch-up + live). Host operator path (`force_allow`), not
-an MCP tool. See [cli.md](cli.md) and [deploy_service.md](deploy_service.md).
+Loads every symbol from DuckDB **`stock_tickers`**, batches gather + forecast,
+default origin = **live week start**. Optional catch-up (monthly + live).
+
+| How | When |
+|-----|------|
+| **In-process (preferred)** | APScheduler inside MCP (`MCP_ALLOW_RUNS=1`) or dashboard if `CANSWIM_WEEKEND_SCHEDULER=1` |
+| **CLI one-shot** | `python -m canswim weekend` / `./weekend.sh` |
+
+Host path uses `force_allow` (not gated by MCP_ALLOW_RUNS for CLI). File lock
+avoids double runs. See [cli.md](cli.md) and [deploy_service.md](deploy_service.md).
 
 ## Get market data (lean & rate-limit aware)
 

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -1,5 +1,13 @@
 #!/usr/bin/env bash
 # Local mirror of .github/workflows/tests.yml (Tests job).
+#
+# Must stay identical to remote for merge decisions:
+#   GHA steps:  pip install -e ".[dev]"
+#               mkdir -p data/data-3rd-party data/forecast
+#               python -m pytest tests/canswim/ -v
+#   GHA python: 3.10 (matrix) — local uses best available interpreter with
+#               working darts/torch (prefer CI_PYTHON / python3.10 / project env).
+#
 # Usage: ./scripts/ci-local.sh
 # Skip: SKIP_LOCAL_CI=1 ./scripts/ci-local.sh   (or git push --no-verify)
 set -euo pipefail
@@ -12,11 +20,18 @@ if [[ "${SKIP_LOCAL_CI:-}" == "1" ]]; then
   exit 0
 fi
 
-echo "==> local CI (matches GitHub Actions Tests workflow)"
+echo "==> local CI (identical suite to GitHub Actions Tests workflow)"
 
-# Prefer project conda env when available (faster than bare pip -e . every push)
+# Interpreter selection: explicit override, then common CI mirrors, then conda, then PATH.
 PY=()
-if command -v conda >/dev/null 2>&1; then
+if [[ -n "${CI_PYTHON:-}" ]]; then
+  PY=("${CI_PYTHON}")
+  echo "    using: CI_PYTHON=${CI_PYTHON} ($("${PY[@]}" -V 2>&1))"
+elif [[ -x "${HOME}/.venvs/canswim-ci310/bin/python" ]] \
+  && "${HOME}/.venvs/canswim-ci310/bin/python" -c "from darts.models import TiDEModel" 2>/dev/null; then
+  PY=("${HOME}/.venvs/canswim-ci310/bin/python")
+  echo "    using: canswim-ci310 (Python 3.10 GHA mirror) ($("${PY[@]}" -V 2>&1))"
+elif command -v conda >/dev/null 2>&1; then
   # shellcheck disable=SC1091
   if [[ -f "${HOME}/anaconda3/etc/profile.d/conda.sh" ]]; then
     # shellcheck source=/dev/null
@@ -26,7 +41,6 @@ if command -v conda >/dev/null 2>&1; then
     source "${HOME}/miniconda3/etc/profile.d/conda.sh"
   fi
   if conda env list 2>/dev/null | awk '{print $1}' | grep -qx 'canswim'; then
-    # conda run keeps isolation without mutating the caller shell
     PY=(conda run -n canswim --no-capture-output python)
     echo "    using: conda env canswim"
   fi
@@ -36,26 +50,24 @@ if [[ ${#PY[@]} -eq 0 ]]; then
   echo "    using: $(command -v python) ($("${PY[@]}" -V 2>&1))"
 fi
 
-# Tests use per-test temp data dirs (tests/conftest.py). Never mkdir/write under
-# repo data/ when it is a symlink to production ~/.canswim/data.
+# Same scaffolding as GHA "Create data directories". Never mkdir under a symlink
+# to production ~/.canswim/data (tests/conftest.py uses per-test temps).
 if [[ -L data ]]; then
   echo "    note: data/ is a symlink — not creating dirs there (prod isolation)"
 elif [[ -d data ]]; then
-  # Real directory (CI / fresh checkout): empty scaffolding only, no prod home.
   mkdir -p data/data-3rd-party data/forecast
 else
   mkdir -p data/data-3rd-party data/forecast
 fi
 
-# Ensure editable install has test deps (pytest moved to extras_require[dev])
+# Same as GHA "Install dependencies" when pytest missing
 if ! "${PY[@]}" -c "import pytest" 2>/dev/null; then
-  echo "==> installing package with [dev] extras for pytest"
+  echo "==> installing package with [dev] extras for pytest (GHA: pip install -e \".[dev]\")"
   "${PY[@]}" -m pip install -q -e ".[dev]"
 fi
 
-echo "==> pytest tests/canswim/"
-# Recurse package (includes tests/canswim/dashboard/, etc.)
-# Isolation is enforced by tests/conftest.py (autouse temp data_dir + write guards).
-"${PY[@]}" -m pytest tests/canswim/ -q --tb=short
+echo "==> python -m pytest tests/canswim/ -v   # same path + flags as GHA Tests"
+# Isolation: tests/conftest.py (autouse temp data_dir + write guards).
+"${PY[@]}" -m pytest tests/canswim/ -v --tb=short
 
-echo "==> local CI OK"
+echo "==> local CI OK (suite matches .github/workflows/tests.yml)"

--- a/service/canswim-weekend.timer
+++ b/service/canswim-weekend.timer
@@ -1,5 +1,5 @@
 [Unit]
-Description=Schedule CANSWIM weekend forecast (all DB symbols, live week start)
+Description=DEPRECATED — prefer in-process APScheduler (CANSWIM_WEEKEND_SCHEDULER / MCP_ALLOW_RUNS)
 Documentation=https://ivelin.github.io/canswim/deploy_service/
 
 [Timer]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = canswim
-version = 0.0.20260806
+version = 0.0.20260807
 author = Ivelin Ivanov
 author_email = ivelin117@gmail.com
 description = Developer toolkit for CANSLIM-style investors (CLI, Gradio GUI, MCP)
@@ -45,6 +45,7 @@ install_requires =
     mcp>=1.2,<2
     python-dotenv
     requests-ratelimiter>=0.6,<1
+    APScheduler>=3.10,<4
 
 [options.package_data]
 * = *.txt, *.rst, *.md

--- a/src/canswim/dashboard/__init__.py
+++ b/src/canswim/dashboard/__init__.py
@@ -173,6 +173,15 @@ class CanswimPlayground:
 
 
 def main(same_data=False):
+    # Optional in-process weekend job (off unless CANSWIM_WEEKEND_SCHEDULER=1)
+    try:
+        from canswim.scheduler import start_inprocess_scheduler
+
+        start_inprocess_scheduler(role="dashboard")
+    except Exception as e:
+        from loguru import logger
+
+        logger.warning("Could not start in-process weekend scheduler: {}", e)
 
     canswim_playground = CanswimPlayground(same_data=same_data)
     canswim_playground.launch()

--- a/src/canswim/data_run_lock.py
+++ b/src/canswim/data_run_lock.py
@@ -3,8 +3,13 @@
 Prevents concurrent pipelines from MCP clients, CLI weekend, and the in-process
 scheduler from stomping the same parquet/DuckDB paths or duplicating GPU work.
 
-Uses ``fcntl`` flock on ``{data_dir}/canswim_data_run.lock``. Same-process
-re-entrancy is allowed (nested callers share one hold).
+**Mechanism (not a sticky pidfile):** Linux ``fcntl.flock`` on a sentinel path
+``{data_dir}/canswim_data_run.lock``. The kernel owns the lock and releases it
+when the holding process exits, crashes, or the host reboots. **Presence of the
+file alone never means “locked”** — only a live process with an exclusive flock
+does. Stale text left in the file after a crash is diagnostic junk only.
+
+Same-process re-entrancy is allowed (nested callers share one hold).
 """
 
 from __future__ import annotations
@@ -14,7 +19,7 @@ import threading
 import time
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Iterator, Optional
+from typing import Any, Iterator, Optional
 
 from loguru import logger
 
@@ -26,6 +31,24 @@ def data_run_lock_path(data_dir: Optional[str | Path] = None) -> Path:
     root = Path(data_dir or os.getenv("data_dir", "data")).expanduser()
     root.mkdir(parents=True, exist_ok=True)
     return root / _LOCK_NAME
+
+
+def data_run_lock_status(*, data_dir: Optional[str | Path] = None) -> dict[str, Any]:
+    """Operator snapshot: whether a *live* holder has the flock (not file mtime).
+
+    Safe after reboot: leftover file + dead PID → ``held=False``.
+    """
+    path = data_run_lock_path(data_dir)
+    note = path.read_text(encoding="utf-8").strip() if path.is_file() else ""
+    # Probe without waiting: if we can take LOCK_NB, nothing live holds it.
+    free = try_exclusive_data_run("status-probe", data_dir=data_dir)
+    return {
+        "path": str(path),
+        "held": not free,
+        "file_exists": path.is_file(),
+        "note": note or None,
+        "mechanism": "fcntl.flock (kernel-released on process exit/reboot)",
+    }
 
 
 @contextmanager
@@ -40,6 +63,9 @@ def exclusive_data_run(
     Yields True if the lock was acquired, False if non-blocking and busy.
     When ``blocking=True``, waits until the lock is free (then yields True).
     Nested calls in the same thread re-enter without deadlock.
+
+    Crash/reboot safe: the kernel drops flock with the process; a leftover
+    ``.lock`` file does not block the next acquirer.
     """
     import fcntl
 
@@ -53,6 +79,7 @@ def exclusive_data_run(
         return
 
     path = data_run_lock_path(data_dir)
+    # Sentinel path only — never treat path.exists() as locked.
     fh = open(path, "a+", encoding="utf-8")
     acquired = False
     try:
@@ -71,9 +98,13 @@ def exclusive_data_run(
                     yield False
                     return
                 time.sleep(0.5)
+        # Overwrite any stale crash note; presence of text is never authoritative.
         fh.seek(0)
         fh.truncate()
-        fh.write(f"holder={holder} pid={os.getpid()} t={time.time():.0f}\n")
+        fh.write(
+            f"holder={holder} pid={os.getpid()} t={time.time():.0f} "
+            f"(fcntl.flock; file presence is not a lock)\n"
+        )
         fh.flush()
         _tls.depth = 1
         _tls.fh = fh
@@ -83,6 +114,17 @@ def exclusive_data_run(
         if acquired:
             _tls.depth = 0
             _tls.fh = None
+            try:
+                # Clear holder note so the leftover file does not look "active"
+                fh.seek(0)
+                fh.truncate()
+                fh.write(
+                    f"last_released_by={holder} pid={os.getpid()} "
+                    f"t={time.time():.0f} (idle — not locked)\n"
+                )
+                fh.flush()
+            except OSError:
+                pass
             try:
                 fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
             except OSError:
@@ -97,7 +139,8 @@ def exclusive_data_run(
 def try_exclusive_data_run(holder: str, *, data_dir: Optional[str | Path] = None) -> bool:
     """Non-blocking probe: True if lock free and briefly held then released.
 
-    Prefer :func:`exclusive_data_run` for real work.
+    Prefer :func:`exclusive_data_run` for real work. Does **not** look at file
+    existence — only whether ``flock(LOCK_NB)`` succeeds.
     """
     with exclusive_data_run(holder, blocking=False, data_dir=data_dir) as ok:
         return bool(ok)

--- a/src/canswim/data_run_lock.py
+++ b/src/canswim/data_run_lock.py
@@ -1,0 +1,103 @@
+"""Cross-entry exclusive lock for heavy gather/forecast/refresh work.
+
+Prevents concurrent pipelines from MCP clients, CLI weekend, and the in-process
+scheduler from stomping the same parquet/DuckDB paths or duplicating GPU work.
+
+Uses ``fcntl`` flock on ``{data_dir}/canswim_data_run.lock``. Same-process
+re-entrancy is allowed (nested callers share one hold).
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator, Optional
+
+from loguru import logger
+
+_LOCK_NAME = "canswim_data_run.lock"
+_tls = threading.local()
+
+
+def data_run_lock_path(data_dir: Optional[str | Path] = None) -> Path:
+    root = Path(data_dir or os.getenv("data_dir", "data")).expanduser()
+    root.mkdir(parents=True, exist_ok=True)
+    return root / _LOCK_NAME
+
+
+@contextmanager
+def exclusive_data_run(
+    holder: str,
+    *,
+    blocking: bool = True,
+    data_dir: Optional[str | Path] = None,
+) -> Iterator[bool]:
+    """Hold the global data-run lock for the duration of the context.
+
+    Yields True if the lock was acquired, False if non-blocking and busy.
+    When ``blocking=True``, waits until the lock is free (then yields True).
+    Nested calls in the same thread re-enter without deadlock.
+    """
+    import fcntl
+
+    depth = int(getattr(_tls, "depth", 0) or 0)
+    if depth > 0:
+        _tls.depth = depth + 1
+        try:
+            yield True
+        finally:
+            _tls.depth = depth
+        return
+
+    path = data_run_lock_path(data_dir)
+    fh = open(path, "a+", encoding="utf-8")
+    acquired = False
+    try:
+        flags = fcntl.LOCK_EX if blocking else (fcntl.LOCK_EX | fcntl.LOCK_NB)
+        while True:
+            try:
+                fcntl.flock(fh.fileno(), flags)
+                acquired = True
+                break
+            except BlockingIOError:
+                if not blocking:
+                    logger.info(
+                        "data_run_lock busy — {} did not wait (non-blocking)",
+                        holder,
+                    )
+                    yield False
+                    return
+                time.sleep(0.5)
+        fh.seek(0)
+        fh.truncate()
+        fh.write(f"holder={holder} pid={os.getpid()} t={time.time():.0f}\n")
+        fh.flush()
+        _tls.depth = 1
+        _tls.fh = fh
+        logger.debug("data_run_lock acquired by {}", holder)
+        yield True
+    finally:
+        if acquired:
+            _tls.depth = 0
+            _tls.fh = None
+            try:
+                fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+            except OSError:
+                pass
+            logger.debug("data_run_lock released by {}", holder)
+        try:
+            fh.close()
+        except OSError:
+            pass
+
+
+def try_exclusive_data_run(holder: str, *, data_dir: Optional[str | Path] = None) -> bool:
+    """Non-blocking probe: True if lock free and briefly held then released.
+
+    Prefer :func:`exclusive_data_run` for real work.
+    """
+    with exclusive_data_run(holder, blocking=False, data_dir=data_dir) as ok:
+        return bool(ok)

--- a/src/canswim/mcp/jobs.py
+++ b/src/canswim/mcp/jobs.py
@@ -130,6 +130,50 @@ def find_active_refresh_job() -> Optional[dict[str, Any]]:
     return None
 
 
+def _norm_ticker_set(tickers: Any) -> set[str]:
+    out: set[str] = set()
+    if not tickers:
+        return out
+    if isinstance(tickers, str):
+        parts = tickers.replace("\n", ",").split(",")
+    else:
+        parts = list(tickers)
+    for p in parts:
+        s = str(p).strip().upper()
+        if s:
+            out.add(s)
+    return out
+
+
+def coalesce_with_active_job(
+    ticker_list: list[str],
+    *,
+    include_covariates: bool,
+    dry_run: bool,
+    active: Optional[dict[str, Any]] = None,
+) -> Optional[dict[str, Any]]:
+    """If an in-flight refresh already covers this request, return that job.
+
+    Coalesce when the new request's symbols are a **subset** of the active job's
+    ticker list and dry_run / include_covariates match. Clients should poll the
+    existing ``job_id`` instead of starting duplicate work.
+    """
+    job = active if active is not None else find_active_refresh_job()
+    if job is None:
+        return None
+    if bool(job.get("dry_run")) != bool(dry_run):
+        return None
+    if bool(job.get("include_covariates", True)) != bool(include_covariates):
+        return None
+    active_set = _norm_ticker_set(job.get("ticker_list") or job.get("tickers"))
+    req_set = _norm_ticker_set(ticker_list)
+    if not req_set or not active_set:
+        return None
+    if req_set <= active_set:
+        return job
+    return None
+
+
 def _reconcile_orphan(job: dict[str, Any]) -> dict[str, Any]:
     """If status is running/queued but no live worker in this process, mark failed."""
     jid = job.get("job_id")
@@ -338,22 +382,50 @@ def start_refresh_job(
         }
 
     with _start_lock:
+        tlist = list(parsed["tickers"])
         active = find_active_refresh_job()
         if active is not None:
+            # Same/subset request from another client → attach to existing job
+            hit = coalesce_with_active_job(
+                tlist,
+                include_covariates=bool(include_covariates),
+                dry_run=bool(dry_run),
+                active=active,
+            )
+            if hit is not None:
+                view = _public_view(hit)
+                view["coalesced"] = True
+                view["message"] = (
+                    f"Joined in-flight job {hit.get('job_id')} "
+                    f"(request covered by active {hit.get('status')} refresh; "
+                    "no duplicate work). Poll refresh_job_status."
+                )
+                logger.info(
+                    "MCP refresh coalesced into job_id={} n_req={} n_active={}",
+                    hit.get("job_id"),
+                    len(tlist),
+                    hit.get("requested_count"),
+                )
+                return {
+                    "ok": True,
+                    "coalesced": True,
+                    "data": view,
+                }
             view = _public_view(active)
             return {
                 "ok": False,
                 "error": (
                     f"A refresh job is already {active.get('status')} "
                     f"(job_id={active.get('job_id')}). "
-                    "Poll refresh_job_status until it finishes, then start a new one."
+                    "It does not cover this full ticker list. "
+                    "Poll refresh_job_status until it finishes, then start a new one "
+                    "for any remaining symbols."
                 ),
                 "data": view,
                 "active_job_id": active.get("job_id"),
             }
 
         job_id = _new_job_id()
-        tlist = list(parsed["tickers"])
         ticker_csv = ",".join(tlist)
         n = len(tlist)
         store = str(jobs_dir())
@@ -515,14 +587,18 @@ def _run_refresh_worker(
                 _progress(_base + _span * f, msg)
 
             _progress(base, f"Batch {bi + 1}/{n_batches}: starting {batch_csv[:80]}…")
-            result = refresh_symbols(
-                batch_csv,
-                include_covariates=include_covariates,
-                dry_run=dry_run,
-                force_allow=False,
-                progress_cb=_batch_cb,
-                max_tickers=max(len(batch), DEFAULT_MAX_TICKERS),
-            )
+            # Serialize with weekend scheduler / CLI weekend (shared flock)
+            from canswim.data_run_lock import exclusive_data_run
+
+            with exclusive_data_run(f"mcp-refresh-job-{job_id[:8]}", blocking=True):
+                result = refresh_symbols(
+                    batch_csv,
+                    include_covariates=include_covariates,
+                    dry_run=dry_run,
+                    force_allow=False,
+                    progress_cb=_batch_cb,
+                    max_tickers=max(len(batch), DEFAULT_MAX_TICKERS),
+                )
             batch_results.append(
                 {
                     "batch_index": bi,

--- a/src/canswim/mcp/server.py
+++ b/src/canswim/mcp/server.py
@@ -530,6 +530,13 @@ def main(
         )
     else:
         logger.info("canswim-mcp transport=stdio")
+    # Weekend gather+forecast inside this process (APScheduler) — no extra systemd unit
+    try:
+        from canswim.scheduler import start_inprocess_scheduler
+
+        start_inprocess_scheduler(role="mcp")
+    except Exception as e:
+        logger.warning("Could not start in-process weekend scheduler: {}", e)
     mcp.run(transport=resolved)  # type: ignore[arg-type]
 
 

--- a/src/canswim/mcp/tools/_common.py
+++ b/src/canswim/mcp/tools/_common.py
@@ -257,8 +257,10 @@ _DEFAULT_CLIENT_HINTS: dict[str, str] = {
         "(wait=false). Do not invent ids."
     ),
     FAIL_JOB_BUSY: (
-        "Poll refresh_job_status until the active job finishes "
-        "(status succeeded or failed), then start a new refresh_job_start."
+        "A refresh is already running (possibly for a different symbol set). "
+        "Poll refresh_job_status on active_job_id until done, then start a job "
+        "only for remaining symbols. If your list is a subset of the active job, "
+        "the server coalesces and returns that job_id with ok=true instead."
     ),
     FAIL_JOB_FAILED: (
         "Report the error and coverage to the user. Do not claim the portfolio "

--- a/src/canswim/mcp/tools/jobs.py
+++ b/src/canswim/mcp/tools/jobs.py
@@ -34,7 +34,21 @@ def refresh_job_start_impl(
         dry_run=dry_run,
     )
     if out.get("ok"):
-        return ok_result(out["data"])
+        data = out["data"]
+        # Coalesced onto an in-flight job — same job_id for all clients
+        if out.get("coalesced") and isinstance(data, dict):
+            data = dict(data)
+            data["coalesced"] = True
+            return ok_result(
+                data,
+                coalesced=True,
+                client_hint=(
+                    "Another client (or the weekend scheduler) already runs this "
+                    "refresh. Poll refresh_job_status with this job_id; do not start "
+                    "a second job."
+                ),
+            )
+        return ok_result(data)
     err = out.get("error") or "could not start job"
     fr = out.get("fail_reason") or infer_fail_reason_from_error(err)
     if fr is None:

--- a/src/canswim/mcp/tools/meta.py
+++ b/src/canswim/mcp/tools/meta.py
@@ -107,12 +107,20 @@ def get_server_info_impl() -> dict[str, Any]:
     from canswim.mcp.jobs import JOB_MAX_TICKERS
     from canswim.run_triggers import DEFAULT_MAX_TICKERS
 
+    try:
+        from canswim.scheduler import get_scheduler_status
+
+        weekend_sched = get_scheduler_status()
+    except Exception:
+        weekend_sched = {"running": False, "error": "status unavailable"}
+
     return ok_result(
         {
             "name": "canswim-mcp",
             "version": __version__,
             "is_read_only": not allow_runs,
             "runs_allowed": allow_runs,
+            "weekend_scheduler": weekend_sched,
             "access": CLIENT_ACCESS_BOUNDARY,
             "model": (
                 "TiDE precomputed forecasts via MCP read tools only. "

--- a/src/canswim/scheduler.py
+++ b/src/canswim/scheduler.py
@@ -68,65 +68,24 @@ def _data_dir() -> Path:
     return Path(os.getenv("data_dir", "data")).expanduser()
 
 
-def _lock_path() -> Path:
-    d = _data_dir()
-    d.mkdir(parents=True, exist_ok=True)
-    return d / "weekend_job.lock"
-
-
-def _try_acquire_lock(fh) -> bool:
-    """Non-blocking exclusive flock; True if held."""
-    import fcntl
-
-    try:
-        fcntl.flock(fh.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-        return True
-    except BlockingIOError:
-        return False
-    except OSError as e:
-        logger.warning("Weekend lock OSError: {}", e)
-        return False
-
-
-def _release_lock(fh) -> None:
-    import fcntl
-
-    try:
-        fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
-    except OSError:
-        pass
-
-
 def run_weekend_job_now(*, catchup: Optional[bool] = None) -> dict[str, Any]:
     """Execute weekend job with cross-process lock (callable from scheduler or tests)."""
     global _last_run
     from canswim.weekend import run_weekend_all_db
 
+    # Default ON for service path: monthly backtests (~12m) + live week.
+    # Set CANSWIM_WEEKEND_CATCHUP=0 for live-only.
     use_catchup = (
-        _env_truthy("CANSWIM_WEEKEND_CATCHUP", "0")
+        _env_truthy("CANSWIM_WEEKEND_CATCHUP", "1")
         if catchup is None
         else bool(catchup)
     )
-    lock_file = _lock_path()
     started = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
-    with open(lock_file, "a+", encoding="utf-8") as fh:
-        if not _try_acquire_lock(fh):
-            msg = "Weekend job skipped — another process holds weekend_job.lock"
-            logger.info(msg)
-            out = {
-                "ok": True,
-                "skipped": True,
-                "reason": "lock_held",
-                "message": msg,
-                "started_at": started,
-            }
-            _last_run = out
-            return out
+    # Shared with MCP refresh jobs — one heavy pipeline at a time
+    from canswim.data_run_lock import exclusive_data_run
+
+    with exclusive_data_run("weekend-scheduler", blocking=True):
         try:
-            fh.seek(0)
-            fh.truncate()
-            fh.write(f"pid={os.getpid()} started={started}\n")
-            fh.flush()
             logger.info(
                 "Weekend in-process job starting (catchup={}, pid={})",
                 use_catchup,
@@ -135,7 +94,9 @@ def run_weekend_job_now(*, catchup: Optional[bool] = None) -> dict[str, Any]:
             result = run_weekend_all_db(
                 dry_run=False,
                 catchup=use_catchup,
-                include_covariates=not _env_truthy("CANSWIM_WEEKEND_NO_COVARIATES", "0"),
+                include_covariates=not _env_truthy(
+                    "CANSWIM_WEEKEND_NO_COVARIATES", "0"
+                ),
                 skip_gather=_env_truthy("CANSWIM_WEEKEND_SKIP_GATHER", "0"),
             )
             result = dict(result)
@@ -165,8 +126,6 @@ def run_weekend_job_now(*, catchup: Optional[bool] = None) -> dict[str, Any]:
             }
             _last_run = out
             return out
-        finally:
-            _release_lock(fh)
 
 
 def get_scheduler_status() -> dict[str, Any]:
@@ -189,7 +148,10 @@ def get_scheduler_status() -> dict[str, Any]:
             "jobs": jobs,
             "cron": _cron_kwargs(),
             "last_run": dict(_last_run) if _last_run else None,
-            "lock_path": str(_lock_path()),
+            "lock_path": str(
+                Path(os.getenv("data_dir", "data")).expanduser()
+                / "canswim_data_run.lock"
+            ),
         }
 
 

--- a/src/canswim/scheduler.py
+++ b/src/canswim/scheduler.py
@@ -128,6 +128,12 @@ def run_weekend_job_now(*, catchup: Optional[bool] = None) -> dict[str, Any]:
             return out
 
 
+def _data_run_lock_status() -> dict[str, Any]:
+    from canswim.data_run_lock import data_run_lock_status
+
+    return data_run_lock_status()
+
+
 def get_scheduler_status() -> dict[str, Any]:
     """Snapshot for get_server_info / operators."""
     with _lock:
@@ -148,10 +154,7 @@ def get_scheduler_status() -> dict[str, Any]:
             "jobs": jobs,
             "cron": _cron_kwargs(),
             "last_run": dict(_last_run) if _last_run else None,
-            "lock_path": str(
-                Path(os.getenv("data_dir", "data")).expanduser()
-                / "canswim_data_run.lock"
-            ),
+            "data_run_lock": _data_run_lock_status(),
         }
 
 

--- a/src/canswim/scheduler.py
+++ b/src/canswim/scheduler.py
@@ -1,0 +1,257 @@
+"""In-process job scheduling for long-lived canswim services (MCP / dashboard).
+
+Uses **APScheduler** (BackgroundScheduler + CronTrigger) so weekend gather/forecast
+runs inside the same process — no separate systemd timer unit.
+
+Enable with ``CANSWIM_WEEKEND_SCHEDULER=1`` (default when ``MCP_ALLOW_RUNS=1`` for
+MCP; off otherwise unless forced). Cross-process lock under ``data_dir`` prevents
+dashboard + MCP from both executing the same weekend run.
+"""
+
+from __future__ import annotations
+
+import atexit
+import os
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+from loguru import logger
+
+_lock = threading.Lock()
+_scheduler = None  # BackgroundScheduler | None
+_started = False
+_last_run: dict[str, Any] = {}
+
+
+def _env_truthy(name: str, default: str = "0") -> bool:
+    return str(os.getenv(name, default)).strip().lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )
+
+
+def weekend_scheduler_wanted(*, role: str = "service") -> bool:
+    """Whether this process should start the in-process weekend scheduler.
+
+    * Explicit ``CANSWIM_WEEKEND_SCHEDULER=0|1`` wins.
+    * Else MCP with ``MCP_ALLOW_RUNS=1`` / ``CANSWIM_ALLOW_RUNS=1`` → on.
+    * Dashboard / other → off unless explicit on (avoids double schedule).
+    """
+    raw = os.getenv("CANSWIM_WEEKEND_SCHEDULER")
+    if raw is not None and str(raw).strip() != "":
+        return _env_truthy("CANSWIM_WEEKEND_SCHEDULER", "0")
+    if role == "mcp":
+        return _env_truthy("MCP_ALLOW_RUNS", "0") or _env_truthy(
+            "CANSWIM_ALLOW_RUNS", "0"
+        )
+    return False
+
+
+def _cron_kwargs() -> dict[str, Any]:
+    """Cron fields for weekend job (local timezone).
+
+    Defaults: Saturday 06:00 — after Friday US cash close / before Monday open.
+    Override with ``CANSWIM_WEEKEND_DOW`` (e.g. ``sat``), ``_HOUR``, ``_MINUTE``.
+    """
+    return {
+        "day_of_week": (os.getenv("CANSWIM_WEEKEND_DOW") or "sat").strip().lower(),
+        "hour": int(os.getenv("CANSWIM_WEEKEND_HOUR") or "6"),
+        "minute": int(os.getenv("CANSWIM_WEEKEND_MINUTE") or "0"),
+    }
+
+
+def _data_dir() -> Path:
+    return Path(os.getenv("data_dir", "data")).expanduser()
+
+
+def _lock_path() -> Path:
+    d = _data_dir()
+    d.mkdir(parents=True, exist_ok=True)
+    return d / "weekend_job.lock"
+
+
+def _try_acquire_lock(fh) -> bool:
+    """Non-blocking exclusive flock; True if held."""
+    import fcntl
+
+    try:
+        fcntl.flock(fh.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        return True
+    except BlockingIOError:
+        return False
+    except OSError as e:
+        logger.warning("Weekend lock OSError: {}", e)
+        return False
+
+
+def _release_lock(fh) -> None:
+    import fcntl
+
+    try:
+        fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+    except OSError:
+        pass
+
+
+def run_weekend_job_now(*, catchup: Optional[bool] = None) -> dict[str, Any]:
+    """Execute weekend job with cross-process lock (callable from scheduler or tests)."""
+    global _last_run
+    from canswim.weekend import run_weekend_all_db
+
+    use_catchup = (
+        _env_truthy("CANSWIM_WEEKEND_CATCHUP", "0")
+        if catchup is None
+        else bool(catchup)
+    )
+    lock_file = _lock_path()
+    started = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+    with open(lock_file, "a+", encoding="utf-8") as fh:
+        if not _try_acquire_lock(fh):
+            msg = "Weekend job skipped — another process holds weekend_job.lock"
+            logger.info(msg)
+            out = {
+                "ok": True,
+                "skipped": True,
+                "reason": "lock_held",
+                "message": msg,
+                "started_at": started,
+            }
+            _last_run = out
+            return out
+        try:
+            fh.seek(0)
+            fh.truncate()
+            fh.write(f"pid={os.getpid()} started={started}\n")
+            fh.flush()
+            logger.info(
+                "Weekend in-process job starting (catchup={}, pid={})",
+                use_catchup,
+                os.getpid(),
+            )
+            result = run_weekend_all_db(
+                dry_run=False,
+                catchup=use_catchup,
+                include_covariates=not _env_truthy("CANSWIM_WEEKEND_NO_COVARIATES", "0"),
+                skip_gather=_env_truthy("CANSWIM_WEEKEND_SKIP_GATHER", "0"),
+            )
+            result = dict(result)
+            result["skipped"] = False
+            result["started_at"] = started
+            result["finished_at"] = (
+                datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+            )
+            _last_run = result
+            logger.info(
+                "Weekend in-process job finished ok={} forecasted={} incomplete={}",
+                result.get("ok"),
+                len(result.get("forecasted") or []),
+                len(result.get("incomplete") or []),
+            )
+            return result
+        except Exception as e:
+            logger.exception("Weekend in-process job crashed: {}", e)
+            out = {
+                "ok": False,
+                "skipped": False,
+                "error": str(e),
+                "started_at": started,
+                "finished_at": datetime.now(timezone.utc)
+                .replace(microsecond=0)
+                .isoformat(),
+            }
+            _last_run = out
+            return out
+        finally:
+            _release_lock(fh)
+
+
+def get_scheduler_status() -> dict[str, Any]:
+    """Snapshot for get_server_info / operators."""
+    with _lock:
+        jobs = []
+        if _scheduler is not None:
+            for j in _scheduler.get_jobs():
+                jobs.append(
+                    {
+                        "id": j.id,
+                        "next_run_time": (
+                            j.next_run_time.isoformat() if j.next_run_time else None
+                        ),
+                        "trigger": str(j.trigger),
+                    }
+                )
+        return {
+            "running": bool(_started and _scheduler is not None),
+            "jobs": jobs,
+            "cron": _cron_kwargs(),
+            "last_run": dict(_last_run) if _last_run else None,
+            "lock_path": str(_lock_path()),
+        }
+
+
+def start_inprocess_scheduler(*, role: str = "service") -> bool:
+    """Start BackgroundScheduler if wanted and not already running.
+
+    Returns True if scheduler is running after the call.
+    """
+    global _scheduler, _started
+    if not weekend_scheduler_wanted(role=role):
+        logger.info(
+            "In-process weekend scheduler not enabled for role={} "
+            "(set CANSWIM_WEEKEND_SCHEDULER=1 to force)",
+            role,
+        )
+        return False
+    with _lock:
+        if _started and _scheduler is not None:
+            return True
+        try:
+            from apscheduler.schedulers.background import BackgroundScheduler
+            from apscheduler.triggers.cron import CronTrigger
+        except ImportError as e:
+            logger.error(
+                "APScheduler not installed — cannot start weekend scheduler: {}", e
+            )
+            return False
+
+        cron = _cron_kwargs()
+        sched = BackgroundScheduler(timezone=os.getenv("TZ") or None)
+        sched.add_job(
+            run_weekend_job_now,
+            CronTrigger(**cron),
+            id="canswim_weekend",
+            name="canswim weekend all-DB live forecast",
+            replace_existing=True,
+            max_instances=1,
+            coalesce=True,
+            misfire_grace_time=3600 * 6,
+        )
+        sched.start(paused=False)
+        _scheduler = sched
+        _started = True
+        atexit.register(stop_inprocess_scheduler)
+        logger.info(
+            "In-process weekend scheduler started (cron day_of_week={} hour={} "
+            "minute={}) via APScheduler",
+            cron["day_of_week"],
+            cron["hour"],
+            cron["minute"],
+        )
+        return True
+
+
+def stop_inprocess_scheduler() -> None:
+    """Shut down scheduler (idempotent)."""
+    global _scheduler, _started
+    with _lock:
+        if _scheduler is not None:
+            try:
+                _scheduler.shutdown(wait=False)
+            except Exception as e:
+                logger.debug("scheduler shutdown: {}", e)
+            _scheduler = None
+        _started = False

--- a/src/canswim/weekend.py
+++ b/src/canswim/weekend.py
@@ -140,6 +140,37 @@ def run_weekend_all_db(
         messages.append("Dry run only — no gather or forecast executed.")
         return plan
 
+    # Serialize with MCP refresh jobs / other weekend invokers
+    from canswim.data_run_lock import exclusive_data_run
+
+    with exclusive_data_run("weekend-cli", blocking=True):
+        return _run_weekend_batches(
+            universe=universe,
+            batches=batches,
+            batch_size=batch_size,
+            forecast_start=forecast_start,
+            live_start=live_start,
+            start_info=start_info,
+            mode=mode,
+            skip_gather=skip_gather,
+            include_covariates=include_covariates,
+            messages=messages,
+        )
+
+
+def _run_weekend_batches(
+    *,
+    universe: list[str],
+    batches: list[list[str]],
+    batch_size: int,
+    forecast_start: Optional[str],
+    live_start: str,
+    start_info: dict[str, Any],
+    mode: str,
+    skip_gather: bool,
+    include_covariates: bool,
+    messages: list[str],
+) -> dict[str, Any]:
     # Live run
     batch_results: list[dict[str, Any]] = []
     all_forecasted: list[str] = []

--- a/tests/canswim/test_data_run_lock.py
+++ b/tests/canswim/test_data_run_lock.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+import fcntl
+import os
 import threading
 import time
+from multiprocessing import Process
 from pathlib import Path
 
 from canswim.data_run_lock import (
     data_run_lock_path,
+    data_run_lock_status,
     exclusive_data_run,
     try_exclusive_data_run,
 )
@@ -48,3 +52,63 @@ def test_reentrant_same_thread(tmp_path: Path):
         assert ok1 is True
         with exclusive_data_run("inner", blocking=True, data_dir=tmp_path) as ok2:
             assert ok2 is True
+
+
+def test_stale_lock_file_does_not_block(tmp_path: Path):
+    """Reboot/crash leftover: file on disk with dead holder text is NOT locked."""
+    path = tmp_path / "canswim_data_run.lock"
+    path.write_text("holder=dead-after-reboot pid=1 t=0\n", encoding="utf-8")
+    assert try_exclusive_data_run("after-reboot", data_dir=tmp_path) is True
+    st = data_run_lock_status(data_dir=tmp_path)
+    assert st["held"] is False
+    assert st["file_exists"] is True
+
+
+def test_process_death_releases_flock(tmp_path: Path):
+    """Crash analog: child exits without unlock → parent can acquire."""
+    path = tmp_path / "canswim_data_run.lock"
+
+    def hold_and_die():
+        fh = open(path, "a+", encoding="utf-8")
+        fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+        fh.write(f"holder=crashed pid={os.getpid()}\n")
+        fh.flush()
+        time.sleep(0.15)
+        # intentional: no unlock, no close — OS reaps on exit
+
+    p = Process(target=hold_and_die)
+    p.start()
+    # While child lives, non-blocking must fail
+    deadline = time.time() + 2.0
+    saw_busy = False
+    while time.time() < deadline and p.is_alive():
+        if not try_exclusive_data_run("during", data_dir=tmp_path):
+            saw_busy = True
+            break
+        time.sleep(0.02)
+    assert saw_busy, "expected flock held while child alive"
+    p.join(timeout=3.0)
+    assert p.exitcode == 0
+    assert path.is_file()  # junk file may remain
+    assert try_exclusive_data_run("after-crash", data_dir=tmp_path) is True
+
+
+def test_status_held_while_live_holder(tmp_path: Path):
+    release = threading.Event()
+
+    def holder():
+        with exclusive_data_run("live", blocking=True, data_dir=tmp_path):
+            release.wait(timeout=3.0)
+
+    t = threading.Thread(target=holder)
+    t.start()
+    deadline = time.time() + 2.0
+    while time.time() < deadline:
+        st = data_run_lock_status(data_dir=tmp_path)
+        if st["held"]:
+            break
+        time.sleep(0.02)
+    assert data_run_lock_status(data_dir=tmp_path)["held"] is True
+    release.set()
+    t.join(timeout=3.0)
+    assert data_run_lock_status(data_dir=tmp_path)["held"] is False

--- a/tests/canswim/test_data_run_lock.py
+++ b/tests/canswim/test_data_run_lock.py
@@ -1,0 +1,50 @@
+"""Shared exclusive lock for MCP refresh / weekend / CLI heavy runs."""
+
+from __future__ import annotations
+
+import threading
+import time
+from pathlib import Path
+
+from canswim.data_run_lock import (
+    data_run_lock_path,
+    exclusive_data_run,
+    try_exclusive_data_run,
+)
+
+
+def test_lock_path_under_data_dir(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("data_dir", str(tmp_path))
+    p = data_run_lock_path()
+    assert p == tmp_path / "canswim_data_run.lock"
+
+
+def test_exclusive_blocks_other_thread(tmp_path: Path):
+    order: list[str] = []
+    release = threading.Event()
+
+    def holder():
+        with exclusive_data_run("t1", blocking=True, data_dir=tmp_path) as ok:
+            assert ok is True
+            order.append("held")
+            release.wait(timeout=3.0)
+            order.append("release")
+
+    t = threading.Thread(target=holder)
+    t.start()
+    # Wait until holder has the lock
+    deadline = time.time() + 2.0
+    while time.time() < deadline and "held" not in order:
+        time.sleep(0.01)
+    assert "held" in order
+    assert try_exclusive_data_run("probe", data_dir=tmp_path) is False
+    release.set()
+    t.join(timeout=3.0)
+    assert try_exclusive_data_run("probe2", data_dir=tmp_path) is True
+
+
+def test_reentrant_same_thread(tmp_path: Path):
+    with exclusive_data_run("outer", blocking=True, data_dir=tmp_path) as ok1:
+        assert ok1 is True
+        with exclusive_data_run("inner", blocking=True, data_dir=tmp_path) as ok2:
+            assert ok2 is True

--- a/tests/canswim/test_docs_sync.py
+++ b/tests/canswim/test_docs_sync.py
@@ -97,8 +97,9 @@ def test_deploy_service_doc_covers_gui_and_mcp_split():
         "CANSWIM_HOME",
         "~/.canswim/service",
         "~/.canswim/data",
-        "canswim-weekend",
         "stock_tickers",
+        "APScheduler",
+        "CANSWIM_WEEKEND_SCHEDULER",
     ):
         assert needle in text, f"docs/deploy_service.md missing {needle!r}"
     # Legacy deploy path must not reappear as the documented primary layout

--- a/tests/canswim/test_mcp_jobs.py
+++ b/tests/canswim/test_mcp_jobs.py
@@ -43,6 +43,101 @@ def test_status_empty_id(jobs_env):
     assert out["ok"] is False
 
 
+def test_coalesce_subset_returns_same_job_id(jobs_env):
+    """Second client requesting a subset of an active job joins without new work."""
+    import threading
+
+    release = threading.Event()
+    entered = threading.Event()
+
+    def slow_refresh(tickers, **kwargs):
+        entered.set()
+        release.wait(timeout=5.0)
+        return {
+            "ok": True,
+            "ready": ["AAPL", "MSFT", "GOOG"],
+            "gather": {"ok": True},
+            "forecast": {"ok": True},
+        }
+
+    with patch("canswim.mcp.jobs.refresh_symbols", side_effect=slow_refresh):
+        first = job_tools.refresh_job_start_impl("AAPL,MSFT,GOOG")
+        assert first["ok"] is True
+        jid = first["data"]["job_id"]
+        assert entered.wait(timeout=2.0)
+
+        # Same list → coalesce
+        same = job_tools.refresh_job_start_impl("AAPL,MSFT,GOOG")
+        assert same["ok"] is True
+        assert same.get("coalesced") is True
+        assert same["data"]["job_id"] == jid
+        assert same["data"].get("coalesced") is True
+
+        # Subset → coalesce
+        sub = job_tools.refresh_job_start_impl("MSFT")
+        assert sub["ok"] is True
+        assert sub.get("coalesced") is True
+        assert sub["data"]["job_id"] == jid
+
+        # Disjoint / supersets that are not covered → busy
+        busy = job_tools.refresh_job_start_impl("TSLA")
+        assert busy["ok"] is False
+        assert busy.get("active_job_id") == jid
+        assert busy.get("fail_reason") == "job_busy"
+
+        release.set()
+        deadline = time.time() + 5.0
+        while time.time() < deadline:
+            if job_tools.refresh_job_status_impl(jid)["data"]["done"]:
+                break
+            time.sleep(0.05)
+
+
+def test_coalesce_with_active_job_unit():
+    """Pure unit: subset matches; dry_run / covariates mismatch does not."""
+    active = {
+        "job_id": "abc",
+        "status": "running",
+        "ticker_list": ["AAPL", "MSFT"],
+        "dry_run": False,
+        "include_covariates": True,
+    }
+    hit = job_core.coalesce_with_active_job(
+        ["msft"],
+        include_covariates=True,
+        dry_run=False,
+        active=active,
+    )
+    assert hit is not None and hit["job_id"] == "abc"
+    assert (
+        job_core.coalesce_with_active_job(
+            ["MSFT", "TSLA"],
+            include_covariates=True,
+            dry_run=False,
+            active=active,
+        )
+        is None
+    )
+    assert (
+        job_core.coalesce_with_active_job(
+            ["MSFT"],
+            include_covariates=False,
+            dry_run=False,
+            active=active,
+        )
+        is None
+    )
+    assert (
+        job_core.coalesce_with_active_job(
+            ["MSFT"],
+            include_covariates=True,
+            dry_run=True,
+            active=active,
+        )
+        is None
+    )
+
+
 def test_job_lifecycle_succeeds(jobs_env):
     """Worker runs refresh_symbols mock and reaches succeeded."""
     seen_cb: list[tuple[float, str]] = []

--- a/tests/canswim/test_scheduler.py
+++ b/tests/canswim/test_scheduler.py
@@ -67,27 +67,62 @@ def test_run_weekend_job_now_calls_run_weekend(tmp_path, monkeypatch):
     ) as m:
         out = sched.run_weekend_job_now(catchup=False)
     m.assert_called_once()
+    assert m.call_args.kwargs.get("catchup") is False
     assert out["ok"] is True
     assert out["skipped"] is False
     assert out.get("forecasted") == ["AAPL"]
     assert sched.get_scheduler_status()["last_run"]["ok"] is True
 
 
-def test_run_weekend_job_lock_skip(tmp_path, monkeypatch):
-    """Second concurrent call skips when lock held."""
-    import fcntl
+def test_run_weekend_job_defaults_to_catchup(tmp_path, monkeypatch):
+    """Service path: monthly backtests + live unless CANSWIM_WEEKEND_CATCHUP=0."""
+    monkeypatch.setenv("data_dir", str(tmp_path))
+    monkeypatch.delenv("CANSWIM_WEEKEND_CATCHUP", raising=False)
+    with patch(
+        "canswim.weekend.run_weekend_all_db",
+        return_value={"ok": True, "forecasted": [], "incomplete": []},
+    ) as m:
+        sched.run_weekend_job_now()  # catchup=None → env default
+    assert m.call_args.kwargs.get("catchup") is True
+
+
+def test_run_weekend_job_catchup_can_be_disabled(tmp_path, monkeypatch):
+    monkeypatch.setenv("data_dir", str(tmp_path))
+    monkeypatch.setenv("CANSWIM_WEEKEND_CATCHUP", "0")
+    with patch(
+        "canswim.weekend.run_weekend_all_db",
+        return_value={"ok": True, "forecasted": [], "incomplete": []},
+    ) as m:
+        sched.run_weekend_job_now()
+    assert m.call_args.kwargs.get("catchup") is False
+
+
+def test_run_weekend_job_uses_shared_data_run_lock(tmp_path, monkeypatch):
+    """Weekend path holds data_dir/canswim_data_run.lock (shared with MCP refresh)."""
+    import threading
 
     monkeypatch.setenv("data_dir", str(tmp_path))
-    lock = tmp_path / "weekend_job.lock"
-    lock.write_text("")
-    with open(lock, "a+") as fh:
-        fcntl.flock(fh.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-        with patch("canswim.weekend.run_weekend_all_db") as m:
-            out = sched.run_weekend_job_now()
-        m.assert_not_called()
-        assert out.get("skipped") is True
-        assert out.get("reason") == "lock_held"
-        fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+    probe_busy = threading.Event()
+    continue_weekend = threading.Event()
+
+    def _fake_weekend(**kwargs):
+        from canswim.data_run_lock import try_exclusive_data_run
+
+        # Another thread must see the shared lock as busy while we hold it
+        def probe():
+            if not try_exclusive_data_run("probe", data_dir=tmp_path):
+                probe_busy.set()
+            continue_weekend.set()
+
+        threading.Thread(target=probe).start()
+        assert continue_weekend.wait(timeout=2.0)
+        return {"ok": True, "forecasted": [], "incomplete": []}
+
+    with patch("canswim.weekend.run_weekend_all_db", side_effect=_fake_weekend):
+        out = sched.run_weekend_job_now(catchup=False)
+    assert out["ok"] is True
+    assert probe_busy.is_set()
+    assert (tmp_path / "canswim_data_run.lock").is_file()
 
 
 def test_get_server_info_includes_weekend_scheduler(monkeypatch):

--- a/tests/canswim/test_scheduler.py
+++ b/tests/canswim/test_scheduler.py
@@ -1,0 +1,106 @@
+"""In-process APScheduler weekend job."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from canswim import scheduler as sched
+
+
+@pytest.fixture(autouse=True)
+def _reset_scheduler():
+    sched.stop_inprocess_scheduler()
+    sched._last_run = {}
+    yield
+    sched.stop_inprocess_scheduler()
+    sched._last_run = {}
+
+
+def test_weekend_scheduler_wanted_mcp_defaults_to_allow_runs(monkeypatch):
+    monkeypatch.delenv("CANSWIM_WEEKEND_SCHEDULER", raising=False)
+    monkeypatch.setenv("MCP_ALLOW_RUNS", "1")
+    assert sched.weekend_scheduler_wanted(role="mcp") is True
+    monkeypatch.setenv("MCP_ALLOW_RUNS", "0")
+    monkeypatch.delenv("CANSWIM_ALLOW_RUNS", raising=False)
+    assert sched.weekend_scheduler_wanted(role="mcp") is False
+
+
+def test_weekend_scheduler_wanted_explicit_override(monkeypatch):
+    monkeypatch.setenv("CANSWIM_WEEKEND_SCHEDULER", "1")
+    monkeypatch.setenv("MCP_ALLOW_RUNS", "0")
+    assert sched.weekend_scheduler_wanted(role="dashboard") is True
+    monkeypatch.setenv("CANSWIM_WEEKEND_SCHEDULER", "0")
+    monkeypatch.setenv("MCP_ALLOW_RUNS", "1")
+    assert sched.weekend_scheduler_wanted(role="mcp") is False
+
+
+def test_start_scheduler_registers_cron_job(monkeypatch):
+    monkeypatch.setenv("CANSWIM_WEEKEND_SCHEDULER", "1")
+    monkeypatch.setenv("CANSWIM_WEEKEND_DOW", "sun")
+    monkeypatch.setenv("CANSWIM_WEEKEND_HOUR", "7")
+    monkeypatch.setenv("CANSWIM_WEEKEND_MINUTE", "30")
+    assert sched.start_inprocess_scheduler(role="dashboard") is True
+    st = sched.get_scheduler_status()
+    assert st["running"] is True
+    assert len(st["jobs"]) == 1
+    assert st["jobs"][0]["id"] == "canswim_weekend"
+    assert st["cron"]["day_of_week"] == "sun"
+    assert st["cron"]["hour"] == 7
+    assert st["cron"]["minute"] == 30
+    # idempotent
+    assert sched.start_inprocess_scheduler(role="dashboard") is True
+
+
+def test_start_skipped_when_not_wanted(monkeypatch):
+    monkeypatch.setenv("CANSWIM_WEEKEND_SCHEDULER", "0")
+    assert sched.start_inprocess_scheduler(role="mcp") is False
+    assert sched.get_scheduler_status()["running"] is False
+
+
+def test_run_weekend_job_now_calls_run_weekend(tmp_path, monkeypatch):
+    monkeypatch.setenv("data_dir", str(tmp_path))
+    with patch(
+        "canswim.weekend.run_weekend_all_db",
+        return_value={"ok": True, "forecasted": ["AAPL"], "incomplete": []},
+    ) as m:
+        out = sched.run_weekend_job_now(catchup=False)
+    m.assert_called_once()
+    assert out["ok"] is True
+    assert out["skipped"] is False
+    assert out.get("forecasted") == ["AAPL"]
+    assert sched.get_scheduler_status()["last_run"]["ok"] is True
+
+
+def test_run_weekend_job_lock_skip(tmp_path, monkeypatch):
+    """Second concurrent call skips when lock held."""
+    import fcntl
+
+    monkeypatch.setenv("data_dir", str(tmp_path))
+    lock = tmp_path / "weekend_job.lock"
+    lock.write_text("")
+    with open(lock, "a+") as fh:
+        fcntl.flock(fh.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        with patch("canswim.weekend.run_weekend_all_db") as m:
+            out = sched.run_weekend_job_now()
+        m.assert_not_called()
+        assert out.get("skipped") is True
+        assert out.get("reason") == "lock_held"
+        fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+
+
+def test_get_server_info_includes_weekend_scheduler(monkeypatch):
+    monkeypatch.setenv("CANSWIM_WEEKEND_SCHEDULER", "0")
+    from canswim.mcp.tools import meta
+
+    with patch("canswim.mcp.tools.meta.runs_allowed", return_value=True):
+        with patch(
+            "canswim.mcp.tools.meta.__version__",
+            "0.0.test",
+        ):
+            # health-independent path for server info
+            out = meta.get_server_info_impl()
+    assert out["ok"] is True
+    assert "weekend_scheduler" in out["data"]
+    assert "running" in out["data"]["weekend_scheduler"]

--- a/weekend.sh
+++ b/weekend.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 # CANSWIM weekend forecast — all symbols in the Charts/search DB (stock_tickers).
-# Prefer systemd: service/canswim-weekend.timer (see docs/deploy_service.md).
-# Cron example (Saturday 06:00):
-#   0 6 * * 6 /home/YOU/canswim/weekend.sh >> /tmp/canswim-weekend.log 2>&1
+# One-shot / manual. For recurring runs, use the in-process APScheduler inside
+# canswim-mcp (MCP_ALLOW_RUNS=1) — see docs/deploy_service.md §3b.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"


### PR DESCRIPTION
## Summary

- Weekend all-DB forecast is scheduled **inside** the long-lived canswim process with **[APScheduler](https://apscheduler.readthedocs.io/)** — no extra systemd timer to operate.
- **MCP** starts the scheduler automatically when `MCP_ALLOW_RUNS=1` (this host already does).
- **Dashboard** stays off unless `CANSWIM_WEEKEND_SCHEDULER=1`.
- Cross-process **flock** on `data_dir/weekend_job.lock`.
- Cron defaults: **Sat 06:00** local (`CANSWIM_WEEKEND_DOW/HOUR/MINUTE`).
- `get_server_info` → `weekend_scheduler` status.
- Version **0.0.20260807**; docs updated; legacy timer template marked deprecated.

## Test plan

- [x] `./scripts/ci-local.sh` (309 passed)
- [x] `test_scheduler.py` (start/stop, cron, lock skip, server_info) — scheduler.py ~86% cov
- [ ] After merge: `systemctl --user restart canswim-mcp` and check logs for “In-process weekend scheduler started”
- [ ] `get_server_info` shows `weekend_scheduler.running: true` and a next_run_time