### PR TITLE
feat(dashboard): shareable chart deep links

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ python -m canswim dashboard --same_data True
 
 | Tab | Purpose |
 |-----|---------|
-| **Charts** | Price history + forecast bands for a symbol |
+| **Charts** | Price history + forecast bands for a symbol (shareable `?ticker=AAPL&lowq=95`) |
 | **Scans** | Filter forecasts by as-of date, reward, risk, confidence |
 | **Run** | **Refresh data & forecasts** (primary) · more options for gather-only / forecast-only / **Rebuild Charts database** |
 | **Advanced Queries** | Read-only SQL against the search DB |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -25,7 +25,7 @@ Local work should keep **`hfhub_sync=False`** (default) unless you intentionally
 
 | Task | Purpose | Common flags |
 |------|---------|----------------|
-| `dashboard` | Gradio UI: Charts, Scans, Run, Advanced | `--same_data True` to reuse DuckDB |
+| `dashboard` | Gradio UI: Charts, Scans, Run, Advanced | `--same_data True` to reuse DuckDB; share a chart via `?ticker=AAPL&lowq=95` |
 | `gatherdata` | Get market data (full universe or scoped) | `--tickers`, `--no_covariates` |
 | `forecast` | Run forecasts (full or scoped) | `--tickers`, `--forecast_start_date`, `--dry_run` |
 | `resolve_start` | Print which forecast start date would be used | `--forecast_start_date` |

--- a/docs/superpowers/specs/2026-08-06-chart-deep-links-design.md
+++ b/docs/superpowers/specs/2026-08-06-chart-deep-links-design.md
@@ -1,0 +1,130 @@
+# Chart deep links (shareable GUI URLs)
+
+**Status:** Approved design  
+**Date:** 2026-08-06  
+**Scope:** Gradio dashboard Charts tab only (v1)
+
+## Problem
+
+The CANSWIM Gradio playground exposes a single top-level URL (e.g. `http://host:7860/`). Selecting a stock symbol, confidence level, or other UI state does not change the browser URL, so users cannot copy a link that opens the same chart.
+
+## Goals
+
+1. Selecting a ticker (and confidence) updates the browser address bar with a shareable, human-readable query string.
+2. Opening that URL loads the Charts tab with the same ticker and confidence and renders the forecast chart.
+3. Links remain valid across Gradio process restarts (no server-side snapshot dependency).
+
+## Non-goals (v1)
+
+- Encoding active tab (Scans / Run / Advanced)
+- Scans filters, forecast start date, Advanced query text
+- Gradio `DeepLinkButton` / opaque `deep_link=` hashes
+- Path-based multi-page routing (`/charts`, etc.)
+- MCP / CLI changes or version bump
+
+## URL contract
+
+| Param   | Required | Values                         | Notes |
+|---------|----------|--------------------------------|--------|
+| `ticker` | No      | Uppercase symbol string        | Must be in the Charts dropdown choices (symbols known to the search DB). Case-insensitive on input; normalized to uppercase. |
+| `lowq`   | No      | `80`, `95`, or `99`            | Confidence % for lowest close price. Invalid/missing → `80`. |
+
+**Examples**
+
+```
+http://spark-9045.tail39d5a.ts.net:7860/?ticker=AAPL
+http://spark-9045.tail39d5a.ts.net:7860/?ticker=AAPL&lowq=95
+```
+
+**Invalid / missing behavior**
+
+- Missing both params → keep current behavior (random default ticker from available symbols, `lowq=80`).
+- Unknown `ticker` (not in choices) → fall back to current default ticker; do not crash.
+- Invalid `lowq` → use `80`.
+- Preserve unrelated query params if present when updating the URL (only set/replace `ticker` and `lowq`).
+
+## Approach (chosen)
+
+**Readable query params + live `history.replaceState`.**
+
+Rejected alternatives:
+
+- **Gradio DeepLinkButton** — opaque hashes, server-side state files, not always in the address bar, fragile across restarts.
+- **Multi-page Gradio routes** — larger refactor than needed for charts-only share links.
+
+## Architecture
+
+### 1. Pure helpers (testable)
+
+Small module or functions (e.g. under `src/canswim/dashboard/url_state.py` or next to charts):
+
+- `parse_chart_query(query_params: Mapping) -> tuple[str | None, int]`  
+  - Normalize ticker (strip, upper); validate `lowq` ∈ {80, 95, 99}.
+- `resolve_chart_ticker(requested: str | None, choices: Sequence[str], default: str | None) -> str | None`  
+  - Return requested if in choices (case-insensitive match to canonical choice), else default.
+- `chart_query_js` string (or builder) for client-side URL sync — keep JS minimal and documented.
+
+### 2. Load path
+
+In `CanswimPlayground.launch` / existing `demo.load`:
+
+- Accept `gr.Request` (or read query via Gradio’s request injection).
+- On page load, parse `ticker` / `lowq` from `request.query_params`.
+- Resolve against current ticker choices.
+- Outputs must update: `tickerDropdown`, `lowq`, plot, reward/risk table, company markdown (same outputs as today’s load + plot path).
+- Prefer query values over component-constructed defaults when valid.
+
+### 3. Live URL sync
+
+When `tickerDropdown` or `lowq` changes:
+
+- Existing Python `plot_forecast` handlers stay responsible for chart data.
+- Attach client-side JS (Gradio `js=` on the change events, or a thin wrapper) that:
+  1. Reads current ticker and lowq from the event inputs.
+  2. Updates `URLSearchParams` for `ticker` and `lowq` only.
+  3. Calls `history.replaceState` (no navigation / no reload).
+
+No full page reload on ticker change.
+
+### 4. Component defaults
+
+- Keep random default ticker when no query param (current UX for casual browsing).
+- When query provides a valid ticker, dropdown initial value should match so load does not flash a wrong symbol longer than necessary (best-effort: set `value=` after parse if we can read query only at load-time via request; initial render may still use random until load runs — acceptable Gradio limitation).
+
+## Error handling
+
+- Parse/resolve never raises into Gradio UI; invalid input → defaults.
+- Missing DB / empty ticker list → existing empty-state behavior.
+- JS failures must not break plot updates (plot remains Python-driven).
+
+## Testing
+
+1. **Unit tests** for parse/resolve helpers:
+   - case normalization (`aapl` → `AAPL`)
+   - invalid lowq → 80
+   - unknown ticker → default
+   - empty / missing params
+2. No browser E2E required for v1; optional manual check on the live dashboard.
+
+## Documentation
+
+- Short note for operators/users: share chart via address bar `?ticker=&lowq=`.
+  - Prefer a brief addition near dashboard mentions in `README.md` or `docs/cli.md` / deploy docs only if those already describe the GUI URL — keep docs proportional.
+- Do **not** invent a parallel long design tree in user-facing docs; this file is the design record.
+
+## Implementation plan outline (for later planning skill)
+
+1. Add pure URL helpers + unit tests.
+2. Wire `demo.load` to request query params → component updates + plot.
+3. Wire ticker/lowq change events with JS `replaceState`.
+4. Run `./scripts/ci-local.sh`.
+5. Manual smoke: open `/?ticker=…`, change ticker, confirm address bar and reload.
+
+## Success criteria
+
+- [ ] `/?ticker=AAPL&lowq=95` opens Charts with AAPL at 95% confidence and plots.
+- [ ] Changing ticker or confidence updates the address bar without reload.
+- [ ] Copy-paste of that URL in a new tab restores the same chart controls.
+- [ ] Unknown ticker / bad lowq does not error; falls back safely.
+- [ ] `./scripts/ci-local.sh` passes.
+- [ ] No MCP version bump (GUI-only).

--- a/src/canswim/dashboard/__init__.py
+++ b/src/canswim/dashboard/__init__.py
@@ -8,6 +8,11 @@ from canswim.dashboard.charts import ChartTab
 from canswim.dashboard.scans import ScanTab
 from canswim.dashboard.advanced import AdvancedTab
 from canswim.dashboard.run_tab import RunTab
+from canswim.dashboard.url_state import (
+    CHART_URL_SYNC_JS,
+    parse_chart_query,
+    resolve_chart_ticker,
+)
 from canswim.db import DataPaths, init_search_db
 
 # Note: It appears that gradio Plot ignores the backend plot lib setting
@@ -99,9 +104,24 @@ class CanswimPlayground:
                     db_path=self.db_path,
                 )
 
-            def _on_load(ticker, lowq):
-                """Page load: chart + company blurb + scan dates + auto-scan."""
-                chart_out = charts_tab.plot_forecast(ticker, lowq)
+            def _on_load(ticker, lowq, request: gr.Request):
+                """Page load: apply ?ticker=&lowq=, chart + scans."""
+                query = {}
+                try:
+                    if request is not None:
+                        query = dict(request.query_params or {})
+                except Exception as e:
+                    logger.debug("chart deep-link query read failed: {}", e)
+                req_ticker, req_lowq = parse_chart_query(query)
+                choices = getattr(charts_tab, "sorted_tickers", None) or []
+                default_ticker = getattr(charts_tab, "default_ticker", None)
+                # Component value is the random default when no query ticker.
+                fallback = ticker if ticker is not None else default_ticker
+                resolved = resolve_chart_ticker(req_ticker, choices, fallback)
+                # parse_chart_query always returns a valid lowq (default 80).
+                resolved_lowq = req_lowq
+
+                chart_out = charts_tab.plot_forecast(resolved, resolved_lowq)
                 start_dd, start_iso, scan_status, scan_table = (
                     scans_tab.initial_scan()
                 )
@@ -109,29 +129,29 @@ class CanswimPlayground:
                     plot_val = chart_out.get(charts_tab.plotComponent)
                     rr_val = chart_out.get(charts_tab.rrTable)
                     company_val = chart_out.get(charts_tab.companyInfo)
-                    return (
-                        plot_val,
-                        rr_val,
-                        company_val,
-                        start_dd,
-                        start_iso,
-                        scan_status,
-                        scan_table,
-                    )
+                else:
+                    plot_val = chart_out[0]
+                    rr_val = chart_out[1]
+                    company_val = charts_tab._company_md(resolved)
                 return (
-                    chart_out[0],
-                    chart_out[1],
-                    charts_tab._company_md(ticker),
+                    gr.update(value=resolved),
+                    gr.update(value=resolved_lowq),
+                    plot_val,
+                    rr_val,
+                    company_val,
                     start_dd,
                     start_iso,
                     scan_status,
                     scan_table,
                 )
 
+            # After resolving query params into controls, sync the address bar.
             demo.load(
                 fn=_on_load,
                 inputs=[charts_tab.tickerDropdown, charts_tab.lowq],
                 outputs=[
+                    charts_tab.tickerDropdown,
+                    charts_tab.lowq,
                     charts_tab.plotComponent,
                     charts_tab.rrTable,
                     charts_tab.companyInfo,
@@ -140,6 +160,10 @@ class CanswimPlayground:
                     scans_tab.scanStatus,
                     scans_tab.scanResult,
                 ],
+            ).then(
+                fn=None,
+                inputs=[charts_tab.tickerDropdown, charts_tab.lowq],
+                js=CHART_URL_SYNC_JS,
             )
 
         import os

--- a/src/canswim/dashboard/charts.py
+++ b/src/canswim/dashboard/charts.py
@@ -15,6 +15,7 @@ from canswim.db import (
     get_company_profile,
     format_company_profile_markdown,
 )
+from canswim.dashboard.url_state import CHART_URL_SYNC_JS
 
 # Note: It appears that gradio Plot ignores the backend plot lib setting
 # pd.options.plotting.backend = 'hvplot'
@@ -34,6 +35,8 @@ class ChartTab:
             default_ticker = (
                 random.sample(sorted_tickers, 1)[0] if sorted_tickers else None
             )
+            self.sorted_tickers = sorted_tickers
+            self.default_ticker = default_ticker
             self.tickerDropdown = gr.Dropdown(
                 choices=sorted_tickers,
                 label="Stock Symbol",
@@ -62,6 +65,18 @@ class ChartTab:
             fn=self.plot_forecast,
             inputs=[self.tickerDropdown, self.lowq],
             outputs=[self.plotComponent, self.rrTable, self.companyInfo],
+        )
+        # Live shareable URL (?ticker=&lowq=) — separate from plot handlers so
+        # Gradio js= does not rewrite plot_forecast inputs.
+        self.tickerDropdown.change(
+            fn=None,
+            inputs=[self.tickerDropdown, self.lowq],
+            js=CHART_URL_SYNC_JS,
+        )
+        self.lowq.change(
+            fn=None,
+            inputs=[self.tickerDropdown, self.lowq],
+            js=CHART_URL_SYNC_JS,
         )
 
     def _company_md(self, ticker: str | None) -> str:

--- a/src/canswim/dashboard/url_state.py
+++ b/src/canswim/dashboard/url_state.py
@@ -1,0 +1,91 @@
+"""Shareable chart URL helpers for the Gradio dashboard.
+
+Query contract (Charts tab v1):
+  ?ticker=AAPL
+  ?ticker=AAPL&lowq=95
+
+``lowq`` is confidence % for the lowest close price: 80 | 95 | 99.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+VALID_LOWQ = frozenset({80, 95, 99})
+DEFAULT_LOWQ = 80
+
+# Side-effect only: update address bar without reload. Used with fn=None listeners.
+# Inputs: (ticker, lowq). Preserve unrelated query params.
+CHART_URL_SYNC_JS = """
+(ticker, lowq) => {
+  try {
+    const url = new URL(window.location.href);
+    if (ticker) {
+      url.searchParams.set('ticker', String(ticker));
+    } else {
+      url.searchParams.delete('ticker');
+    }
+    if (lowq !== null && lowq !== undefined && lowq !== '') {
+      url.searchParams.set('lowq', String(lowq));
+    }
+    window.history.replaceState({}, '', url);
+  } catch (e) {
+    console.error('canswim chart URL sync failed', e);
+  }
+}
+"""
+
+
+def parse_chart_query(query_params: Mapping[str, Any] | None) -> tuple[str | None, int]:
+    """Parse chart deep-link query params.
+
+    Returns
+    -------
+    ticker :
+        Uppercased symbol string, or ``None`` if missing/blank.
+    lowq :
+        Confidence percent in ``VALID_LOWQ``; invalid or missing → ``DEFAULT_LOWQ``.
+    """
+    if not query_params:
+        return None, DEFAULT_LOWQ
+
+    raw_ticker = query_params.get("ticker")
+    ticker: str | None = None
+    if raw_ticker is not None:
+        s = str(raw_ticker).strip().upper()
+        if s:
+            ticker = s
+
+    lowq = DEFAULT_LOWQ
+    raw_lowq = query_params.get("lowq")
+    if raw_lowq is not None and str(raw_lowq).strip() != "":
+        try:
+            n = int(float(str(raw_lowq).strip()))
+            if n in VALID_LOWQ:
+                lowq = n
+        except (TypeError, ValueError):
+            pass
+
+    return ticker, lowq
+
+
+def resolve_chart_ticker(
+    requested: str | None,
+    choices: Sequence[str] | None,
+    default: str | None,
+) -> str | None:
+    """Map a requested ticker to a canonical choice, or fall back to ``default``."""
+    if not requested:
+        return default
+    if not choices:
+        return default
+    want = str(requested).strip().upper()
+    if not want:
+        return default
+    for c in choices:
+        if c is None:
+            continue
+        if str(c).strip().upper() == want:
+            return str(c)
+    return default

--- a/tests/canswim/dashboard/test_url_state.py
+++ b/tests/canswim/dashboard/test_url_state.py
@@ -1,0 +1,78 @@
+"""Unit tests for chart deep-link URL helpers."""
+
+from canswim.dashboard.url_state import (
+    CHART_URL_SYNC_JS,
+    DEFAULT_LOWQ,
+    parse_chart_query,
+    resolve_chart_ticker,
+)
+
+
+def test_url_sync_js_uses_replace_state():
+    assert "history.replaceState" in CHART_URL_SYNC_JS
+    assert "searchParams" in CHART_URL_SYNC_JS
+    assert "ticker" in CHART_URL_SYNC_JS
+    assert "lowq" in CHART_URL_SYNC_JS
+
+
+class TestParseChartQuery:
+    def test_missing_params(self):
+        assert parse_chart_query({}) == (None, DEFAULT_LOWQ)
+        assert parse_chart_query(None) == (None, DEFAULT_LOWQ)
+
+    def test_ticker_normalized_upper(self):
+        t, q = parse_chart_query({"ticker": "aapl"})
+        assert t == "AAPL"
+        assert q == DEFAULT_LOWQ
+
+    def test_ticker_stripped(self):
+        t, _ = parse_chart_query({"ticker": "  msft  "})
+        assert t == "MSFT"
+
+    def test_blank_ticker_is_none(self):
+        t, _ = parse_chart_query({"ticker": "   "})
+        assert t is None
+
+    def test_lowq_valid(self):
+        assert parse_chart_query({"lowq": "95"})[1] == 95
+        assert parse_chart_query({"lowq": 99})[1] == 99
+        assert parse_chart_query({"lowq": "80"})[1] == 80
+
+    def test_lowq_invalid_falls_back(self):
+        assert parse_chart_query({"lowq": "50"})[1] == DEFAULT_LOWQ
+        assert parse_chart_query({"lowq": "nope"})[1] == DEFAULT_LOWQ
+        assert parse_chart_query({"lowq": ""})[1] == DEFAULT_LOWQ
+
+    def test_ticker_and_lowq_together(self):
+        t, q = parse_chart_query({"ticker": "nvda", "lowq": "95"})
+        assert t == "NVDA"
+        assert q == 95
+
+    def test_unrelated_params_ignored(self):
+        t, q = parse_chart_query({"foo": "bar", "ticker": "IBM"})
+        assert t == "IBM"
+        assert q == DEFAULT_LOWQ
+
+
+class TestResolveChartTicker:
+    choices = ["AAPL", "MSFT", "GOOG"]
+
+    def test_exact_match(self):
+        assert resolve_chart_ticker("AAPL", self.choices, "MSFT") == "AAPL"
+
+    def test_case_insensitive_match(self):
+        assert resolve_chart_ticker("aapl", self.choices, "MSFT") == "AAPL"
+        assert resolve_chart_ticker("MsFt", self.choices, "AAPL") == "MSFT"
+
+    def test_unknown_falls_back_to_default(self):
+        assert resolve_chart_ticker("NOTREAL", self.choices, "AAPL") == "AAPL"
+
+    def test_none_requested_uses_default(self):
+        assert resolve_chart_ticker(None, self.choices, "GOOG") == "GOOG"
+
+    def test_empty_choices_uses_default(self):
+        assert resolve_chart_ticker("AAPL", [], "X") == "X"
+        assert resolve_chart_ticker("AAPL", None, "X") == "X"
+
+    def test_blank_requested_uses_default(self):
+        assert resolve_chart_ticker("  ", self.choices, "MSFT") == "MSFT"


### PR DESCRIPTION
## Summary

- Charts tab updates the browser URL live with `?ticker=` and `?lowq=` so operators can copy/share a specific chart.
- On load, query params select the symbol and confidence and render the chart (unknown/invalid values fall back safely).
- Pure parse/resolve helpers with unit tests; README + `docs/cli.md` note the share URL shape. Design: `docs/superpowers/specs/2026-08-06-chart-deep-links-design.md`.

## Test plan

- [x] `./scripts/ci-local.sh` (336 passed)
- [x] Unit tests for `parse_chart_query` / `resolve_chart_ticker` / URL sync JS contract
- [x] Manual: open `/?ticker=AAPL&lowq=95`, change ticker, address bar updates, reload restores chart