### PR TITLE
feat: idempotent weekend↔MCP shared refresh jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable releases are documented here. Versioning follows date-style `0.0.YYYYMMDD` unless noted.
 
+## 0.0.20260808
+
+Idempotent multi-entry work: weekend and MCP share one refresh job registry.
+
+### Highlights
+
+- **Weekend catch-up (service default)** enqueues the same async **refresh job** as MCP (`source=weekend`) for the full DuckDB universe
+- MCP clients requesting a **subset** of an in-flight weekend (or other) job **coalesce** onto that `job_id` — no duplicate gather/forecast
+- Forecast/gather remain **idempotent** (skip-if-saved partition, lean gather); flock is only a narrow per-batch write guard vs CLI
+- Live-only / skip-gather weekend still uses the CLI batch path
+
+### Install
+
+```bash
+pip install canswim==0.0.20260808
+```
+
 ## 0.0.20260807
 
 Weekend all-DB forecast runs **inside** the long-lived canswim process (APScheduler), not a separate systemd timer.

--- a/docs/deploy_service.md
+++ b/docs/deploy_service.md
@@ -216,8 +216,8 @@ canswim process via **[APScheduler](https://apscheduler.readthedocs.io/)**
 |---------|---------|
 | **MCP** with `MCP_ALLOW_RUNS=1` | Scheduler **on** (Sat 06:00 local) |
 | **Dashboard** | Scheduler **off** unless `CANSWIM_WEEKEND_SCHEDULER=1` |
-| Concurrent heavy work | Shared **`fcntl.flock`** on `data_dir/canswim_data_run.lock` — MCP refresh, weekend scheduler, and CLI `weekend` take turns. Kernel-released on crash/reboot (leftover file is not a lock) |
-| Multi-client refresh | Same/subset ticker list while a job runs → coalesce to one `job_id` (no duplicate work) |
+| Concurrent heavy work | **Idempotent job units** first: weekend catch-up = same refresh job registry as MCP; clients coalesce. Narrow **`fcntl.flock`** only guards parquet write batches vs CLI (kernel-released on crash/reboot) |
+| Multi-client refresh | Same/subset ticker list while a job runs (including weekend `source=weekend`) → coalesce to one `job_id` |
 
 ```bash
 # MCP unit already has MCP_ALLOW_RUNS=1 on this host → weekend cron is active after restart

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -159,9 +159,9 @@ Optional: `wait=true` on `refresh_tickers` forces the old blocking path (max ~50
 
 Workers batch symbols (~20). Job state is under `{data_dir}/mcp_jobs/`. Only **one** refresh job at a time.
 
-**Multi-client dedupe:** if client B starts a refresh whose ticker list is a **subset** of an already queued/running job (same `dry_run` / `include_covariates`), the server **coalesces** — `ok=true`, same `job_id`, `coalesced=true`. Poll `refresh_job_status`; do **not** start a second job. If the active job does **not** cover the full request, response is `ok=false` / `fail_reason=job_busy` with `active_job_id` — poll until done, then start only remaining symbols.
+**Idempotent multi-client work:** if client B starts a refresh whose ticker list is a **subset** of an already queued/running job (same `dry_run` / `include_covariates`), the server **coalesces** — `ok=true`, same `job_id`, `coalesced=true`. Poll `refresh_job_status`; do **not** start a second job. If the active job does **not** cover the full request, response is `ok=false` / `fail_reason=job_busy` with `active_job_id` — poll until done, then start only remaining symbols.
 
-Heavy gather/forecast work also takes a process-wide file lock (`data_dir/canswim_data_run.lock`) so MCP refresh does not race the in-process weekend job or CLI `weekend`. Within a job, symbols that already have a complete forecast partition for an origin are skipped (no re-inference).
+The **in-process weekend** catch-up job uses this **same** registry (`source=weekend`, full DuckDB universe). Portfolio MCP refreshes during the weekend run join that job instead of duplicating work. Gather/forecast units are **idempotent** (skip remote when history is fresh; skip forecast when a complete partition already exists). A narrow `fcntl.flock` only serializes parquet write batches vs CLI `weekend` on the same host — not the API contract.
 
 **Do not** claim portfolio-wide success after a tool timeout, a `dry_run`, a subset list, or while status is still `queued`/`running`.
 

--- a/docs/run_triggers.md
+++ b/docs/run_triggers.md
@@ -28,15 +28,12 @@ Loads every symbol from DuckDB **`stock_tickers`**, batches gather + forecast.
 | **In-process (MCP with `MCP_ALLOW_RUNS=1`)** | **Monthly catch-up (~12) + live** (`CANSWIM_WEEKEND_CATCHUP` defaults **on**) |
 | **CLI one-shot** `python -m canswim weekend` | Live week only (pass **`--catchup`** for monthly + live) |
 
-Host path uses `force_allow` (not gated by MCP_ALLOW_RUNS for CLI). Shared
-**`fcntl.flock`** on `data_dir/canswim_data_run.lock` serializes weekend with MCP
-async refresh (one heavy pipeline at a time). This is **not** a sticky pidfile:
-the kernel releases the lock when the holding process exits, crashes, or the host
-reboots. A leftover `.lock` file on disk does **not** block future runs (file
-presence ≠ locked). MCP clients that request the same/subset refresh while a job
-is in flight **coalesce** onto that `job_id` (see [mcp.md](mcp.md)). Forecast
-skips origins that already have a saved partition. See [cli.md](cli.md) and
-[deploy_service.md](deploy_service.md).
+**Service weekend (MCP + catch-up):** enqueues the same async **refresh job** as
+MCP for all DuckDB symbols (`source=weekend`). Clients with a subset **coalesce**
+onto that `job_id` (see [mcp.md](mcp.md)). Units are idempotent: lean gather +
+skip-if-saved forecast. CLI one-shot and live-only weekend still batch in-process
+with a narrow `fcntl.flock` write guard (not a sticky pidfile). See [cli.md](cli.md)
+and [deploy_service.md](deploy_service.md).
 
 ## Get market data (lean & rate-limit aware)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = canswim
-version = 0.0.20260807
+version = 0.0.20260808
 author = Ivelin Ivanov
 author_email = ivelin117@gmail.com
 description = Developer toolkit for CANSLIM-style investors (CLI, Gradio GUI, MCP)

--- a/src/canswim/mcp/jobs.py
+++ b/src/canswim/mcp/jobs.py
@@ -36,8 +36,14 @@ STATUS_SUCCEEDED = "succeeded"
 STATUS_FAILED = "failed"
 TERMINAL = frozenset({STATUS_SUCCEEDED, STATUS_FAILED})
 
+# Who enqueued the job (MCP client vs in-process weekend). Same worker + coalesce.
+SOURCE_MCP = "mcp"
+SOURCE_WEEKEND = "weekend"
+
 # Portfolio-scale async refresh (blocking refresh_tickers stays at DEFAULT_MAX_TICKERS)
 JOB_MAX_TICKERS = 200
+# Weekend / host internal enqueues may cover full DuckDB universe.
+JOB_MAX_TICKERS_INTERNAL = 50_000
 # Internal worker chunks (GPU/memory + finer progress). Not exposed as separate jobs.
 WORKER_BATCH_SIZE = 20
 
@@ -227,6 +233,7 @@ def _public_view(job: dict[str, Any]) -> dict[str, Any]:
     view: dict[str, Any] = {
         "job_id": job.get("job_id"),
         "kind": job.get("kind"),
+        "source": job.get("source") or SOURCE_MCP,
         "status": status,
         "done": done,
         "tickers": job.get("tickers"),
@@ -249,6 +256,7 @@ def _public_view(job: dict[str, Any]) -> dict[str, Any]:
             else None,
             result=result if isinstance(result, dict) else None,
             error=job.get("error"),
+            source=job.get("source"),
         ),
     }
     if job.get("error"):
@@ -279,6 +287,7 @@ def _client_hint(
     requested_count: int | None = None,
     result: dict[str, Any] | None = None,
     error: Any = None,
+    source: Any = None,
 ) -> str:
     if status == STATUS_SUCCEEDED:
         cov = (result or {}).get("coverage") or {}
@@ -320,12 +329,44 @@ def _client_hint(
             "Do not claim the portfolio is refreshed. "
             "They may retry with refresh_job_start after fixing the cause."
         )
+    src = f" (source={source})" if source else ""
     return (
-        f"Job still in progress (status={status}). "
+        f"Job still in progress (status={status}){src}. "
         f"Wait about {poll}s, then call refresh_job_status with job_id={job_id}. "
         "Do not claim the refresh is complete until status is succeeded or failed. "
-        "Do not call refresh_tickers / refresh_job_start again while this job runs."
+        "If your symbols are a subset of this job, call refresh_job_start again — "
+        "the server coalesces onto the same job_id (no duplicate work)."
     )
+
+
+def wait_for_job(
+    job_id: str,
+    *,
+    timeout_s: Optional[float] = None,
+    poll_s: float = 1.0,
+) -> dict[str, Any]:
+    """Block until job reaches a terminal status (or timeout).
+
+    Used by the in-process weekend path so scheduler waits on the same job
+    clients poll via ``refresh_job_status``.
+    """
+    deadline = None if timeout_s is None else (time.time() + float(timeout_s))
+    poll = max(0.05, float(poll_s))
+    while True:
+        out = get_job_status(job_id)
+        if not out.get("ok"):
+            return out
+        data = out.get("data") or {}
+        if data.get("done") or data.get("status") in TERMINAL:
+            return out
+        if deadline is not None and time.time() >= deadline:
+            return {
+                "ok": False,
+                "error": f"Timed out waiting for job_id={job_id}",
+                "job_id": job_id,
+                "data": data,
+            }
+        time.sleep(poll)
 
 
 def get_job_status(job_id: str) -> dict[str, Any]:
@@ -346,22 +387,45 @@ def start_refresh_job(
     *,
     include_covariates: bool = True,
     dry_run: bool = False,
+    force_allow: bool = False,
+    source: str = SOURCE_MCP,
+    max_tickers: Optional[int] = None,
+    wait: bool = False,
+    wait_timeout_s: Optional[float] = None,
 ) -> dict[str, Any]:
     """Validate, enqueue, spawn background refresh; return immediately.
 
-    Requires ``MCP_ALLOW_RUNS=1``. Only one non-terminal refresh job at a time.
+    External MCP clients require ``MCP_ALLOW_RUNS=1`` (unless ``force_allow``).
+    Only one non-terminal refresh job at a time; **subset requests coalesce**
+    onto the active job (same work units — no duplicate gather/forecast).
+
+    Parameters
+    ----------
+    force_allow
+        Host/weekend path: skip MCP_ALLOW_RUNS gate (same as CLI force_allow).
+    source
+        ``mcp`` or ``weekend`` — recorded for operators; same worker either way.
+    max_tickers
+        Cap for parse (default :data:`JOB_MAX_TICKERS`; weekend uses internal max).
+    wait
+        If True, block until the job (or coalesced job) is terminal.
     """
-    blocked = require_runs_allowed()
-    if blocked is not None:
-        return {
-            "ok": False,
-            "error": blocked["error"],
-            "runs_allowed": False,
-        }
+    if not force_allow:
+        blocked = require_runs_allowed()
+        if blocked is not None:
+            return {
+                "ok": False,
+                "error": blocked["error"],
+                "runs_allowed": False,
+            }
+
+    cap = int(max_tickers) if max_tickers is not None else JOB_MAX_TICKERS
+    if force_allow and max_tickers is None and source == SOURCE_WEEKEND:
+        cap = JOB_MAX_TICKERS_INTERNAL
 
     parsed = parse_ticker_list(
         tickers,
-        max_tickers=JOB_MAX_TICKERS,
+        max_tickers=cap,
         overflow="error",
     )
     if not parsed.get("ok"):
@@ -395,28 +459,40 @@ def start_refresh_job(
             if hit is not None:
                 view = _public_view(hit)
                 view["coalesced"] = True
+                src = hit.get("source") or SOURCE_MCP
                 view["message"] = (
                     f"Joined in-flight job {hit.get('job_id')} "
-                    f"(request covered by active {hit.get('status')} refresh; "
-                    "no duplicate work). Poll refresh_job_status."
+                    f"(source={src}, status={hit.get('status')}; "
+                    "request covered — no duplicate work). Poll refresh_job_status."
                 )
                 logger.info(
-                    "MCP refresh coalesced into job_id={} n_req={} n_active={}",
+                    "Refresh coalesced into job_id={} source={} n_req={} n_active={}",
                     hit.get("job_id"),
+                    src,
                     len(tlist),
                     hit.get("requested_count"),
                 )
-                return {
+                out = {
                     "ok": True,
                     "coalesced": True,
                     "data": view,
                 }
+                if wait:
+                    waited = wait_for_job(
+                        str(hit.get("job_id")),
+                        timeout_s=wait_timeout_s,
+                    )
+                    if waited.get("ok"):
+                        waited["coalesced"] = True
+                    return waited
+                return out
             view = _public_view(active)
             return {
                 "ok": False,
                 "error": (
                     f"A refresh job is already {active.get('status')} "
-                    f"(job_id={active.get('job_id')}). "
+                    f"(job_id={active.get('job_id')}, "
+                    f"source={active.get('source') or SOURCE_MCP}). "
                     "It does not cover this full ticker list. "
                     "Poll refresh_job_status until it finishes, then start a new one "
                     "for any remaining symbols."
@@ -429,9 +505,11 @@ def start_refresh_job(
         ticker_csv = ",".join(tlist)
         n = len(tlist)
         store = str(jobs_dir())
+        src = (source or SOURCE_MCP).strip().lower() or SOURCE_MCP
         job: dict[str, Any] = {
             "job_id": job_id,
             "kind": JOB_KIND_REFRESH,
+            "source": src,
             "status": STATUS_QUEUED,
             "done": False,
             "tickers": ticker_csv,
@@ -439,9 +517,10 @@ def start_refresh_job(
             "requested_count": n,
             "include_covariates": bool(include_covariates),
             "dry_run": bool(dry_run),
+            "force_allow": bool(force_allow),
             "progress_pct": 0.0,
             "message": (
-                f"Queued — {n} symbol(s), "
+                f"Queued — {n} symbol(s), source={src}, "
                 f"{(n + WORKER_BATCH_SIZE - 1) // WORKER_BATCH_SIZE} batch(es)…"
             ),
             "created_at": _utc_now(),
@@ -463,6 +542,7 @@ def start_refresh_job(
                 "ticker_list": tlist,
                 "include_covariates": bool(include_covariates),
                 "dry_run": bool(dry_run),
+                "force_allow": bool(force_allow),
                 "store_dir": store,
             },
             daemon=True,
@@ -472,17 +552,113 @@ def start_refresh_job(
         thr.start()
 
     logger.info(
-        "MCP refresh job started job_id={} n_tickers={} dry_run={}",
+        "Refresh job started job_id={} source={} n_tickers={} dry_run={}",
         job_id,
+        src,
         n,
         dry_run,
     )
     # Re-read in case worker already advanced
     latest = read_job(job_id) or job
-    return {
+    out = {
         "ok": True,
+        "coalesced": False,
         "data": _public_view(latest),
     }
+    if wait:
+        waited = wait_for_job(job_id, timeout_s=wait_timeout_s)
+        return waited
+    return out
+
+
+def run_all_db_refresh_job(
+    *,
+    include_covariates: bool = True,
+    dry_run: bool = False,
+    symbols: Optional[list[str]] = None,
+    wait: bool = True,
+    wait_timeout_s: Optional[float] = None,
+) -> dict[str, Any]:
+    """Enqueue catch-up refresh for the full DuckDB universe (weekend path).
+
+    Uses the **same** job registry and worker as MCP ``refresh_job_start`` so
+    concurrent clients with a subset of symbols **coalesce** onto this job
+    instead of starting duplicate work. Forecast/gather remain idempotent
+    (skip-if-saved / lean gather).
+
+    If a smaller in-flight job exists, waits for it to finish first (those
+    symbols are then cheap skip-if-done), then starts the full-universe job.
+    If an in-flight job already covers the full universe, joins it.
+    """
+    from canswim.weekend import list_db_symbols
+
+    universe = (
+        sorted({str(s).strip().upper() for s in symbols if str(s).strip()})
+        if symbols is not None
+        else list_db_symbols()
+    )
+    if not universe:
+        return {
+            "ok": False,
+            "error": "No symbols in stock_tickers (empty Charts universe).",
+            "symbols": [],
+            "source": SOURCE_WEEKEND,
+        }
+
+    # Drain non-covering active jobs so we can start (or join) full coverage.
+    # Idempotent units: prior job work is not re-done.
+    idle_deadline = (
+        None if wait_timeout_s is None else (time.time() + float(wait_timeout_s))
+    )
+    while True:
+        active = find_active_refresh_job()
+        if active is None:
+            break
+        active_set = _norm_ticker_set(active.get("ticker_list") or active.get("tickers"))
+        univ_set = set(universe)
+        if univ_set and univ_set <= active_set:
+            logger.info(
+                "Weekend joining existing job_id={} (covers full universe n={})",
+                active.get("job_id"),
+                active.get("requested_count"),
+            )
+            if wait:
+                return wait_for_job(
+                    str(active["job_id"]),
+                    timeout_s=wait_timeout_s,
+                )
+            return {"ok": True, "coalesced": True, "data": _public_view(active)}
+        jid = str(active.get("job_id") or "")
+        logger.info(
+            "Weekend waiting for in-flight job_id={} (n={}) before full-universe start",
+            jid,
+            active.get("requested_count"),
+        )
+        remaining = None
+        if idle_deadline is not None:
+            remaining = max(0.0, idle_deadline - time.time())
+            if remaining <= 0:
+                return {
+                    "ok": False,
+                    "error": f"Timed out waiting for active job_id={jid}",
+                    "active_job_id": jid,
+                    "source": SOURCE_WEEKEND,
+                }
+        waited = wait_for_job(jid, timeout_s=remaining)
+        if not waited.get("ok") and not (waited.get("data") or {}).get("done"):
+            return waited
+
+    ticker_csv = ",".join(universe)
+    return start_refresh_job(
+        ticker_csv,
+        include_covariates=include_covariates,
+        dry_run=dry_run,
+        force_allow=True,
+        source=SOURCE_WEEKEND,
+        max_tickers=max(len(universe), JOB_MAX_TICKERS),
+        wait=wait,
+        wait_timeout_s=wait_timeout_s,
+    )
 
 
 def _merge_symbol_lists(*lists: Any) -> list[str]:
@@ -505,6 +681,7 @@ def _run_refresh_worker(
     ticker_list: list[str],
     include_covariates: bool,
     dry_run: bool,
+    force_allow: bool = False,
     store_dir: str | None = None,
 ) -> None:
     def _load() -> Optional[dict[str, Any]]:
@@ -587,15 +764,16 @@ def _run_refresh_worker(
                 _progress(_base + _span * f, msg)
 
             _progress(base, f"Batch {bi + 1}/{n_batches}: starting {batch_csv[:80]}…")
-            # Serialize with weekend scheduler / CLI weekend (shared flock)
+            # Narrow write critical section vs CLI weekend (same host data_dir).
+            # Idempotent units (skip-if-saved + lean gather) make re-entry cheap.
             from canswim.data_run_lock import exclusive_data_run
 
-            with exclusive_data_run(f"mcp-refresh-job-{job_id[:8]}", blocking=True):
+            with exclusive_data_run(f"refresh-job-{job_id[:8]}-b{bi}", blocking=True):
                 result = refresh_symbols(
                     batch_csv,
                     include_covariates=include_covariates,
                     dry_run=dry_run,
-                    force_allow=False,
+                    force_allow=bool(force_allow),
                     progress_cb=_batch_cb,
                     max_tickers=max(len(batch), DEFAULT_MAX_TICKERS),
                 )

--- a/src/canswim/scheduler.py
+++ b/src/canswim/scheduler.py
@@ -69,7 +69,17 @@ def _data_dir() -> Path:
 
 
 def run_weekend_job_now(*, catchup: Optional[bool] = None) -> dict[str, Any]:
-    """Execute weekend job with cross-process lock (callable from scheduler or tests)."""
+    """Execute weekend job (callable from scheduler or tests).
+
+    **Default (catch-up ON):** enqueue the same async **refresh job** MCP clients
+    use (full DuckDB universe). Clients requesting a subset **coalesce** onto
+    that ``job_id`` — no duplicate work. Gather/forecast stay idempotent
+    (skip-if-saved / lean gather). A narrow per-batch flock remains only for
+    safe parquet writes vs CLI ``weekend``.
+
+    **Live-only** (``CANSWIM_WEEKEND_CATCHUP=0``) or ``CANSWIM_WEEKEND_SKIP_GATHER=1``:
+    keeps the direct batch path in :func:`canswim.weekend.run_weekend_all_db`.
+    """
     global _last_run
     from canswim.weekend import run_weekend_all_db
 
@@ -80,52 +90,99 @@ def run_weekend_job_now(*, catchup: Optional[bool] = None) -> dict[str, Any]:
         if catchup is None
         else bool(catchup)
     )
+    include_covariates = not _env_truthy("CANSWIM_WEEKEND_NO_COVARIATES", "0")
+    skip_gather = _env_truthy("CANSWIM_WEEKEND_SKIP_GATHER", "0")
     started = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
-    # Shared with MCP refresh jobs — one heavy pipeline at a time
-    from canswim.data_run_lock import exclusive_data_run
 
-    with exclusive_data_run("weekend-scheduler", blocking=True):
-        try:
-            logger.info(
-                "Weekend in-process job starting (catchup={}, pid={})",
-                use_catchup,
-                os.getpid(),
-            )
-            result = run_weekend_all_db(
+    try:
+        logger.info(
+            "Weekend in-process job starting (catchup={}, skip_gather={}, pid={})",
+            use_catchup,
+            skip_gather,
+            os.getpid(),
+        )
+        # Preferred path: same job registry as MCP refresh (idempotent + coalesce)
+        if use_catchup and not skip_gather:
+            from canswim.mcp.jobs import run_all_db_refresh_job
+
+            job_out = run_all_db_refresh_job(
+                include_covariates=include_covariates,
                 dry_run=False,
-                catchup=use_catchup,
-                include_covariates=not _env_truthy(
-                    "CANSWIM_WEEKEND_NO_COVARIATES", "0"
-                ),
-                skip_gather=_env_truthy("CANSWIM_WEEKEND_SKIP_GATHER", "0"),
+                wait=True,
             )
+            result = _job_out_to_weekend_result(job_out)
+        else:
+            # Live-only / forecast-only: direct batches (still skip-if-saved)
+            from canswim.data_run_lock import exclusive_data_run
+
+            with exclusive_data_run("weekend-scheduler", blocking=True):
+                result = run_weekend_all_db(
+                    dry_run=False,
+                    catchup=use_catchup,
+                    include_covariates=include_covariates,
+                    skip_gather=skip_gather,
+                )
             result = dict(result)
-            result["skipped"] = False
-            result["started_at"] = started
-            result["finished_at"] = (
-                datetime.now(timezone.utc).replace(microsecond=0).isoformat()
-            )
-            _last_run = result
-            logger.info(
-                "Weekend in-process job finished ok={} forecasted={} incomplete={}",
-                result.get("ok"),
-                len(result.get("forecasted") or []),
-                len(result.get("incomplete") or []),
-            )
-            return result
-        except Exception as e:
-            logger.exception("Weekend in-process job crashed: {}", e)
-            out = {
-                "ok": False,
-                "skipped": False,
-                "error": str(e),
-                "started_at": started,
-                "finished_at": datetime.now(timezone.utc)
-                .replace(microsecond=0)
-                .isoformat(),
-            }
-            _last_run = out
-            return out
+
+        result["skipped"] = False
+        result["started_at"] = started
+        result["finished_at"] = (
+            datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+        )
+        _last_run = result
+        logger.info(
+            "Weekend in-process job finished ok={} via={} forecasted={} incomplete={}",
+            result.get("ok"),
+            result.get("via") or "weekend_batches",
+            len(result.get("forecasted") or []),
+            len(result.get("incomplete") or []),
+        )
+        return result
+    except Exception as e:
+        logger.exception("Weekend in-process job crashed: {}", e)
+        out = {
+            "ok": False,
+            "skipped": False,
+            "error": str(e),
+            "started_at": started,
+            "finished_at": datetime.now(timezone.utc)
+            .replace(microsecond=0)
+            .isoformat(),
+        }
+        _last_run = out
+        return out
+
+
+def _job_out_to_weekend_result(job_out: dict[str, Any]) -> dict[str, Any]:
+    """Map refresh job status envelope → weekend-style summary for last_run."""
+    data = job_out.get("data") if isinstance(job_out.get("data"), dict) else {}
+    res = data.get("result") if isinstance(data.get("result"), dict) else {}
+    status = data.get("status")
+    if not job_out.get("ok") and status not in ("succeeded", "failed"):
+        ok = False
+    elif status == "succeeded":
+        ok = True
+    elif status == "failed":
+        ok = False
+    else:
+        ok = bool(res.get("ok")) if res else bool(job_out.get("ok"))
+    forecasted = list(res.get("forecasted") or [])
+    incomplete = list(res.get("incomplete") or [])
+    return {
+        "ok": ok,
+        "via": "refresh_job",
+        "job_id": data.get("job_id") or job_out.get("job_id"),
+        "source": data.get("source") or "weekend",
+        "coalesced": bool(job_out.get("coalesced")),
+        "status": status,
+        "forecasted": forecasted,
+        "incomplete": incomplete,
+        "ready": list(res.get("ready") or []),
+        "coverage": res.get("coverage"),
+        "error": data.get("error") or job_out.get("error") or res.get("error"),
+        "mode": "catchup",
+        "messages": list(res.get("messages") or []),
+    }
 
 
 def _data_run_lock_status() -> dict[str, Any]:

--- a/src/canswim/weekend.py
+++ b/src/canswim/weekend.py
@@ -1,11 +1,14 @@
-"""Weekend routine: gather + live-week forecast for all DB symbols.
+"""Weekend routine: gather + forecast for all DB symbols.
 
-Intended for a recurring systemd timer (or cron) on the host operator account.
-Uses the same ``gather_for_tickers`` / ``forecast_for_tickers`` paths as CLI/MCP
-so policy (price hard-fail, fund gates, skip-existing) stays DRY.
+**In-process service (MCP + APScheduler):** prefer
+:func:`canswim.mcp.jobs.run_all_db_refresh_job` so work uses the same job
+registry as MCP ``refresh_job_start`` — clients with a subset **coalesce** and
+forecast/gather stay idempotent (skip-if-saved). See :mod:`canswim.scheduler`.
 
-Default: **live week start only** (next market week open after the latest close).
-Optional ``--catchup`` runs blank-start catch-up (~12 monthly origins + live).
+**CLI one-shot** (``python -m canswim weekend``): this module’s batch path —
+default **live week only**; ``--catchup`` = monthly + live. Still shares
+policy with MCP (price hard-fail, fund gates, skip-existing) via
+``gather_for_tickers`` / ``forecast_for_tickers``.
 """
 
 from __future__ import annotations
@@ -140,7 +143,8 @@ def run_weekend_all_db(
         messages.append("Dry run only — no gather or forecast executed.")
         return plan
 
-    # Serialize with MCP refresh jobs / other weekend invokers
+    # CLI / live-only: narrow flock per process so we don't race MCP job batches
+    # writing the same parquet. Idempotent forecast/gather still skip completed work.
     from canswim.data_run_lock import exclusive_data_run
 
     with exclusive_data_run("weekend-cli", blocking=True):

--- a/tests/canswim/test_scheduler.py
+++ b/tests/canswim/test_scheduler.py
@@ -74,16 +74,39 @@ def test_run_weekend_job_now_calls_run_weekend(tmp_path, monkeypatch):
     assert sched.get_scheduler_status()["last_run"]["ok"] is True
 
 
-def test_run_weekend_job_defaults_to_catchup(tmp_path, monkeypatch):
-    """Service path: monthly backtests + live unless CANSWIM_WEEKEND_CATCHUP=0."""
+def test_run_weekend_job_defaults_to_catchup_via_refresh_job(tmp_path, monkeypatch):
+    """Service default: full-universe refresh job (same registry as MCP)."""
     monkeypatch.setenv("data_dir", str(tmp_path))
     monkeypatch.delenv("CANSWIM_WEEKEND_CATCHUP", raising=False)
+    monkeypatch.delenv("CANSWIM_WEEKEND_SKIP_GATHER", raising=False)
+    job_out = {
+        "ok": True,
+        "coalesced": False,
+        "data": {
+            "job_id": "abc",
+            "source": "weekend",
+            "status": "succeeded",
+            "result": {
+                "ok": True,
+                "forecasted": ["AAPL"],
+                "incomplete": [],
+                "ready": ["AAPL"],
+                "coverage": {"requested_count": 1},
+            },
+        },
+    }
     with patch(
-        "canswim.weekend.run_weekend_all_db",
-        return_value={"ok": True, "forecasted": [], "incomplete": []},
+        "canswim.mcp.jobs.run_all_db_refresh_job",
+        return_value=job_out,
     ) as m:
-        sched.run_weekend_job_now()  # catchup=None → env default
-    assert m.call_args.kwargs.get("catchup") is True
+        with patch("canswim.weekend.run_weekend_all_db") as direct:
+            out = sched.run_weekend_job_now()  # catchup=None → env default
+    m.assert_called_once()
+    direct.assert_not_called()
+    assert out["ok"] is True
+    assert out.get("via") == "refresh_job"
+    assert out.get("job_id") == "abc"
+    assert out.get("forecasted") == ["AAPL"]
 
 
 def test_run_weekend_job_catchup_can_be_disabled(tmp_path, monkeypatch):
@@ -93,12 +116,15 @@ def test_run_weekend_job_catchup_can_be_disabled(tmp_path, monkeypatch):
         "canswim.weekend.run_weekend_all_db",
         return_value={"ok": True, "forecasted": [], "incomplete": []},
     ) as m:
-        sched.run_weekend_job_now()
+        with patch("canswim.mcp.jobs.run_all_db_refresh_job") as job_path:
+            sched.run_weekend_job_now()
+    m.assert_called_once()
     assert m.call_args.kwargs.get("catchup") is False
+    job_path.assert_not_called()
 
 
-def test_run_weekend_job_uses_shared_data_run_lock(tmp_path, monkeypatch):
-    """Weekend path holds data_dir/canswim_data_run.lock (shared with MCP refresh)."""
+def test_run_weekend_live_uses_shared_data_run_lock(tmp_path, monkeypatch):
+    """Live-only weekend path holds flock (CLI-style batches)."""
     import threading
 
     monkeypatch.setenv("data_dir", str(tmp_path))
@@ -108,7 +134,6 @@ def test_run_weekend_job_uses_shared_data_run_lock(tmp_path, monkeypatch):
     def _fake_weekend(**kwargs):
         from canswim.data_run_lock import try_exclusive_data_run
 
-        # Another thread must see the shared lock as busy while we hold it
         def probe():
             if not try_exclusive_data_run("probe", data_dir=tmp_path):
                 probe_busy.set()

--- a/tests/canswim/test_weekend_job_queue.py
+++ b/tests/canswim/test_weekend_job_queue.py
@@ -1,0 +1,115 @@
+"""Weekend full-universe work uses the same refresh job registry as MCP."""
+
+from __future__ import annotations
+
+import threading
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from canswim.mcp import jobs as job_core
+from canswim.mcp.tools import jobs as job_tools
+
+
+@pytest.fixture
+def jobs_env(canswim_isolated_data_dir: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("MCP_ALLOW_RUNS", "1")
+    yield canswim_isolated_data_dir
+
+
+def test_mcp_coalesces_into_weekend_all_db_job(jobs_env):
+    """Client subset joins in-flight weekend full-universe refresh."""
+    release = threading.Event()
+    entered = threading.Event()
+
+    def slow_refresh(tickers, **kwargs):
+        entered.set()
+        release.wait(timeout=5.0)
+        return {
+            "ok": True,
+            "ready": ["AAPL", "MSFT", "GOOG"],
+            "gather": {"ok": True},
+            "forecast": {"ok": True, "forecasted": ["AAPL", "MSFT", "GOOG"]},
+        }
+
+    with patch("canswim.mcp.jobs.refresh_symbols", side_effect=slow_refresh):
+        with patch(
+            "canswim.weekend.list_db_symbols",
+            return_value=["AAPL", "MSFT", "GOOG"],
+        ):
+            started = job_core.run_all_db_refresh_job(
+                include_covariates=True,
+                wait=False,
+            )
+        assert started["ok"] is True
+        jid = started["data"]["job_id"]
+        assert started["data"].get("source") == "weekend"
+        assert entered.wait(timeout=2.0)
+
+        client = job_tools.refresh_job_start_impl("MSFT")
+        assert client["ok"] is True
+        assert client.get("coalesced") is True
+        assert client["data"]["job_id"] == jid
+        assert client["data"].get("source") == "weekend"
+
+        release.set()
+        st = None
+        deadline = time.time() + 5.0
+        while time.time() < deadline:
+            st = job_tools.refresh_job_status_impl(jid)
+            if st["data"]["done"]:
+                break
+            time.sleep(0.05)
+        assert st is not None
+        assert st["data"]["status"] == "succeeded"
+
+
+def test_run_all_db_waits_for_smaller_job_then_starts(jobs_env):
+    """Full-universe start drains a non-covering job first."""
+    release = threading.Event()
+    entered = threading.Event()
+
+    def slow_refresh(tickers, **kwargs):
+        entered.set()
+        release.wait(timeout=5.0)
+        return {
+            "ok": True,
+            "ready": ["AAPL"],
+            "gather": {"ok": True},
+            "forecast": {"ok": True, "forecasted": ["AAPL"]},
+        }
+
+    def later_refresh(tickers, **kwargs):
+        return {
+            "ok": True,
+            "ready": ["AAPL", "MSFT"],
+            "gather": {"ok": True},
+            "forecast": {"ok": True, "forecasted": ["MSFT"]},
+        }
+
+    with patch("canswim.mcp.jobs.refresh_symbols", side_effect=slow_refresh):
+        first = job_tools.refresh_job_start_impl("AAPL")
+        assert first["ok"] is True
+        jid1 = first["data"]["job_id"]
+        assert entered.wait(timeout=2.0)
+
+        # Finish small job, then weekend starts full universe
+        release.set()
+        deadline = time.time() + 5.0
+        while time.time() < deadline:
+            if job_tools.refresh_job_status_impl(jid1)["data"]["done"]:
+                break
+            time.sleep(0.05)
+
+    with patch("canswim.mcp.jobs.refresh_symbols", side_effect=later_refresh):
+        with patch(
+            "canswim.weekend.list_db_symbols",
+            return_value=["AAPL", "MSFT"],
+        ):
+            out = job_core.run_all_db_refresh_job(wait=True)
+    assert out["ok"] is True
+    assert out["data"]["status"] == "succeeded"
+    assert out["data"].get("source") == "weekend"
+    assert out["data"]["job_id"] != jid1


### PR DESCRIPTION
## Summary

- **Weekend catch-up (service default)** runs through the same async **refresh job** registry as MCP (`source=weekend`, full DuckDB universe).
- MCP clients whose symbols are a **subset** of an in-flight weekend (or other) job **coalesce** onto that `job_id` — no duplicate gather/forecast.
- Work units stay **idempotent** (lean gather + skip-if-saved forecast). `fcntl.flock` is only a narrow per-batch write guard vs CLI, not the API contract.
- Live-only / skip-gather weekend still uses the direct batch path.

## API / behavior

| Entry | Path |
|-------|------|
| MCP `refresh_job_start` | Existing job + coalesce |
| APScheduler weekend (catch-up) | `run_all_db_refresh_job` → same worker |
| CLI `weekend` / live-only | Prior batch path + flock |

Version **0.0.20260808** (MCP rediscovery).

## Test plan

- [x] `./scripts/ci-local.sh` — 321 passed (Python 3.10 GHA-parity suite)
- [x] MCP coalesces into weekend full-universe job
- [x] Weekend drains non-covering job then starts full universe
- [x] Scheduler default uses job path; live-only uses batches